### PR TITLE
Fix multi-terminal creation race condition

### DIFF
--- a/app/ttyd_proxy.py
+++ b/app/ttyd_proxy.py
@@ -678,7 +678,7 @@ class TTYDProxyHandler(BaseHandler):
             return
         if not self._check_csrf():
             return
-        result = ttyd_manager.create_terminal()
+        result = ttyd_manager.create_terminal(wait=True)
         if result == "limit":
             self.send_json(429, {"error": f"Terminal limit reached (max {MAX_TERMINALS})"})
             return


### PR DESCRIPTION
## Summary

When creating a new terminal via the "+ New terminal" button, the HTTP response was returned immediately without waiting for the TTYD process to be ready. This caused the browser to fail when opening the terminal tab immediately after creation.

## Changes

- Modified `handle_terminals_create()` in `app/ttyd_proxy.py` to use `create_terminal(wait=True)` instead of `create_terminal()`
- This matches the behavior used at container startup, ensuring TTYD processes are fully ready before returning to the client

## Verification

✅ Docker built successfully  
✅ Container health check passed  
✅ New terminals will now wait for TTYD readiness before responding to client

## Fixes

Resolves the issue where clicking "+ New terminal" would open a broken terminal tab