### PR TITLE
Add mobile virtual keyboard controls for Claude Code

### DIFF
--- a/app/assets/virtual_keyboard.html
+++ b/app/assets/virtual_keyboard.html
@@ -1,14 +1,26 @@
 <div class="vkbd" id="vkbd">
   <button data-key="esc">ESC</button>
+  <button data-key="1">1</button>
+  <button data-key="2">2</button>
+  <button data-key="3">3</button>
+  <button data-key="4">4</button>
+  <button data-key="5">5</button>
+  <button data-key="backspace">&#9003;</button>
   <button data-key="tab">Tab</button>
-  <button data-key="shift-tab">Shift+Tab</button>
-  <button data-key="ctrl-c">Ctrl+C</button>
-  <button data-key="ctrl-b">Ctrl+B</button>
-  <button data-key="up">&#8593;</button>
-  <button data-key="left">&#8592;</button>
-  <button data-key="down">&#8595;</button>
-  <button data-key="right">&#8594;</button>
-  <button data-key="ctrl-v">Ctrl+V</button>
+  <button data-key="shift-tab">&#8617;Tab</button>
+  <button data-key="slash">/</button>
+  <button data-key="bang">!</button>
+  <button data-key="ctrl-c">C-C</button>
+  <button data-key="ctrl-v">C-V</button>
+  <button data-key="ctrl-l">C-L</button>
+  <button data-key="enter">&#8629;</button>
+  <button data-key="ctrl-b">C-B</button>
+  <div class="arrow-grid">
+    <button data-key="up" style="grid-area: up">&#8593;</button>
+    <button data-key="left" style="grid-area: left">&#8592;</button>
+    <button data-key="down" style="grid-area: down">&#8595;</button>
+    <button data-key="right" style="grid-area: right">&#8594;</button>
+  </div>
 </div>
 <script>
   (function() {
@@ -65,10 +77,17 @@
             case 'esc': data = ESC; break;
             case 'ctrl-c': data = String.fromCharCode(3); break;
             case 'ctrl-b': data = String.fromCharCode(2); break;
+            case 'ctrl-l': data = String.fromCharCode(12); break;
             case 'up': data = ESC + '[A'; break;
             case 'down': data = ESC + '[B'; break;
             case 'right': data = ESC + '[C'; break;
             case 'left': data = ESC + '[D'; break;
+            case '1': case '2': case '3': case '4': case '5':
+              data = key; break;
+            case 'slash': data = '/'; break;
+            case 'bang': data = '!'; break;
+            case 'backspace': data = String.fromCharCode(127); break;
+            case 'enter': data = '\r'; break;
           }
           if (data) {
             socket.send('0' + data);
@@ -88,4 +107,3 @@
     });
   })();
 </script>
-

--- a/app/assets/virtual_keyboard_style.css
+++ b/app/assets/virtual_keyboard_style.css
@@ -1,12 +1,20 @@
-.vkbd { display: none; background: #1a1a2e; padding: 8px; gap: 6px; flex-wrap: wrap; justify-content: center; }
+.vkbd { display: none; background: #1a1a2e; padding: 8px; gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(44px, 1fr)); }
 .vkbd button {
   background: #16213e; color: #e8e8e8; border: 1px solid #0f3460;
   padding: 12px 16px; font-size: 14px; font-family: monospace;
   border-radius: 4px; min-width: 44px; touch-action: manipulation;
 }
 .vkbd button:active { background: #0f3460; }
+.arrow-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 44px);
+  grid-template-areas: ". up ." "left down right";
+  gap: 4px;
+  justify-self: end;
+}
 @media (max-width: 768px) {
-  .vkbd { display: flex; }
-  body { height: calc(100vh - 60px); }
+  .vkbd { display: grid; }
+  body { height: calc(100vh - 180px); }
 }
 

--- a/tests/unit/test_vkbd_html.py
+++ b/tests/unit/test_vkbd_html.py
@@ -9,9 +9,15 @@ class TestVKBDEnabled(unittest.TestCase):
         self.html = render_terminal_page(1, "testuser", vkbd_enabled=True)
 
     def test_vkbd_buttons_present(self):
-        for key in ("esc", "tab", "shift-tab", "ctrl-c", "ctrl-b", "up", "left", "down", "right", "ctrl-v"):
+        for key in ("esc", "tab", "shift-tab", "ctrl-c", "ctrl-b", "ctrl-l",
+                     "ctrl-v", "up", "left", "down", "right",
+                     "1", "2", "3", "4", "5",
+                     "slash", "bang", "backspace", "enter"):
             with self.subTest(key=key):
                 self.assertIn(f'data-key="{key}"', self.html)
+
+    def test_arrow_grid_present(self):
+        self.assertIn("arrow-grid", self.html)
 
     def test_mobile_styles_present(self):
         self.assertIn("@media (max-width: 768px)", self.html)
@@ -26,6 +32,13 @@ class TestVKBDEnabled(unittest.TestCase):
         self.assertIn("socket.send('0' + data)", self.html)
         self.assertIn("win.sendTabKey", self.html)
         self.assertIn("win.scrollTerminalLines", self.html)
+
+    def test_new_key_sequences(self):
+        self.assertIn("String.fromCharCode(127)", self.html)  # backspace
+        self.assertIn("String.fromCharCode(12)", self.html)   # ctrl-l
+        self.assertIn("'\\r'", self.html)                      # enter
+        self.assertIn("case 'slash'", self.html)               # /
+        self.assertIn("case 'bang'", self.html)                # !
 
     def test_iframe_points_to_terminal(self):
         self.assertIn('id="terminal-shell"', self.html)


### PR DESCRIPTION
## Summary
- Add 10 new VKBD buttons: 1-5 (option selection), Enter, / (slash commands), ! (shell), Backspace, Ctrl+L (clear screen)
- Rearrange buttons into keyboard-like layout: ESC+numbers+⌫ top row, Tab+actions+Enter middle row, inverted-T arrows bottom
- Switch CSS from flex-wrap to grid layout with dedicated arrow-grid for inverted-T arrow keys

## Testing
- [x] All 68 unit tests pass
- [ ] Visual verification on mobile device (narrow browser to ≤768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)