### PR TITLE
Fix mobile touch scroll on iOS and after reconnect on Android (#36)

### DIFF
--- a/app/assets/tab_fix_script.html
+++ b/app/assets/tab_fix_script.html
@@ -112,6 +112,46 @@
       term.scrollLines(lines);
       return true;
     };
+
+    var touchActive = false;
+    var touchLastY = 0;
+    var touchRemainder = 0;
+    var TOUCH_LINE_HEIGHT = 24;
+
+    function resetTouch() {
+      touchActive = false;
+      touchLastY = 0;
+      touchRemainder = 0;
+    }
+
+    document.addEventListener('touchstart', function(e) {
+      if (e.touches.length !== 1) { resetTouch(); return; }
+      touchActive = true;
+      touchLastY = e.touches[0].clientY;
+      touchRemainder = 0;
+    }, { capture: true, passive: true });
+
+    document.addEventListener('touchmove', function(e) {
+      if (!touchActive) return;
+      if (e.touches.length !== 1) { resetTouch(); return; }
+      if (isAlternateScreen(term)) return;
+
+      var deltaY = e.touches[0].clientY - touchLastY;
+      if (deltaY === 0) return;
+      touchLastY = e.touches[0].clientY;
+      touchRemainder += deltaY;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      var steps = Math.trunc(touchRemainder / TOUCH_LINE_HEIGHT);
+      if (steps === 0) return;
+      touchRemainder -= steps * TOUCH_LINE_HEIGHT;
+      term.scrollLines(-steps);
+    }, { passive: false, capture: true });
+
+    document.addEventListener('touchend', resetTouch, { capture: true, passive: true });
+    document.addEventListener('touchcancel', resetTouch, { capture: true, passive: true });
   });
 })();
 </script>

--- a/app/assets/tab_fix_script.html
+++ b/app/assets/tab_fix_script.html
@@ -150,7 +150,13 @@
       term.scrollLines(-steps);
     }, { passive: false, capture: true });
 
-    document.addEventListener('touchend', resetTouch, { capture: true, passive: true });
+    document.addEventListener('touchend', function() {
+      if (touchActive) {
+        var ta = document.querySelector('.xterm-helper-textarea');
+        if (ta) ta.focus();
+      }
+      resetTouch();
+    }, { capture: true, passive: true });
     document.addEventListener('touchcancel', resetTouch, { capture: true, passive: true });
   });
 })();

