### PR TITLE
Add favicon to web UI

### DIFF
--- a/app/favicon.svg
+++ b/app/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="12" fill="#1a1d24"/>
+  <text x="14" y="68" font-family="monospace" font-size="52" font-weight="bold" fill="#4a90d9">&gt;_</text>
+</svg>

--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='12' fill='%231a1d24'/><text x='14' y='68' font-family='monospace' font-size='52' font-weight='bold' fill='%234a90d9'>&gt;_</text></svg>">
   <title>HAPI Dashboard</title>
   <style>
     * { box-sizing: border-box; }

--- a/app/login.html
+++ b/app/login.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="{{CSRF_TOKEN}}">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='12' fill='%231a1d24'/><text x='14' y='68' font-family='monospace' font-size='52' font-weight='bold' fill='%234a90d9'>&gt;_</text></svg>">
   <title>TTYD Login</title>
   <style>
     * { box-sizing: border-box; }

--- a/app/terminal.html
+++ b/app/terminal.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='12' fill='%231a1d24'/><text x='14' y='68' font-family='monospace' font-size='52' font-weight='bold' fill='%234a90d9'>&gt;_</text></svg>">
   <title>{{TITLE}}</title>
   <style>
     * { box-sizing: border-box; }

--- a/docs/superpowers/specs/2026-05-04-favicon-design.md
+++ b/docs/superpowers/specs/2026-05-04-favicon-design.md
@@ -1,0 +1,16 @@
+# Favicon Design
+
+## Summary
+Add an inline SVG favicon to all HTML pages (login, dashboard, terminal) for browser tab identification.
+
+## Approach
+- **Inline SVG data URI** in the `<link rel="icon">` tag — no external files, no server changes.
+- Icon: `>_` terminal prompt characters on a dark (#1a1a2e) background in a monospace style.
+- Added to all 3 HTML templates: `login.html`, `index.html`, `terminal.html`.
+
+## Scope
+- Only HTML `<head>` changes in existing templates.
+- No new files, no env vars, no server-side changes.
+
+## Testing
+- Verify favicon appears in browser tab on all 3 pages (login, dashboard, terminal).


### PR DESCRIPTION
## Summary
- Adds an inline SVG `>_` terminal prompt favicon to all 3 HTML pages (login, dashboard, terminal)
- No external files or server changes — pure `<link rel="icon">` with data URI
- Includes `app/favicon.svg` source file for easy editing

## Preview

<img src="https://raw.githubusercontent.com/axisrow/clihost/favicon-issue-28/app/favicon.svg" width="32" height="32"> 

 terminal prompt favicon (32×32, actual browser tab size)

<details>
<summary>SVG source</summary>

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
  <rect width="100" height="100" rx="12" fill="#1a1d24"/>
  <text x="14" y="68" font-family="monospace" font-size="52" font-weight="bold" fill="#4a90d9">&gt;_</text>
</svg>
```

</details>

Closes #28