### PR TITLE
Add Railway template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ docker run -p 22:22 -p 8080:8080 clihost
 
 Open http://localhost:8080 for web terminal access.
 
+## Deploy on Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/axisrow/clihost)
+
+### Environment Variables for Railway
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `TTYD_PASSWORD` | **Required** | Password for web terminal access |
+| `PASSWORD_SECRET` | Recommended | Session persistence across restarts |
+| `SECURE_COOKIES` | Set to `true` | Railway serves HTTPS automatically |
+| `PORT` | Auto | Injected by Railway, do not set manually |
+
+### Volume
+
+Add persistent volume at `/home/hapi` via Railway dashboard → Service → Volumes.
+
+### Notes
+
+- SSH (port 22) is not accessible externally on Railway — web terminal only
+- `PORT` is injected automatically by Railway, `ttyd_proxy.py` reads it via `os.environ`
+
 ## Архитектура
 
 ```

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary

- Create `railway.json` with Dockerfile builder and healthcheck configuration
- Add 'Deploy on Railway' section to README with one-click deploy button
- Document required env vars (TTYD_PASSWORD) and recommended settings (PASSWORD_SECRET, SECURE_COOKIES)
- Add volume mount and SSH accessibility notes for Railway deployments

Closes #18

## Test plan

- [ ] Build image: `docker build -t clihost .`
- [ ] Deploy on Railway via template button — should auto-detect Dockerfile
- [ ] Verify /health endpoint responds with 200
- [ ] Login with TTYD_PASSWORD and create terminal
- [ ] Confirm SSH is not accessible externally (expected for Railway)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)