--- a/app/assets/terminal_parent_tab_handler.html
+++ b/app/assets/terminal_parent_tab_handler.html
@@ -1,32 +1,12 @@
 <script>
   (function() {
     var iframe = document.getElementById('terminal');
-    var terminalShell = document.getElementById('terminal-shell');
-    var touchScrollActive = false;
-    var touchScrollLastY = 0;
-    var touchScrollRemainder = 0;
-    var TOUCH_SCROLL_LINE_HEIGHT = 24;
-
-    function resetTouchScroll() {
-      touchScrollActive = false;
-      touchScrollLastY = 0;
-      touchScrollRemainder = 0;
-    }
-
-    function getTerminalWindow() {
-      try {
-        return iframe && iframe.contentWindow ? iframe.contentWindow : null;
-      } catch (e) {
-        return null;
-      }
-    }
 
     function focusTerminal() {
-      var win = getTerminalWindow();
-      if (!win) return;
       try {
-        win.focus();
-        var doc = win.document;
+        if (!iframe || !iframe.contentWindow) return;
+        iframe.contentWindow.focus();
+        var doc = iframe.contentWindow.document;
         if (!doc) return;
         var textarea = doc.querySelector('.xterm-helper-textarea');
         if (textarea) textarea.focus();
@@ -47,58 +27,6 @@
       iframe.addEventListener('focus', function() {
         focusTerminal();
       });
-    }
-
-    if (terminalShell) {
-      terminalShell.addEventListener('touchstart', function(e) {
-        if (e.touches.length !== 1) {
-          resetTouchScroll();
-          return;
-        }
-
-        touchScrollActive = true;
-        touchScrollLastY = e.touches[0].clientY;
-        touchScrollRemainder = 0;
-      }, { capture: true });
-
-      terminalShell.addEventListener('touchmove', function(e) {
-        if (!touchScrollActive) return;
-        if (e.touches.length !== 1) {
-          resetTouchScroll();
-          return;
-        }
-
-        var win = getTerminalWindow();
-        if (!win) return;
-        if (win.isTerminalAlternateScreen && win.isTerminalAlternateScreen()) return;
-
-        var deltaY = e.touches[0].clientY - touchScrollLastY;
-        if (deltaY === 0) return;
-
-        touchScrollLastY = e.touches[0].clientY;
-        touchScrollRemainder += deltaY;
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        var lineSteps = Math.trunc(touchScrollRemainder / TOUCH_SCROLL_LINE_HEIGHT);
-        if (lineSteps === 0) return;
-
-        touchScrollRemainder -= lineSteps * TOUCH_SCROLL_LINE_HEIGHT;
-
-        if (win.scrollTerminalLines) {
-          win.scrollTerminalLines(-lineSteps);
-        }
-      }, { passive: false, capture: true });
-
-      terminalShell.addEventListener('touchend', function() {
-        if (touchScrollActive) focusTerminal();
-        resetTouchScroll();
-      }, { capture: true });
-
-      terminalShell.addEventListener('touchcancel', function() {
-        resetTouchScroll();
-      }, { capture: true });
     }
   })();
 </script>

--- a/tests/unit/test_inject_tab_fix.py
+++ b/tests/unit/test_inject_tab_fix.py
@@ -86,5 +86,29 @@ class TestInjectTTYDRealistic(unittest.TestCase):
         self.assertIn("</script>", TAB_FIX_SCRIPT)
 
 
+class TestInjectTouchScroll(unittest.TestCase):
+    """Touch scroll is handled inside the iframe so iOS (which doesn't bubble
+    touch events out of iframes) works, and so registration happens after term
+    is ready (fixes #36 race after reconnect)."""
+
+    def test_touch_listeners_present(self):
+        for event_name in ("touchstart", "touchmove", "touchend", "touchcancel"):
+            with self.subTest(event_name=event_name):
+                self.assertIn(f"addEventListener('{event_name}'", TAB_FIX_SCRIPT)
+
+    def test_touchmove_is_non_passive_and_captured(self):
+        section = TAB_FIX_SCRIPT[TAB_FIX_SCRIPT.index("addEventListener('touchmove'"):]
+        self.assertIn("passive: false", section)
+        self.assertIn("capture: true", section)
+
+    def test_touchmove_skips_alternate_screen(self):
+        section = TAB_FIX_SCRIPT[TAB_FIX_SCRIPT.index("addEventListener('touchmove'"):]
+        self.assertIn("isAlternateScreen(term)", section)
+
+    def test_touchmove_calls_term_scroll_lines(self):
+        section = TAB_FIX_SCRIPT[TAB_FIX_SCRIPT.index("addEventListener('touchmove'"):]
+        self.assertIn("term.scrollLines(", section)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_inject_tab_fix.py
+++ b/tests/unit/test_inject_tab_fix.py
@@ -109,6 +109,16 @@ class TestInjectTouchScroll(unittest.TestCase):
         section = TAB_FIX_SCRIPT[TAB_FIX_SCRIPT.index("addEventListener('touchmove'"):]
         self.assertIn("term.scrollLines(", section)
 
+    def test_touchend_restores_textarea_focus(self):
+        # Regression guard for commit 79cda5b (iOS keyboard flash fix):
+        # touchend must refocus .xterm-helper-textarea after a swipe so the
+        # soft keyboard reopens on the next tap.
+        section = TAB_FIX_SCRIPT[TAB_FIX_SCRIPT.index("addEventListener('touchend'"):]
+        end = section.index("addEventListener('touchcancel'")
+        touchend_section = section[:end]
+        self.assertIn(".xterm-helper-textarea", touchend_section)
+        self.assertIn(".focus()", touchend_section)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_terminal_parent_tab_handler.py
+++ b/tests/unit/test_terminal_parent_tab_handler.py
@@ -8,23 +8,17 @@ class TestTerminalParentTabHandler(unittest.TestCase):
     def setUp(self):
         self.script = TERMINAL_PARENT_TAB_HANDLER
 
-    def test_touch_listeners_present(self):
+    def test_tab_keydown_handler_present(self):
+        self.assertIn("addEventListener('keydown'", self.script)
+        self.assertIn("e.key !== 'Tab'", self.script)
+
+    def test_iframe_focus_handler_present(self):
+        self.assertIn("iframe.addEventListener('focus'", self.script)
+
+    def test_touch_handlers_moved_to_iframe(self):
         for event_name in ("touchstart", "touchmove", "touchend", "touchcancel"):
             with self.subTest(event_name=event_name):
-                self.assertIn(f"addEventListener('{event_name}'", self.script)
-
-    def test_touchmove_listener_is_non_passive(self):
-        touchmove_section = self.script[self.script.index("addEventListener('touchmove'"):]
-        self.assertIn("passive: false", touchmove_section)
-        self.assertIn("capture: true", touchmove_section)
-
-    def test_touchmove_uses_iframe_helpers(self):
-        touchmove_section = self.script[self.script.index("addEventListener('touchmove'"):]
-        self.assertIn("win.isTerminalAlternateScreen", touchmove_section)
-        self.assertIn("win.scrollTerminalLines(-lineSteps);", touchmove_section)
-
-    def test_terminal_shell_is_used_for_gestures(self):
-        self.assertIn("document.getElementById('terminal-shell')", self.script)
+                self.assertNotIn(f"addEventListener('{event_name}'", self.script)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_vkbd_html.py
+++ b/tests/unit/test_vkbd_html.py
@@ -35,7 +35,6 @@ class TestVKBDEnabled(unittest.TestCase):
         self.assertIn("navigator.clipboard.readText()", self.html)
         self.assertIn("socket.send('0' + data)", self.html)
         self.assertIn("win.sendTabKey", self.html)
-        self.assertIn("win.scrollTerminalLines", self.html)
 
     def test_new_key_sequences(self):
         self.assertIn("String.fromCharCode(127)", self.html)  # backspace


### PR DESCRIPTION
## Summary

- Move touch scroll handler from parent window into the TTYD iframe (`tab_fix_script.html`), next to the wheel handler
- Simplify `terminal_parent_tab_handler.html` to only handle Tab keydown + iframe focus
- Relocate touch-scroll tests from `test_terminal_parent_tab_handler.py` to `test_inject_tab_fix.py`

## Why

Two related mobile scroll bugs with a common root cause:

1. **iOS (undocumented):** scroll never worked. Safari/iOS does not bubble touch events out of iframes, so the parent-level handler never received `touchmove` when the user's finger was on the terminal.
2. **Android #36:** scroll froze after closing and reopening the tab in a fresh browser session. Race condition — the parent handler called `iframe.contentWindow.scrollTerminalLines()`, but that function is only defined after xterm.js initializes inside the iframe via `waitForTerm()`. Early swipes hit `undefined` and the user saw a dead scroll.

Running the handler inside the iframe eliminates both: no iframe barrier for iOS, and registration happens inside `waitForTerm` so it can't race with `term`.

## Test plan

- [x] `python -m pytest tests/` — 96 passed
- [ ] Open terminal on iPhone Safari, scroll with finger → should scroll
- [ ] Open terminal on Android Chrome, close tab, open fresh, scroll immediately → should scroll (no freeze)
- [ ] Open `vim` on mobile, swipe → xterm shouldn't scroll (alternate screen check still in place)
- [ ] Desktop mouse wheel still works

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)