### PR TITLE
Fix stored XSS via hapi_url injection in TTYD proxy

### DIFF
--- a/app/ttyd_proxy.py
+++ b/app/ttyd_proxy.py
@@ -24,6 +24,7 @@ import crypt
 import subprocess
 import re
 import secrets
+import html as html_module
 
 # Import base HTTP server
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -561,12 +562,19 @@ class TTYDProxyHandler(BaseHandler):
         except (FileNotFoundError, IOError):
             pass
 
+        # Validate URL scheme - only allow http:// and https://
+        if hapi_url:
+            parsed_url = urlparse(hapi_url)
+            if parsed_url.scheme not in ('http', 'https'):
+                hapi_url = None
+
         # Load and render menu template
         html = load_template('index.html')
-        html = html.replace('{{USERNAME}}', username)
+        html = html.replace('{{USERNAME}}', html_module.escape(username))
 
         if hapi_url:
-            hapi_link = f'<a href="{hapi_url}" target="_blank" class="menu-link">HAPI Server</a>'
+            escaped_url = html_module.escape(hapi_url, quote=True)
+            hapi_link = f'<a href="{escaped_url}" target="_blank" class="menu-link">HAPI Server</a>'
         else:
             hapi_link = '<span class="menu-link disabled">HAPI Server (not available)</span>'
 


### PR DESCRIPTION
## 💪 What

- Fixes a stored XSS vulnerability in the TTYD proxy menu page (`app/ttyd_proxy.py`)
- Adds URL scheme validation — only `http://` and `https://` are allowed for the hapi URL read from `/home/hapi/url`
- HTML-escapes `hapi_url` (with `quote=True`) before interpolation into the `<a href="...">` attribute
- HTML-escapes `username` before template substitution as defense-in-depth

## 🤔 Why

- The contents of `/home/hapi/url` were interpolated directly into HTML without any sanitization
- An attacker with write access to that file (SSH user, hapi process) could inject arbitrary HTML/JS via attribute breakout (`"></a><script>...`) or `javascript:` URI scheme
- CSP includes `script-src 'unsafe-inline'`, so injected scripts execute in the context of any authenticated user visiting the menu page
- This enables session hijacking (cookie theft) and actions on behalf of the victim

## 👩‍🔬 How to validate

1. Build and run the container:
   ```bash
   ./build.sh && docker run -p 8080:8080 clihost
   ```
2. Write a malicious payload to the url file inside the container:
   ```bash
   docker exec <id> bash -c 'echo "javascript:alert(1)" > /home/hapi/url'
   ```
3. Log in at `http://localhost:8080` — the HAPI Server link should render as **"not available"** (scheme rejected)
4. Try an attribute-breakout payload:
   ```bash
   docker exec <id> bash -c 'echo "\"><script>alert(1)</script>" > /home/hapi/url'
   ```
5. Refresh the menu page — inspect the HTML source; the payload should be escaped (`&quot;&gt;&lt;script&gt;...`) and no alert fires
6. Write a legitimate URL and confirm the link renders correctly:
   ```bash
   docker exec <id> bash -c 'echo "https://example.com" > /home/hapi/url'
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)