### PR TITLE
Add cleanup dashboard

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -107,6 +107,9 @@
       margin-top: 1.5rem;
       text-align: left;
     }
+    .section.collapsed .section-body {
+      display: none;
+    }
     .section-header {
       display: flex;
       align-items: center;
@@ -134,6 +137,12 @@
     .section-actions .menu-link {
       padding: 0.75rem 1rem;
       font-size: 0.9rem;
+    }
+    .section-toggle {
+      background: #3d4450;
+    }
+    .section-toggle:hover {
+      background: #4d5460;
     }
     .menu-link.danger {
       background: #8c3949;
@@ -255,21 +264,25 @@
       <div id="terminals-list"></div>
       <button class="menu-link new-terminal" id="new-terminal-btn" onclick="createTerminal()">+ New terminal</button>
     </div>
-    <div class="section">
+    <div class="section collapsed" id="cleanup-section">
       <div class="section-header">
         <div class="section-title">Cleanup</div>
         <div class="section-actions">
+          <button class="menu-link section-toggle" id="toggle-cleanup-btn" onclick="toggleCleanupSection()">Show cleanup</button>
           <button class="menu-link secondary" id="refresh-cleanup-btn" onclick="loadCleanupTargets()">Refresh</button>
           <button class="menu-link danger" id="delete-cleanup-btn" onclick="deleteSelectedCleanup()" disabled>Delete selected</button>
         </div>
       </div>
-      <div class="section-note" id="cleanup-summary">Loading cleanup targets...</div>
-      <div class="section-note" id="cleanup-status"></div>
-      <div class="cleanup-list" id="cleanup-list"></div>
+      <div class="section-body">
+        <div class="section-note" id="cleanup-summary">Cleanup targets are loaded on demand.</div>
+        <div class="section-note" id="cleanup-status"></div>
+        <div class="cleanup-list" id="cleanup-list"></div>
+      </div>
     </div>
   </div>
   <script>
     var DEBUG = false;
+    var cleanupLoaded = false;
     function log() { if (DEBUG) console.log.apply(console, arguments); }
 
     function getCsrfToken() {
@@ -395,6 +408,16 @@
       status.className = isError ? 'section-note error' : 'section-note';
     }
 
+    function toggleCleanupSection() {
+      var section = document.getElementById('cleanup-section');
+      var btn = document.getElementById('toggle-cleanup-btn');
+      var collapsed = section.classList.toggle('collapsed');
+      btn.textContent = collapsed ? 'Show cleanup' : 'Hide cleanup';
+      if (!collapsed && !cleanupLoaded) {
+        loadCleanupTargets();
+      }
+    }
+
     function updateCleanupSelectionState() {
       var selected = document.querySelectorAll('.cleanup-checkbox:checked');
       var btn = document.getElementById('delete-cleanup-btn');
@@ -496,6 +519,7 @@
         })
         .then(function(data) {
           if (!data) return;
+          cleanupLoaded = true;
           renderCleanupTargets(data);
         })
         .catch(function(err) {
@@ -569,7 +593,6 @@
     }
 
     loadTerminals();
-    loadCleanupTargets();
   </script>
 </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -237,7 +237,11 @@
       border: 1px dashed #353b47;
       text-align: center;
     }
-    @media (max-width: 720px) {
+    .section.collapsed #refresh-cleanup-btn,
+    .section.collapsed #delete-cleanup-btn {
+      display: none;
+    }
+    @media (max-width: 800px) {
       .menu-container {
         padding: 1.25rem;
       }

--- a/app/index.html
+++ b/app/index.html
@@ -22,7 +22,7 @@
       border-radius: 8px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.3);
       width: 100%;
-      max-width: 400px;
+      max-width: 760px;
       text-align: center;
     }
     h1 {
@@ -103,6 +103,147 @@
       flex-direction: column;
       gap: 0.5rem;
     }
+    .section {
+      margin-top: 1.5rem;
+      text-align: left;
+    }
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+    .section-title {
+      color: #e0e6ed;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .section-note {
+      color: #b0b8c3;
+      font-size: 0.9rem;
+      margin-bottom: 0.75rem;
+    }
+    .section-note.error {
+      color: #f4a6b3;
+    }
+    .section-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .section-actions .menu-link {
+      padding: 0.75rem 1rem;
+      font-size: 0.9rem;
+    }
+    .menu-link.danger {
+      background: #8c3949;
+    }
+    .menu-link.danger:hover {
+      background: #a64658;
+    }
+    .cleanup-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .cleanup-target {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.9rem;
+      border-radius: 6px;
+      background: #1f242d;
+      border: 1px solid #353b47;
+      cursor: pointer;
+    }
+    .cleanup-target:hover {
+      border-color: #4a90d9;
+    }
+    .cleanup-target input[type="checkbox"] {
+      margin-top: 0.2rem;
+      width: 18px;
+      height: 18px;
+      flex-shrink: 0;
+    }
+    .cleanup-target-body {
+      flex: 1;
+      min-width: 0;
+    }
+    .cleanup-target-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-bottom: 0.35rem;
+    }
+    .cleanup-target-label {
+      color: #eef2f7;
+      font-weight: 600;
+      word-break: break-word;
+    }
+    .cleanup-target-size {
+      color: #cdd6e1;
+      font-size: 0.9rem;
+      white-space: nowrap;
+    }
+    .cleanup-target-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      margin-bottom: 0.35rem;
+    }
+    .cleanup-pill {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 0.15rem 0.5rem;
+      font-size: 0.75rem;
+      background: #313845;
+      color: #d7deea;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+    .cleanup-pill.risk-low {
+      background: #244c3b;
+      color: #bfe8d0;
+    }
+    .cleanup-pill.risk-medium {
+      background: #5b4a24;
+      color: #f0ddab;
+    }
+    .cleanup-pill.risk-high {
+      background: #5b2d36;
+      color: #f3bcc6;
+    }
+    .cleanup-target-description {
+      color: #b0b8c3;
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }
+    .empty-state {
+      padding: 1rem;
+      border-radius: 6px;
+      background: #1f242d;
+      color: #b0b8c3;
+      border: 1px dashed #353b47;
+      text-align: center;
+    }
+    @media (max-width: 720px) {
+      .menu-container {
+        padding: 1.25rem;
+      }
+      .section-header,
+      .cleanup-target-top {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .section-actions {
+        width: 100%;
+      }
+      .section-actions .menu-link {
+        flex: 1;
+      }
+    }
   </style>
 </head>
 <body>
@@ -113,6 +254,18 @@
       {{HAPI_LINK}}
       <div id="terminals-list"></div>
       <button class="menu-link new-terminal" id="new-terminal-btn" onclick="createTerminal()">+ New terminal</button>
+    </div>
+    <div class="section">
+      <div class="section-header">
+        <div class="section-title">Cleanup</div>
+        <div class="section-actions">
+          <button class="menu-link secondary" id="refresh-cleanup-btn" onclick="loadCleanupTargets()">Refresh</button>
+          <button class="menu-link danger" id="delete-cleanup-btn" onclick="deleteSelectedCleanup()" disabled>Delete selected</button>
+        </div>
+      </div>
+      <div class="section-note" id="cleanup-summary">Loading cleanup targets...</div>
+      <div class="section-note" id="cleanup-status"></div>
+      <div class="cleanup-list" id="cleanup-list"></div>
     </div>
   </div>
   <script>
@@ -231,7 +384,179 @@
         });
     }
 
+    function setCleanupStatus(message, isError) {
+      var status = document.getElementById('cleanup-status');
+      status.textContent = message || '';
+      status.className = isError ? 'section-note error' : 'section-note';
+    }
+
+    function updateCleanupSelectionState() {
+      var selected = document.querySelectorAll('.cleanup-checkbox:checked');
+      var btn = document.getElementById('delete-cleanup-btn');
+      var summary = document.getElementById('cleanup-summary');
+      var total = document.querySelectorAll('.cleanup-checkbox').length;
+      btn.disabled = selected.length === 0;
+      if (summary.dataset.baseSummary) {
+        summary.textContent = summary.dataset.baseSummary + ' Selected: ' + selected.length + ' of ' + total + '.';
+      }
+    }
+
+    function renderCleanupTargets(data) {
+      var list = document.getElementById('cleanup-list');
+      var summary = document.getElementById('cleanup-summary');
+      list.innerHTML = '';
+      var targets = data.targets || [];
+      var totals = data.summary || {};
+      if (!targets.length) {
+        summary.dataset.baseSummary = 'No cleanup targets found.';
+        summary.textContent = 'No cleanup targets found.';
+        list.innerHTML = '<div class="empty-state">Nothing to clean up right now.</div>';
+        updateCleanupSelectionState();
+        return;
+      }
+
+      summary.dataset.baseSummary = 'Found ' + totals.count + ' targets totaling ' + totals.total_size_human + '.';
+      summary.textContent = summary.dataset.baseSummary + ' Selected: 0 of ' + targets.length + '.';
+      targets.forEach(function(target) {
+        var row = document.createElement('label');
+        row.className = 'cleanup-target';
+
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'cleanup-checkbox';
+        checkbox.value = target.id;
+        checkbox.setAttribute('data-label', target.label);
+        checkbox.onchange = updateCleanupSelectionState;
+        row.appendChild(checkbox);
+
+        var body = document.createElement('div');
+        body.className = 'cleanup-target-body';
+
+        var top = document.createElement('div');
+        top.className = 'cleanup-target-top';
+
+        var label = document.createElement('div');
+        label.className = 'cleanup-target-label';
+        label.textContent = target.label;
+        top.appendChild(label);
+
+        var size = document.createElement('div');
+        size.className = 'cleanup-target-size';
+        size.textContent = target.size_human;
+        top.appendChild(size);
+
+        body.appendChild(top);
+
+        var meta = document.createElement('div');
+        meta.className = 'cleanup-target-meta';
+
+        var category = document.createElement('span');
+        category.className = 'cleanup-pill';
+        category.textContent = target.category;
+        meta.appendChild(category);
+
+        var risk = document.createElement('span');
+        risk.className = 'cleanup-pill risk-' + target.risk;
+        risk.textContent = target.risk + ' risk';
+        meta.appendChild(risk);
+
+        body.appendChild(meta);
+
+        var description = document.createElement('div');
+        description.className = 'cleanup-target-description';
+        description.textContent = target.description;
+        body.appendChild(description);
+
+        row.appendChild(body);
+        list.appendChild(row);
+      });
+
+      updateCleanupSelectionState();
+    }
+
+    function loadCleanupTargets() {
+      var list = document.getElementById('cleanup-list');
+      var refreshBtn = document.getElementById('refresh-cleanup-btn');
+      refreshBtn.disabled = true;
+      list.innerHTML = '<div class="empty-state">Loading cleanup targets...</div>';
+      setCleanupStatus('', false);
+      fetch('/cleanup')
+        .then(function(r) {
+          if (handleAuthError(r)) return;
+          return r.json();
+        })
+        .then(function(data) {
+          if (!data) return;
+          renderCleanupTargets(data);
+        })
+        .catch(function(err) {
+          log('[cleanup] Failed to load cleanup targets:', err);
+          list.innerHTML = '<div class="empty-state">Failed to load cleanup targets.</div>';
+          setCleanupStatus('Failed to load cleanup targets.', true);
+        })
+        .finally(function() {
+          refreshBtn.disabled = false;
+        });
+    }
+
+    function deleteSelectedCleanup() {
+      var boxes = Array.prototype.slice.call(document.querySelectorAll('.cleanup-checkbox:checked'));
+      if (!boxes.length) {
+        setCleanupStatus('Select at least one item to delete.', true);
+        return;
+      }
+      var ids = boxes.map(function(box) { return box.value; });
+      var labels = boxes.map(function(box) { return box.getAttribute('data-label') || box.value; });
+      if (!confirm('Delete selected items?\n\n' + labels.join('\n'))) return;
+
+      var btn = document.getElementById('delete-cleanup-btn');
+      btn.disabled = true;
+      btn.textContent = 'Deleting...';
+      setCleanupStatus('', false);
+
+      fetch('/cleanup/delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': getCsrfToken()
+        },
+        body: JSON.stringify({ ids: ids })
+      })
+        .then(function(r) {
+          if (handleAuthError(r)) return;
+          return r.json();
+        })
+        .then(function(data) {
+          if (!data) return;
+          if (data.error) {
+            setCleanupStatus(data.error, true);
+            return;
+          }
+          var parts = [];
+          if (data.deleted && data.deleted.length) {
+            parts.push('Deleted: ' + data.deleted.map(function(item) { return item.label; }).join(', '));
+          }
+          if (data.errors && data.errors.length) {
+            parts.push('Errors: ' + data.errors.map(function(item) { return item.label + ' (' + item.error + ')'; }).join(', '));
+          }
+          if (data.skipped && data.skipped.length) {
+            parts.push('Skipped: ' + data.skipped.map(function(item) { return item.id; }).join(', '));
+          }
+          setCleanupStatus(parts.join(' '), data.errors && data.errors.length > 0);
+          loadCleanupTargets();
+        })
+        .catch(function(err) {
+          log('[cleanup] Failed to delete cleanup targets:', err);
+          setCleanupStatus('Failed to delete selected items.', true);
+        })
+        .finally(function() {
+          btn.textContent = 'Delete selected';
+          updateCleanupSelectionState();
+        });
+    }
+
     loadTerminals();
+    loadCleanupTargets();
   </script>
 </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -277,10 +277,15 @@
       return match ? match[1] : '';
     }
 
-    function handleAuthError(r) {
+    function handleAuthError(r, options) {
+      options = options || {};
       if (r.status === 419) {
-        var btn = document.getElementById('new-terminal-btn');
-        if (btn) btn.textContent = 'Session expired, reloading...';
+        if (options.onCsrfExpired) {
+          options.onCsrfExpired();
+        } else {
+          var btn = document.getElementById('new-terminal-btn');
+          if (btn) btn.textContent = 'Session expired, reloading...';
+        }
         setTimeout(function() { window.location.reload(); }, 500);
         return true;
       }
@@ -482,7 +487,11 @@
       setCleanupStatus('', false);
       fetch('/cleanup')
         .then(function(r) {
-          if (handleAuthError(r)) return;
+          if (handleAuthError(r, {
+            onCsrfExpired: function() {
+              setCleanupStatus('Session expired, reloading...', true);
+            }
+          })) return;
           return r.json();
         })
         .then(function(data) {
@@ -523,7 +532,11 @@
         body: JSON.stringify({ ids: ids })
       })
         .then(function(r) {
-          if (handleAuthError(r)) return;
+          if (handleAuthError(r, {
+            onCsrfExpired: function() {
+              setCleanupStatus('Session expired, reloading...', true);
+            }
+          })) return;
           return r.json();
         })
         .then(function(data) {

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -48,6 +48,8 @@ ttyd_manager = TTYDManager(
 )
 login_rate_limiter = RateLimiter(max_attempts=5, window_seconds=60)
 account_rate_limiter = RateLimiter(max_attempts=5, window_seconds=300)
+MAX_CLEANUP_DELETE_IDS = 50
+MAX_CLEANUP_TARGET_ID_LENGTH = 128
 
 
 def _get_memory_rss_mb():
@@ -271,8 +273,14 @@ class TTYDProxyHandler(BaseHandler):
         if not isinstance(target_ids, list) or not target_ids:
             self.send_json(400, {"error": "ids must be a non-empty array"})
             return
+        if len(target_ids) > MAX_CLEANUP_DELETE_IDS:
+            self.send_json(400, {"error": f"ids must contain at most {MAX_CLEANUP_DELETE_IDS} items"})
+            return
         if any(not isinstance(target_id, str) or not target_id for target_id in target_ids):
             self.send_json(400, {"error": "ids must contain non-empty strings"})
+            return
+        if any(len(target_id) > MAX_CLEANUP_TARGET_ID_LENGTH for target_id in target_ids):
+            self.send_json(400, {"error": f"ids must be at most {MAX_CLEANUP_TARGET_ID_LENGTH} characters long"})
             return
 
         self.send_json(200, delete_cleanup_targets(target_ids, CLEANUP_ROOT, HAPI_HOME))

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -7,7 +7,10 @@ from http.server import ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 from server import BaseHTTPHandler as BaseHandler
+from ttydproxy.cleanup import delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
 from ttydproxy.config import (
+    CLEANUP_ROOT,
+    HAPI_HOME,
     PORT,
     TTYD_USER,
     TTYD_PASSWORD,
@@ -71,6 +74,8 @@ class TTYDProxyHandler(BaseHandler):
             self.handle_login_page()
         elif parsed.path == "/health":
             self.handle_health()
+        elif parsed.path == "/cleanup":
+            self.handle_cleanup_list()
         elif parsed.path == "/terminals":
             self.handle_terminals_list()
         else:
@@ -89,6 +94,8 @@ class TTYDProxyHandler(BaseHandler):
         parsed = urlparse(self.path)
         if parsed.path == "/login":
             self.handle_login()
+        elif parsed.path == "/cleanup/delete":
+            self.handle_cleanup_delete()
         elif parsed.path == "/terminals":
             self.handle_terminals_create()
         else:
@@ -177,6 +184,27 @@ class TTYDProxyHandler(BaseHandler):
         self.send_json(415, {"error": "Unsupported content type"})
         return None
 
+    def _load_json_payload(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length > 1048576:
+            self.send_json(413, {"error": "Request too large"})
+            return None
+        try:
+            raw_data = self.rfile.read(content_length).decode("utf-8")
+        except UnicodeDecodeError:
+            self.send_json(400, {"error": "Invalid encoding"})
+            return None
+
+        content_type = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+        if content_type != "application/json":
+            self.send_json(415, {"error": "Unsupported content type"})
+            return None
+        try:
+            return json.loads(raw_data or "{}")
+        except json.JSONDecodeError:
+            self.send_json(400, {"error": "Invalid JSON"})
+            return None
+
     def handle_login_page(self):
         extra_headers, csrf_token = self._auth_cookie_headers()
         self.send_html(200, render_login_page(csrf_token), extra_headers=extra_headers)
@@ -201,6 +229,13 @@ class TTYDProxyHandler(BaseHandler):
             return
         self.send_json(200, {"terminals": ttyd_manager.list_terminals()})
 
+    def handle_cleanup_list(self):
+        username = self._check_auth()
+        if not username:
+            return
+        targets = list_cleanup_targets(CLEANUP_ROOT, HAPI_HOME)
+        self.send_json(200, {"targets": targets, "summary": summarize_cleanup_targets(targets)})
+
     def handle_terminals_create(self):
         username = self._check_auth()
         if not username or not self._check_csrf():
@@ -222,6 +257,25 @@ class TTYDProxyHandler(BaseHandler):
             self.send_json(200, {"deleted": terminal_id})
         else:
             self.send_json(404, {"error": f"Terminal {terminal_id} not found"})
+
+    def handle_cleanup_delete(self):
+        username = self._check_auth()
+        if not username or not self._check_csrf():
+            return
+
+        payload = self._load_json_payload()
+        if payload is None:
+            return
+
+        target_ids = payload.get("ids")
+        if not isinstance(target_ids, list) or not target_ids:
+            self.send_json(400, {"error": "ids must be a non-empty array"})
+            return
+        if any(not isinstance(target_id, str) or not target_id for target_id in target_ids):
+            self.send_json(400, {"error": "ids must contain non-empty strings"})
+            return
+
+        self.send_json(200, delete_cleanup_targets(target_ids, CLEANUP_ROOT, HAPI_HOME))
 
     def handle_login(self):
         client_ip = self.client_address[0]

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -66,6 +66,7 @@ STATIC_TARGETS = (
 
 PROJECT_CATEGORY_ORDER = 100
 RESERVED_TOP_LEVEL_NAMES = {"runtime"}
+MAX_SIZE_WALK_ENTRIES = 5000
 
 
 def _format_size(size_bytes):
@@ -93,31 +94,77 @@ def _resolve_within_root(path, root):
     return resolved_path
 
 
-def _directory_size(path):
+def _relative_path_within_root(path, root):
+    try:
+        return str(path.absolute().relative_to(root.absolute()))
+    except ValueError:
+        return None
+
+
+def _directory_size(path, budget):
     total = 0
+    truncated = False
     try:
         with os.scandir(path) as entries:
             for entry in entries:
+                if budget["remaining"] <= 0:
+                    return total, True
+                budget["remaining"] -= 1
                 try:
                     if entry.is_symlink():
                         continue
                     if entry.is_dir(follow_symlinks=False):
-                        total += _directory_size(entry.path)
+                        child_total, child_truncated = _directory_size(entry.path, budget)
+                        total += child_total
+                        truncated = truncated or child_truncated
                     else:
                         total += entry.stat(follow_symlinks=False).st_size
                 except OSError:
                     continue
     except OSError:
-        return 0
-    return total
+        return 0, truncated
+    return total, truncated
 
 
-def _build_target(path, root, target_id, label, description, category, risk, order, strategy):
+def _measure_directory_size(path, max_entries=MAX_SIZE_WALK_ENTRIES):
+    budget = {"remaining": max_entries}
+    return _directory_size(path, budget)
+
+
+def _is_listable_directory(path, resolved_path):
+    if path.is_symlink():
+        return resolved_path.is_dir()
+    return path.exists() and path.is_dir()
+
+
+def _build_target(
+    path,
+    root,
+    target_id,
+    label,
+    description,
+    category,
+    risk,
+    order,
+    strategy,
+    include_missing=False,
+    max_size_entries=MAX_SIZE_WALK_ENTRIES,
+):
     normalized = _resolve_within_root(path, root)
-    if normalized is None or not normalized.exists() or not normalized.is_dir():
+    relative_path = _relative_path_within_root(path, root)
+    if normalized is None or relative_path is None:
+        return None
+    if not include_missing and not _is_listable_directory(path, normalized):
         return None
 
-    size_bytes = _directory_size(normalized)
+    if path.exists() or path.is_symlink():
+        size_bytes, size_approximate = _measure_directory_size(normalized, max_entries=max_size_entries)
+    else:
+        size_bytes = 0
+        size_approximate = False
+    size_human = _format_size(size_bytes)
+    if size_approximate:
+        size_human = f"~{size_human}"
     return {
         "id": target_id,
         "label": label,
@@ -125,22 +172,36 @@ def _build_target(path, root, target_id, label, description, category, risk, ord
         "category": category,
         "risk": risk,
         "size_bytes": size_bytes,
-        "size_human": _format_size(size_bytes),
-        "path": str(normalized.relative_to(root.resolve())),
+        "size_human": size_human,
+        "size_approximate": size_approximate,
+        "path": relative_path,
         "order": order,
         "strategy": strategy,
     }
 
 
-def list_cleanup_targets(cleanup_root, hapi_home):
-    """Return cleanup candidates within the configured home directory."""
+def _project_target_name(target_id):
+    prefix = "project:"
+    if not target_id.startswith(prefix):
+        return None
+    name = target_id[len(prefix):]
+    if not name or "/" in name or "\\" in name or name in (".", ".."):
+        return None
+    if name.startswith(".") or name in RESERVED_TOP_LEVEL_NAMES:
+        return None
+    return name
+
+
+def resolve_cleanup_target(target_id, cleanup_root, hapi_home, include_missing=False):
+    """Resolve a cleanup target by ID using server-side allowlisted rules."""
     root = Path(cleanup_root)
     hapi_path = Path(hapi_home)
-    targets = []
 
     for spec in STATIC_TARGETS:
+        if spec["id"] != target_id:
+            continue
         path = hapi_path if spec["id"] == "hapi-home" else root / spec["relative_path"]
-        target = _build_target(
+        return _build_target(
             path,
             root,
             spec["id"],
@@ -150,7 +211,34 @@ def list_cleanup_targets(cleanup_root, hapi_home):
             spec["risk"],
             spec["order"],
             spec["strategy"],
+            include_missing=include_missing,
         )
+
+    project_name = _project_target_name(target_id)
+    if project_name is None:
+        return None
+
+    return _build_target(
+        root / project_name,
+        root,
+        target_id,
+        f"{project_name}/",
+        "Project or work directory",
+        "project",
+        "high",
+        PROJECT_CATEGORY_ORDER,
+        "remove-tree",
+        include_missing=include_missing,
+    )
+
+
+def list_cleanup_targets(cleanup_root, hapi_home):
+    """Return cleanup candidates within the configured home directory."""
+    root = Path(cleanup_root)
+    targets = []
+
+    for spec in STATIC_TARGETS:
+        target = resolve_cleanup_target(spec["id"], cleanup_root, hapi_home)
         if target is not None:
             targets.append(target)
 
@@ -163,17 +251,7 @@ def list_cleanup_targets(cleanup_root, hapi_home):
     for entry in entries:
         if entry.name.startswith(".") or entry.name in RESERVED_TOP_LEVEL_NAMES:
             continue
-        target = _build_target(
-            entry,
-            root,
-            f"project:{entry.name}",
-            f"{entry.name}/",
-            "Project or work directory",
-            "project",
-            "high",
-            PROJECT_CATEGORY_ORDER,
-            "remove-tree",
-        )
+        target = resolve_cleanup_target(f"project:{entry.name}", cleanup_root, hapi_home)
         if target is not None:
             projects.append(target)
 
@@ -193,7 +271,10 @@ def summarize_cleanup_targets(targets):
     }
 
 
-def _remove_tree(path):
+def _remove_path(path):
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return True
     if not path.exists():
         return False
     shutil.rmtree(path)
@@ -218,7 +299,6 @@ def _prune_hapi_home(path):
 
 def delete_cleanup_targets(target_ids, cleanup_root, hapi_home):
     """Delete selected cleanup targets by server-issued IDs."""
-    targets = {target["id"]: target for target in list_cleanup_targets(cleanup_root, hapi_home)}
     unique_ids = list(dict.fromkeys(target_ids))
     deleted = []
     skipped = []
@@ -226,18 +306,24 @@ def delete_cleanup_targets(target_ids, cleanup_root, hapi_home):
     root = Path(cleanup_root)
 
     for target_id in unique_ids:
-        target = targets.get(target_id)
+        target = resolve_cleanup_target(target_id, cleanup_root, hapi_home, include_missing=True)
         if target is None:
             skipped.append({"id": target_id, "reason": "unknown target"})
             continue
 
         path = root / target["path"]
+        if not path.exists() and not path.is_symlink():
+            skipped.append({"id": target_id, "label": target["label"], "reason": "already removed"})
+            continue
         try:
             if target["strategy"] == "prune-hapi-home":
-                _prune_hapi_home(path)
+                removed = _prune_hapi_home(path)
             else:
-                _remove_tree(path)
-            deleted.append({"id": target_id, "label": target["label"]})
+                removed = _remove_path(path)
+            if removed:
+                deleted.append({"id": target_id, "label": target["label"]})
+            else:
+                skipped.append({"id": target_id, "label": target["label"], "reason": "already removed"})
         except OSError as exc:
             errors.append({"id": target_id, "label": target["label"], "error": str(exc)})
 

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -8,6 +8,9 @@ PROTECTED_HAPI_NAMES = {
     "runner.state.json",
     "runner.state.json.lock",
     "server.log",
+    # Preserve the live relay/session config during interactive cleanup. The
+    # container entrypoint may remove stale settings on restart, but dashboard
+    # cleanup should avoid breaking the current process mid-session.
     "settings.json",
 }
 
@@ -290,14 +293,20 @@ def _prune_hapi_home(path):
         return False
 
     removed_anything = False
+    errors = []
     for child in path.iterdir():
         if child.name in PROTECTED_HAPI_NAMES:
             continue
-        if child.is_symlink() or child.is_file():
-            child.unlink()
-        else:
-            shutil.rmtree(child)
-        removed_anything = True
+        try:
+            if child.is_symlink() or child.is_file():
+                child.unlink()
+            else:
+                shutil.rmtree(child)
+            removed_anything = True
+        except OSError as exc:
+            errors.append(f"{child.name}: {exc}")
+    if errors:
+        raise OSError("; ".join(errors))
     return removed_anything
 
 

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -1,0 +1,248 @@
+"""Cleanup target discovery and safe deletion helpers."""
+import os
+import shutil
+from pathlib import Path
+
+
+PROTECTED_HAPI_NAMES = {
+    "runner.state.json",
+    "runner.state.json.lock",
+    "server.log",
+    "settings.json",
+}
+
+STATIC_TARGETS = (
+    {
+        "id": "hapi-home",
+        "label": "~/.hapi",
+        "relative_path": ".hapi",
+        "description": "HAPI state, logs, and runtime files (preserves active config/state files)",
+        "category": "state",
+        "risk": "medium",
+        "order": 10,
+        "strategy": "prune-hapi-home",
+    },
+    {
+        "id": "runtime",
+        "label": "runtime/",
+        "relative_path": "runtime",
+        "description": "Runtime data and temporary files",
+        "category": "runtime",
+        "risk": "medium",
+        "order": 20,
+        "strategy": "remove-tree",
+    },
+    {
+        "id": "cache-home",
+        "label": "~/.cache",
+        "relative_path": ".cache",
+        "description": "Shared tool caches",
+        "category": "cache",
+        "risk": "low",
+        "order": 30,
+        "strategy": "remove-tree",
+    },
+    {
+        "id": "npm-cache",
+        "label": "~/.npm",
+        "relative_path": ".npm",
+        "description": "npm cache",
+        "category": "cache",
+        "risk": "low",
+        "order": 40,
+        "strategy": "remove-tree",
+    },
+    {
+        "id": "local-share",
+        "label": "~/.local/share",
+        "relative_path": ".local/share",
+        "description": "Shared local application data and caches",
+        "category": "cache",
+        "risk": "medium",
+        "order": 50,
+        "strategy": "remove-tree",
+    },
+)
+
+PROJECT_CATEGORY_ORDER = 100
+RESERVED_TOP_LEVEL_NAMES = {"runtime"}
+
+
+def _format_size(size_bytes):
+    value = float(size_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            precision = 0 if value >= 10 else 1
+            return f"{value:.{precision}f} {unit}"
+        value /= 1024
+    return "0 B"
+
+
+def _resolve_within_root(path, root):
+    try:
+        resolved_root = root.resolve()
+        resolved_path = path.resolve()
+    except OSError:
+        return None
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved_path
+
+
+def _directory_size(path):
+    total = 0
+    try:
+        with os.scandir(path) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        total += _directory_size(entry.path)
+                    else:
+                        total += entry.stat(follow_symlinks=False).st_size
+                except OSError:
+                    continue
+    except OSError:
+        return 0
+    return total
+
+
+def _build_target(path, root, target_id, label, description, category, risk, order, strategy):
+    normalized = _resolve_within_root(path, root)
+    if normalized is None or not normalized.exists() or not normalized.is_dir():
+        return None
+
+    size_bytes = _directory_size(normalized)
+    return {
+        "id": target_id,
+        "label": label,
+        "description": description,
+        "category": category,
+        "risk": risk,
+        "size_bytes": size_bytes,
+        "size_human": _format_size(size_bytes),
+        "path": str(normalized.relative_to(root.resolve())),
+        "order": order,
+        "strategy": strategy,
+    }
+
+
+def list_cleanup_targets(cleanup_root, hapi_home):
+    """Return cleanup candidates within the configured home directory."""
+    root = Path(cleanup_root)
+    hapi_path = Path(hapi_home)
+    targets = []
+
+    for spec in STATIC_TARGETS:
+        path = hapi_path if spec["id"] == "hapi-home" else root / spec["relative_path"]
+        target = _build_target(
+            path,
+            root,
+            spec["id"],
+            spec["label"],
+            spec["description"],
+            spec["category"],
+            spec["risk"],
+            spec["order"],
+            spec["strategy"],
+        )
+        if target is not None:
+            targets.append(target)
+
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        entries = []
+
+    projects = []
+    for entry in entries:
+        if entry.name.startswith(".") or entry.name in RESERVED_TOP_LEVEL_NAMES:
+            continue
+        target = _build_target(
+            entry,
+            root,
+            f"project:{entry.name}",
+            f"{entry.name}/",
+            "Project or work directory",
+            "project",
+            "high",
+            PROJECT_CATEGORY_ORDER,
+            "remove-tree",
+        )
+        if target is not None:
+            projects.append(target)
+
+    projects.sort(key=lambda item: (-item["size_bytes"], item["label"]))
+    targets.extend(projects)
+    targets.sort(key=lambda item: (item["order"], item["label"]))
+    return targets
+
+
+def summarize_cleanup_targets(targets):
+    """Return aggregate counts and sizes for cleanup targets."""
+    total_size = sum(target["size_bytes"] for target in targets)
+    return {
+        "count": len(targets),
+        "total_size_bytes": total_size,
+        "total_size_human": _format_size(total_size),
+    }
+
+
+def _remove_tree(path):
+    if not path.exists():
+        return False
+    shutil.rmtree(path)
+    return True
+
+
+def _prune_hapi_home(path):
+    if not path.exists() or not path.is_dir():
+        return False
+
+    removed_anything = False
+    for child in path.iterdir():
+        if child.name in PROTECTED_HAPI_NAMES:
+            continue
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        else:
+            shutil.rmtree(child)
+        removed_anything = True
+    return removed_anything
+
+
+def delete_cleanup_targets(target_ids, cleanup_root, hapi_home):
+    """Delete selected cleanup targets by server-issued IDs."""
+    targets = {target["id"]: target for target in list_cleanup_targets(cleanup_root, hapi_home)}
+    unique_ids = list(dict.fromkeys(target_ids))
+    deleted = []
+    skipped = []
+    errors = []
+    root = Path(cleanup_root)
+
+    for target_id in unique_ids:
+        target = targets.get(target_id)
+        if target is None:
+            skipped.append({"id": target_id, "reason": "unknown target"})
+            continue
+
+        path = root / target["path"]
+        try:
+            if target["strategy"] == "prune-hapi-home":
+                _prune_hapi_home(path)
+            else:
+                _remove_tree(path)
+            deleted.append({"id": target_id, "label": target["label"]})
+        except OSError as exc:
+            errors.append({"id": target_id, "label": target["label"], "error": str(exc)})
+
+    return {
+        "deleted": deleted,
+        "skipped": skipped,
+        "errors": errors,
+    }

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -65,6 +65,8 @@ STATIC_TARGETS = (
 )
 
 PROJECT_CATEGORY_ORDER = 100
+# runtime/ is exposed as a dedicated static cleanup target, so it must not also
+# show up in the discovered project/work-directory list.
 RESERVED_TOP_LEVEL_NAMES = {"runtime"}
 MAX_SIZE_WALK_ENTRIES = 5000
 
@@ -78,7 +80,6 @@ def _format_size(size_bytes):
             precision = 0 if value >= 10 else 1
             return f"{value:.{precision}f} {unit}"
         value /= 1024
-    return "0 B"
 
 
 def _resolve_within_root(path, root):
@@ -201,6 +202,9 @@ def resolve_cleanup_target(target_id, cleanup_root, hapi_home, include_missing=F
         if spec["id"] != target_id:
             continue
         path = hapi_path if spec["id"] == "hapi-home" else root / spec["relative_path"]
+        if spec["id"] == "hapi-home" and _resolve_within_root(path, root) is None:
+            print(f"WARNING: HAPI_HOME {path} is outside CLEANUP_ROOT {root}, skipping ~/.hapi cleanup target", flush=True)
+            return None
         return _build_target(
             path,
             root,

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -10,6 +10,8 @@ TTYD_USER = os.environ.get("TTYD_USER", "hapi")
 TTYD_PASSWORD = os.environ.get("TTYD_PASSWORD", "")
 PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", "default-secret-change-me")
 TTYD_BASE_PORT = 7681
+CLEANUP_ROOT = os.environ.get("CLEANUP_ROOT", "/home/hapi")
+HAPI_HOME = os.environ.get("HAPI_HOME", f"{CLEANUP_ROOT}/.hapi")
 MAX_TERMINALS = int(os.environ.get("MAX_TERMINALS", "100"))
 SESSION_TIMEOUT = int(os.environ.get("SESSION_TIMEOUT", "604800"))
 VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
@@ -18,4 +20,3 @@ SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
 
 TTYD_ROUTE_PATTERN = re.compile(r"^/ttyd(\d+)(/.*)?$")
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ fi
 
 HAPI_USER="${HAPI_USER:-hapi}"
 HAPI_USER_HOME="/home/${HAPI_USER}"
+: "${CLEANUP_ROOT:=${HAPI_USER_HOME}}"
 : "${HAPI_HOME:=${HAPI_USER_HOME}/.hapi}"
 HAPI_RUN_PATH="/usr/local/bin:/usr/bin:/bin"
 
@@ -82,7 +83,7 @@ PORT="${PORT}" \
 TTYD_USER="${TTYD_USER}" \
 TTYD_PASSWORD="${TTYD_PASSWORD}" \
 PASSWORD_SECRET="${PASSWORD_SECRET}" \
-CLEANUP_ROOT="${HAPI_USER_HOME}" \
+CLEANUP_ROOT="${CLEANUP_ROOT}" \
 HAPI_HOME="${HAPI_HOME}" \
 python3 /app/ttyd_proxy.py &
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,8 @@ PORT="${PORT}" \
 TTYD_USER="${TTYD_USER}" \
 TTYD_PASSWORD="${TTYD_PASSWORD}" \
 PASSWORD_SECRET="${PASSWORD_SECRET}" \
+CLEANUP_ROOT="${HAPI_USER_HOME}" \
+HAPI_HOME="${HAPI_HOME}" \
 python3 /app/ttyd_proxy.py &
 
 # Start hapi server with relay in background (logs to file, force TCP relay)

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,8 +1,10 @@
 """Tests for cleanup target discovery and deletion helpers."""
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from ttydproxy.cleanup import delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
 
@@ -67,6 +69,31 @@ class TestCleanupTargets(unittest.TestCase):
         self.assertGreater(summary["total_size_bytes"], 0)
         self.assertTrue(summary["total_size_human"])
 
+    def test_size_scan_marks_large_targets_as_approximate(self):
+        write_file(self.root / "project-c" / "file.bin", 16)
+
+        with patch("ttydproxy.cleanup._measure_directory_size", return_value=(16, True)):
+            target = next(
+                item for item in list_cleanup_targets(self.root, self.hapi_home)
+                if item["id"] == "project:project-c"
+            )
+
+        self.assertTrue(target["size_approximate"])
+        self.assertEqual(target["size_human"], "~16 B")
+
+    def test_symlink_target_keeps_original_relative_path(self):
+        real_cache = self.root / "cache_data"
+        write_file(real_cache / "pip" / "cache.bin", 64)
+        symlink_path = self.root / "linked-cache"
+        symlink_path.symlink_to(real_cache, target_is_directory=True)
+
+        target = next(
+            item for item in list_cleanup_targets(self.root, self.hapi_home)
+            if item["id"] == "project:linked-cache"
+        )
+
+        self.assertEqual(target["path"], "linked-cache")
+
 
 class TestCleanupDeletion(unittest.TestCase):
     def setUp(self):
@@ -108,6 +135,30 @@ class TestCleanupDeletion(unittest.TestCase):
         self.assertEqual(result["deleted"], [])
         self.assertEqual(result["errors"], [])
         self.assertEqual(result["skipped"], [{"id": "unknown-target", "reason": "unknown target"}])
+
+    def test_missing_target_returns_already_removed(self):
+        shutil.rmtree(self.root / "project-a")
+
+        result = delete_cleanup_targets(["project:project-a"], self.root, self.hapi_home)
+
+        self.assertEqual(result["deleted"], [])
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(
+            result["skipped"],
+            [{"id": "project:project-a", "label": "project-a/", "reason": "already removed"}],
+        )
+
+    def test_delete_symlink_target_unlinks_symlink_only(self):
+        real_cache = self.root / "cache_data"
+        write_file(real_cache / "pip" / "cache.bin", 64)
+        symlink_path = self.root / "linked-cache"
+        symlink_path.symlink_to(real_cache, target_is_directory=True)
+
+        result = delete_cleanup_targets(["project:linked-cache"], self.root, self.hapi_home)
+
+        self.assertEqual(result["errors"], [])
+        self.assertFalse(symlink_path.exists())
+        self.assertTrue(real_cache.exists())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,114 @@
+"""Tests for cleanup target discovery and deletion helpers."""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from ttydproxy.cleanup import delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
+
+
+def write_file(path, size):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+
+
+class TestCleanupTargets(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.hapi_home = self.root / ".hapi"
+
+        write_file(self.hapi_home / "server.log", 10)
+        write_file(self.hapi_home / "settings.json", 10)
+        write_file(self.hapi_home / "trash" / "artifact.bin", 64)
+        write_file(self.root / "runtime" / "runtime.sock", 32)
+        write_file(self.root / ".cache" / "pip" / "cache.bin", 128)
+        write_file(self.root / ".npm" / "cache.db", 96)
+        write_file(self.root / ".local" / "share" / "uv" / "index.db", 48)
+        write_file(self.root / "project-a" / "node_modules" / "pkg.bin", 256)
+        write_file(self.root / "project-b" / "venv" / "pkg.bin", 512)
+        write_file(self.root / ".config" / "ignored.txt", 12)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_lists_static_and_project_targets(self):
+        targets = list_cleanup_targets(self.root, self.hapi_home)
+        target_ids = [target["id"] for target in targets]
+
+        self.assertIn("hapi-home", target_ids)
+        self.assertIn("runtime", target_ids)
+        self.assertIn("cache-home", target_ids)
+        self.assertIn("npm-cache", target_ids)
+        self.assertIn("local-share", target_ids)
+        self.assertIn("project:project-a", target_ids)
+        self.assertIn("project:project-b", target_ids)
+        self.assertNotIn("project:.config", target_ids)
+
+        project_b = next(target for target in targets if target["id"] == "project:project-b")
+        self.assertEqual(project_b["category"], "project")
+        self.assertEqual(project_b["risk"], "high")
+        self.assertTrue(project_b["size_bytes"] >= 512)
+
+    def test_skips_targets_resolving_outside_root(self):
+        outside = Path(self.tempdir.name).parent / "outside-cleanup-target"
+        outside.mkdir(exist_ok=True)
+        write_file(outside / "large.bin", 1024)
+        os.symlink(outside, self.root / "linked-project")
+
+        targets = list_cleanup_targets(self.root, self.hapi_home)
+        target_ids = [target["id"] for target in targets]
+
+        self.assertNotIn("project:linked-project", target_ids)
+
+    def test_summarize_cleanup_targets(self):
+        summary = summarize_cleanup_targets(list_cleanup_targets(self.root, self.hapi_home))
+        self.assertGreater(summary["count"], 0)
+        self.assertGreater(summary["total_size_bytes"], 0)
+        self.assertTrue(summary["total_size_human"])
+
+
+class TestCleanupDeletion(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.hapi_home = self.root / ".hapi"
+
+        write_file(self.hapi_home / "server.log", 10)
+        write_file(self.hapi_home / "settings.json", 10)
+        write_file(self.hapi_home / "runner.state.json", 10)
+        write_file(self.hapi_home / "trash" / "artifact.bin", 64)
+        write_file(self.root / ".cache" / "pip" / "cache.bin", 128)
+        write_file(self.root / "project-a" / "node_modules" / "pkg.bin", 256)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_delete_cleanup_targets_prunes_hapi_and_removes_projects(self):
+        result = delete_cleanup_targets(
+            ["hapi-home", "cache-home", "project:project-a"],
+            self.root,
+            self.hapi_home,
+        )
+
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(
+            [item["id"] for item in result["deleted"]],
+            ["hapi-home", "cache-home", "project:project-a"],
+        )
+        self.assertTrue((self.hapi_home / "server.log").exists())
+        self.assertTrue((self.hapi_home / "settings.json").exists())
+        self.assertTrue((self.hapi_home / "runner.state.json").exists())
+        self.assertFalse((self.hapi_home / "trash").exists())
+        self.assertFalse((self.root / ".cache").exists())
+        self.assertFalse((self.root / "project-a").exists())
+
+    def test_unknown_target_is_skipped(self):
+        result = delete_cleanup_targets(["unknown-target"], self.root, self.hapi_home)
+        self.assertEqual(result["deleted"], [])
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(result["skipped"], [{"id": "unknown-target", "reason": "unknown target"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from ttydproxy.cleanup import delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
+from ttydproxy.cleanup import _format_size, delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
 
 
 def write_file(path, size):
@@ -94,6 +94,30 @@ class TestCleanupTargets(unittest.TestCase):
 
         self.assertEqual(target["path"], "linked-cache")
 
+    def test_warns_when_hapi_home_is_outside_root(self):
+        outside_hapi_home = Path(self.tempdir.name).parent / "external-hapi-home"
+        outside_hapi_home.mkdir(exist_ok=True)
+
+        with patch("builtins.print") as mock_print:
+            targets = list_cleanup_targets(self.root, outside_hapi_home)
+
+        self.assertNotIn("hapi-home", [target["id"] for target in targets])
+        mock_print.assert_called()
+
+
+class TestFormatSize(unittest.TestCase):
+    def test_zero_bytes(self):
+        self.assertEqual(_format_size(0), "0 B")
+
+    def test_1023_bytes(self):
+        self.assertEqual(_format_size(1023), "1023 B")
+
+    def test_exactly_1024_bytes(self):
+        self.assertEqual(_format_size(1024), "1.0 KB")
+
+    def test_one_terabyte(self):
+        self.assertEqual(_format_size(1024 ** 4), "1.0 TB")
+
 
 class TestCleanupDeletion(unittest.TestCase):
     def setUp(self):
@@ -159,6 +183,30 @@ class TestCleanupDeletion(unittest.TestCase):
         self.assertEqual(result["errors"], [])
         self.assertFalse(symlink_path.exists())
         self.assertTrue(real_cache.exists())
+
+    def test_duplicate_ids_are_deleted_once(self):
+        result = delete_cleanup_targets(
+            ["cache-home", "cache-home", "project:project-a", "project:project-a"],
+            self.root,
+            self.hapi_home,
+        )
+
+        self.assertEqual(
+            [item["id"] for item in result["deleted"]],
+            ["cache-home", "project:project-a"],
+        )
+
+    def test_prune_hapi_home_unlinks_symlink_child(self):
+        external_dir = self.root / "external-cache"
+        write_file(external_dir / "cache.bin", 32)
+        symlink_path = self.hapi_home / "linked-cache"
+        symlink_path.symlink_to(external_dir, target_is_directory=True)
+
+        result = delete_cleanup_targets(["hapi-home"], self.root, self.hapi_home)
+
+        self.assertEqual(result["errors"], [])
+        self.assertFalse(symlink_path.exists())
+        self.assertTrue(external_dir.exists())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -208,6 +208,27 @@ class TestCleanupDeletion(unittest.TestCase):
         self.assertFalse(symlink_path.exists())
         self.assertTrue(external_dir.exists())
 
+    def test_prune_hapi_home_continues_after_child_error(self):
+        good_dir = self.hapi_home / "good-dir"
+        bad_dir = self.hapi_home / "bad-dir"
+        write_file(good_dir / "artifact.bin", 16)
+        write_file(bad_dir / "artifact.bin", 16)
+
+        real_rmtree = shutil.rmtree
+
+        def fake_rmtree(path, *args, **kwargs):
+            if Path(path).name == "bad-dir":
+                raise OSError("permission denied")
+            return real_rmtree(path, *args, **kwargs)
+
+        with patch("ttydproxy.cleanup.shutil.rmtree", side_effect=fake_rmtree):
+            result = delete_cleanup_targets(["hapi-home"], self.root, self.hapi_home)
+
+        self.assertEqual(result["deleted"], [])
+        self.assertEqual(len(result["errors"]), 1)
+        self.assertFalse(good_dir.exists())
+        self.assertTrue(bad_dir.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_cleanup_api.py
+++ b/tests/unit/test_cleanup_api.py
@@ -62,6 +62,13 @@ class TestCleanupAPI(unittest.TestCase):
 
         self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
 
+    def test_handle_cleanup_delete_rejects_empty_ids(self):
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": []}
+        handler.handle_cleanup_delete()
+
+        self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
+
     def test_handle_cleanup_delete_rejects_too_many_ids(self):
         handler = RecordingCleanupHandler()
         handler._load_json_payload = lambda: {"ids": [f"id-{index}" for index in range(51)]}

--- a/tests/unit/test_cleanup_api.py
+++ b/tests/unit/test_cleanup_api.py
@@ -62,6 +62,33 @@ class TestCleanupAPI(unittest.TestCase):
 
         self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
 
+    def test_handle_cleanup_delete_rejects_too_many_ids(self):
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": [f"id-{index}" for index in range(51)]}
+        handler.handle_cleanup_delete()
+
+        self.assertEqual(handler.response, (400, {"error": "ids must contain at most 50 items"}))
+
+    def test_handle_cleanup_delete_rejects_too_long_ids(self):
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": ["x" * 129]}
+        handler.handle_cleanup_delete()
+
+        self.assertEqual(
+            handler.response,
+            (400, {"error": "ids must be at most 128 characters long"}),
+        )
+
+    @patch("ttydproxy.app.delete_cleanup_targets")
+    def test_handle_cleanup_delete_allows_duplicate_ids(self, mock_delete_cleanup_targets):
+        mock_delete_cleanup_targets.return_value = {"deleted": [{"id": "cache-home", "label": "~/.cache"}], "skipped": [], "errors": []}
+
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": ["cache-home", "cache-home"]}
+        handler.handle_cleanup_delete()
+
+        mock_delete_cleanup_targets.assert_called_once_with(["cache-home", "cache-home"], unittest.mock.ANY, unittest.mock.ANY)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_cleanup_api.py
+++ b/tests/unit/test_cleanup_api.py
@@ -1,0 +1,67 @@
+"""Tests for cleanup API handlers."""
+import unittest
+from unittest.mock import patch
+
+from ttydproxy.app import TTYDProxyHandler
+
+
+class RecordingCleanupHandler(TTYDProxyHandler):
+    def __init__(self):
+        self.response = None
+
+    def send_json(self, status, data, extra_headers=None):
+        del extra_headers
+        self.response = (status, data)
+
+    def _check_auth(self, redirect=False):
+        del redirect
+        return "alice"
+
+    def _check_csrf(self):
+        return True
+
+
+class TestCleanupAPI(unittest.TestCase):
+    @patch("ttydproxy.app.summarize_cleanup_targets")
+    @patch("ttydproxy.app.list_cleanup_targets")
+    def test_handle_cleanup_list(self, mock_list_cleanup_targets, mock_summarize_cleanup_targets):
+        mock_list_cleanup_targets.return_value = [{"id": "cache-home", "label": "~/.cache"}]
+        mock_summarize_cleanup_targets.return_value = {"count": 1, "total_size_bytes": 128, "total_size_human": "128 B"}
+
+        handler = RecordingCleanupHandler()
+        handler.handle_cleanup_list()
+
+        self.assertEqual(
+            handler.response,
+            (
+                200,
+                {
+                    "targets": [{"id": "cache-home", "label": "~/.cache"}],
+                    "summary": {"count": 1, "total_size_bytes": 128, "total_size_human": "128 B"},
+                },
+            ),
+        )
+
+    @patch("ttydproxy.app.delete_cleanup_targets")
+    def test_handle_cleanup_delete(self, mock_delete_cleanup_targets):
+        mock_delete_cleanup_targets.return_value = {"deleted": [{"id": "cache-home", "label": "~/.cache"}], "skipped": [], "errors": []}
+
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": ["cache-home"]}
+        handler.handle_cleanup_delete()
+
+        self.assertEqual(
+            handler.response,
+            (200, {"deleted": [{"id": "cache-home", "label": "~/.cache"}], "skipped": [], "errors": []}),
+        )
+
+    def test_handle_cleanup_delete_rejects_invalid_ids(self):
+        handler = RecordingCleanupHandler()
+        handler._load_json_payload = lambda: {"ids": "cache-home"}
+        handler.handle_cleanup_delete()
+
+        self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a cleanup section to the root dashboard with checkbox-based bulk deletion
- add authenticated cleanup list/delete endpoints backed by server-side allowlisted target IDs
- add cleanup discovery and deletion tests, including safe handling for `~/.hapi`

## Testing

- `python -m pytest tests/`

Closes #38
