### PR TITLE
Fix request-handling bugs and simplify ttyd proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,19 +63,22 @@ hapi Client → HTTP API (HAPI_PORT) → hapi Runner
 
 ### Key Components
 
-**app/server.py** - Base HTTP server with common utilities (JSON/HTML responses, silent logging, security headers)
+**app/server.py** - Base HTTP server with common utilities (JSON/HTML/binary responses, silent logging, security headers via `BaseHTTPHandler`)
 
-**app/ttyd_proxy.py** - TTYD reverse proxy (`ThreadingHTTPServer`) with:
-- Cookie-based HMAC-signed session authentication
-- PAM/shadow password verification (or global password via TTYD_PASSWORD)
-- WebSocket tunneling to TTYD process
-- Rate limiting (5 attempts per 60s per IP, 5 per 300s per account)
-- CSRF double-submit token protection
-- Username validation (alphanumeric, max 32 chars) and command injection prevention
-- `env_bool()` utility for parsing boolean environment variables (used for feature toggles like VIRTUAL_KEYBOARD, SECURE_COOKIES)
-- Routes: `/` (dashboard/menu), `/login` (login form), `/health` (health check), `/ttyd` (terminal), `/ttyd/*` (WebSocket proxy)
+**app/ttyd_proxy.py** - Thin process entry point referenced by `entrypoint.sh` (`python3 /app/ttyd_proxy.py`). Imports `main` from `ttydproxy.app` and runs it. All logic lives in the `ttydproxy` package below.
 
-**app/index.html, app/login.html** - HTML templates with variable substitution (`{{USERNAME}}`, `{{CSRF_TOKEN}}`, `{{HAPI_LINK}}`). Values are escaped via `html.escape()` to prevent XSS.
+**app/ttydproxy/** - The TTYD reverse proxy package (`ThreadingHTTPServer`):
+- `app.py` - `TTYDProxyHandler` (request routing + handlers) and `main()` (process wiring, signal handling). Routes: `/` (dashboard/menu), `/login` (login form), `/health`, `/favicon.ico` & friends (unauthenticated static assets), `/cleanup`, `/terminals`, `/ttyd{N}` (terminal page), `/ttyd{N}/*` (HTTP/WebSocket proxy)
+- `security.py` - HMAC-signed session/CSRF tokens, cookie parsing, `is_valid_username`, PAM/shadow password verification, `env_bool()` (boolean env vars like VIRTUAL_KEYBOARD, SECURE_COOKIES)
+- `manager.py` - `TTYDManager`: lifecycle of ttyd child processes, port allocation, tmux sessions
+- `proxy.py` - upstream HTTP/WebSocket proxying and `inject_tab_fix_script()` HTML injection
+- `ratelimit.py` - `RateLimiter` (5 attempts per 60s per IP, 5 per 300s per account)
+- `cleanup.py` - allowlisted cleanup target discovery and safe deletion
+- `views.py` - HTML template rendering (`render_template`, `FAVICON_LINKS`) with XSS escaping
+- `config.py` - runtime configuration from environment variables
+- `assets.py` - cached loading of static asset files (HTML/CSS partials, favicon bytes)
+
+**app/index.html, app/login.html, app/terminal.html** - HTML templates with variable substitution (`{{USERNAME}}`, `{{CSRF_TOKEN}}`, `{{HAPI_LINK}}`, `{{FAVICON}}`, etc.). Values are escaped via `html.escape()` to prevent XSS. The shared favicon `<link>` block is injected via the `{{FAVICON}}` placeholder from `views.FAVICON_LINKS`.
 
 **Dashboard UI (app/index.html)** - Terminal list and controls are built dynamically in JavaScript (not static HTML), so searching for button text in HTML will not find them. Key UI elements:
 - **Terminal row** (`terminal-row` class): each active ttyd instance gets a row with an open link + close button
@@ -130,9 +133,9 @@ The TTYD module provides secure web terminal access. Key implementation details:
 
 ### Tab Key Fix
 
-The proxy injects a JavaScript fix into TTYD HTML to enable Tab key for shell completion. Technical notes:
+The proxy injects a JavaScript fix into TTYD HTML to enable Tab key for shell completion. Implemented in `app/ttydproxy/proxy.py` (`inject_tab_fix_script()`); the injected script itself lives in `app/assets/tab_fix_script.html` and is loaded as `TAB_FIX_SCRIPT` in `app/ttydproxy/assets.py`. Technical notes:
 
-- **Gzip handling**: TTYD returns gzip-compressed HTML. The `inject_tab_fix_script()` function decompresses before injection and re-compresses after.
+- **Gzip handling**: TTYD returns gzip-compressed HTML. The `inject_tab_fix_script()` function decompresses before injection and re-compresses after (gzip is detected from the response's magic bytes).
 - **WebSocket capture**: The injected script intercepts `window.WebSocket` constructor to capture the TTYD socket. The socket reference must be stored in `window._ttydSocket` (global), not as a local variable inside IIFE.
 - **Tab sending**: Uses TTYD protocol prefix `'0'` (INPUT command) + tab character (`\t`) via WebSocket.
 - **Shell requirement**: Tab completion only works in shells that support it (bash). Default `/bin/sh` (dash) does not have completion.

--- a/app/index.html
+++ b/app/index.html
@@ -3,10 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/favicon.ico" sizes="any">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  {{FAVICON}}
   <title>HAPI Dashboard</title>
   <style>
     * { box-sizing: border-box; }

--- a/app/login.html
+++ b/app/login.html
@@ -4,10 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="{{CSRF_TOKEN}}">
-  <link rel="icon" href="/favicon.ico" sizes="any">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  {{FAVICON}}
   <title>TTYD Login</title>
   <style>
     * { box-sizing: border-box; }

--- a/app/server.py
+++ b/app/server.py
@@ -4,7 +4,7 @@ Base HTTP Server
 Provides common HTTP server functionality
 """
 import json
-from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler
 
 
 COMMON_SECURITY_HEADERS = {
@@ -83,26 +83,3 @@ class BaseHTTPHandler(BaseHTTPRequestHandler):
             cache_control,
             extra_headers=extra_headers,
         )
-
-
-class BaseJSONServer:
-    """Base HTTP server class."""
-
-    def __init__(self, port, handler_class):
-        self.port = port
-        self.handler_class = handler_class
-        self.httpd = None
-
-    def start(self):
-        """Start the HTTP server."""
-        server_address = ("0.0.0.0", self.port)
-        self.httpd = ThreadingHTTPServer(server_address, self.handler_class)
-        self.httpd.daemon_threads = True  # don't block shutdown on open connections
-        print(f"HTTP server listening on port {self.port}")
-        self.httpd.serve_forever()
-
-
-def create_server(port, handler_class):
-    """Factory function to create and start HTTP server."""
-    server = BaseJSONServer(port, handler_class)
-    server.start()

--- a/app/terminal.html
+++ b/app/terminal.html
@@ -3,10 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <link rel="icon" href="/favicon.ico" sizes="any">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  {{FAVICON}}
   <title>{{TITLE}}</title>
   <style>
     * { box-sizing: border-box; }

--- a/app/ttyd_proxy.py
+++ b/app/ttyd_proxy.py
@@ -1,78 +1,10 @@
 #!/usr/bin/env python3
-"""Backward-compatible entrypoint for the refactored ttyd proxy server."""
+"""Backward-compatible entrypoint for the refactored ttyd proxy server.
 
-from ttydproxy.app import TTYDProxyHandler, main, ttyd_manager
-from ttydproxy.config import (
-    PORT,
-    TTYD_BASE_PORT,
-    TTYD_PASSWORD,
-    TTYD_ROUTE_PATTERN,
-    TTYD_USER,
-    VIRTUAL_KEYBOARD,
-    CSRF_TOKEN_TTL,
-    SECURE_COOKIES,
-    MAX_TERMINALS,
-    SESSION_TIMEOUT,
-)
-from ttydproxy.manager import TTYDManager
-from ttydproxy.proxy import inject_tab_fix_script
-from ttydproxy.assets import TAB_FIX_SCRIPT
-from ttydproxy.security import (
-    build_csrf_token,
-    build_session_token,
-    env_bool,
-    is_valid_username,
-    parse_cookie_header,
-    parse_csrf_token,
-    parse_session_token,
-    verify_pam_password,
-)
-
-
-def build_ttyd_session(username, port):
-    """Backward-compatible session builder wrapper."""
-    del port
-    from ttydproxy.config import PASSWORD_SECRET
-
-    return build_session_token(username, PASSWORD_SECRET, SESSION_TIMEOUT)
-
-
-def parse_ttyd_session(token):
-    """Backward-compatible session parser wrapper."""
-    from ttydproxy.config import PASSWORD_SECRET
-
-    username = parse_session_token(token, PASSWORD_SECRET)
-    if not username:
-        return None, None
-    return username, TTYD_BASE_PORT
-
-
-__all__ = [
-    "CSRF_TOKEN_TTL",
-    "MAX_TERMINALS",
-    "PORT",
-    "SECURE_COOKIES",
-    "SESSION_TIMEOUT",
-    "TAB_FIX_SCRIPT",
-    "TTYDManager",
-    "TTYDProxyHandler",
-    "TTYD_BASE_PORT",
-    "TTYD_PASSWORD",
-    "TTYD_ROUTE_PATTERN",
-    "TTYD_USER",
-    "VIRTUAL_KEYBOARD",
-    "build_csrf_token",
-    "build_ttyd_session",
-    "env_bool",
-    "inject_tab_fix_script",
-    "is_valid_username",
-    "main",
-    "parse_cookie_header",
-    "parse_csrf_token",
-    "parse_ttyd_session",
-    "ttyd_manager",
-    "verify_pam_password",
-]
+The implementation now lives in the ``ttydproxy`` package. This module remains
+as the process entry point referenced by entrypoint.sh (``python3 /app/ttyd_proxy.py``).
+"""
+from ttydproxy.app import main
 
 
 if __name__ == "__main__":

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -1,4 +1,5 @@
 """HTTP handler and process wiring for the ttyd proxy application."""
+import hmac
 import json
 import sys
 import signal
@@ -129,9 +130,12 @@ class TTYDProxyHandler(BaseHandler):
             "Set-Cookie": f"csrf_token={csrf_token}; Path=/; SameSite=Lax;{self._secure_flag()}",
         }, csrf_token
 
+    def _cookie(self, name):
+        """Return a single cookie value from the request, or '' if absent."""
+        return parse_cookie_header(self.headers.get("Cookie", "")).get(name, "")
+
     def _session_username(self):
-        cookies = parse_cookie_header(self.headers.get("Cookie", ""))
-        token = cookies.get("ttyd_session")
+        token = self._cookie("ttyd_session")
         return parse_session_token(token, PASSWORD_SECRET)
 
     def _check_auth(self, redirect=False):
@@ -149,32 +153,62 @@ class TTYDProxyHandler(BaseHandler):
             return None
         return username
 
-    def _check_csrf(self):
-        csrf_header = self.headers.get("X-CSRF-Token", "")
-        csrf_cookie = parse_cookie_header(self.headers.get("Cookie", "")).get("csrf_token", "")
-        if not csrf_header or not csrf_cookie:
-            self.send_json(419, {"error": "CSRF token missing — please refresh the page"})
+    def _check_csrf(
+        self,
+        payload=None,
+        status=419,
+        missing_error="CSRF token missing — please refresh the page",
+        invalid_error="CSRF token expired — please refresh the page",
+    ):
+        """Validate the CSRF double-submit token.
+
+        Uses the X-CSRF-Token header, falling back to the request payload's
+        ``csrf_token`` field when ``payload`` is provided (form login). The
+        status code and error messages are parameters so the login flow can
+        return 403 with its own wording while API routes return 419.
+        """
+        provided_token = (
+            self.headers.get("X-CSRF-Token", "") or (payload or {}).get("csrf_token", "")
+        ).strip()
+        csrf_cookie = self._cookie("csrf_token")
+        if not provided_token or not csrf_cookie:
+            self.send_json(status, {"error": missing_error})
             return False
-        if csrf_header != csrf_cookie or not parse_csrf_token(csrf_header, PASSWORD_SECRET, CSRF_TOKEN_TTL):
-            self.send_json(419, {"error": "CSRF token expired — please refresh the page"})
+        if not hmac.compare_digest(provided_token, csrf_cookie) or not parse_csrf_token(
+            provided_token, PASSWORD_SECRET, CSRF_TOKEN_TTL
+        ):
+            self.send_json(status, {"error": invalid_error})
             return False
         return True
 
-    def _load_login_payload(self):
-        content_length = int(self.headers.get("Content-Length", 0))
-        if content_length > 1048576:
+    def _read_request_body(self):
+        """Read and UTF-8 decode the request body. Returns text or None on error."""
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            self.send_json(400, {"error": "Invalid Content-Length"})
+            return None
+        if content_length < 0 or content_length > 1048576:
             self.send_json(413, {"error": "Request too large"})
             return None
         try:
-            post_data = self.rfile.read(content_length).decode("utf-8")
+            return self.rfile.read(content_length).decode("utf-8")
         except UnicodeDecodeError:
             self.send_json(400, {"error": "Invalid encoding"})
             return None
 
-        content_type = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+    def _content_type(self):
+        return self.headers.get_content_type()
+
+    def _load_login_payload(self):
+        raw_data = self._read_request_body()
+        if raw_data is None:
+            return None
+
+        content_type = self._content_type()
         if content_type == "application/json":
             try:
-                data = json.loads(post_data)
+                data = json.loads(raw_data or "{}")
             except json.JSONDecodeError:
                 self.send_json(400, {"error": "Invalid JSON"})
                 return None
@@ -185,7 +219,7 @@ class TTYDProxyHandler(BaseHandler):
             }
 
         if content_type == "application/x-www-form-urlencoded":
-            form = parse_qs(post_data, keep_blank_values=True)
+            form = parse_qs(raw_data, keep_blank_values=True)
             return {
                 "username": (form.get("username", [""])[0]).strip(),
                 "password": form.get("password", [""])[0],
@@ -196,18 +230,10 @@ class TTYDProxyHandler(BaseHandler):
         return None
 
     def _load_json_payload(self):
-        content_length = int(self.headers.get("Content-Length", 0))
-        if content_length > 1048576:
-            self.send_json(413, {"error": "Request too large"})
+        raw_data = self._read_request_body()
+        if raw_data is None:
             return None
-        try:
-            raw_data = self.rfile.read(content_length).decode("utf-8")
-        except UnicodeDecodeError:
-            self.send_json(400, {"error": "Invalid encoding"})
-            return None
-
-        content_type = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
-        if content_type != "application/json":
+        if self._content_type() != "application/json":
             self.send_json(415, {"error": "Unsupported content type"})
             return None
         try:
@@ -309,14 +335,12 @@ class TTYDProxyHandler(BaseHandler):
         if payload is None:
             return
 
-        csrf_header = self.headers.get("X-CSRF-Token", "")
-        csrf_cookie = parse_cookie_header(self.headers.get("Cookie", "")).get("csrf_token", "")
-        provided_token = (csrf_header or payload["csrf_token"]).strip()
-        if not provided_token or not csrf_cookie:
-            self.send_json(403, {"error": "CSRF token missing"})
-            return
-        if provided_token != csrf_cookie or not parse_csrf_token(provided_token, PASSWORD_SECRET, CSRF_TOKEN_TTL):
-            self.send_json(403, {"error": "Invalid CSRF token"})
+        if not self._check_csrf(
+            payload=payload,
+            status=403,
+            missing_error="CSRF token missing",
+            invalid_error="Invalid CSRF token",
+        ):
             return
 
         username = payload["username"]

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -41,10 +41,11 @@ def build_ttyd_headers(handler, port):
     return headers
 
 
-def inject_tab_fix_script(data, is_gzipped=False):
+def inject_tab_fix_script(data):
     """Inject the Tab fix script into ttyd HTML responses."""
     try:
-        if is_gzipped or (len(data) >= 2 and data[0:2] == b"\x1f\x8b"):
+        is_gzipped = False
+        if len(data) >= 2 and data[0:2] == b"\x1f\x8b":
             try:
                 data = gzip.decompress(data)
                 is_gzipped = True

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -11,6 +11,16 @@ from ttydproxy.security import env_bool
 APP_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = APP_ROOT
 
+FAVICON_LINKS = "\n  ".join((
+    '<link rel="icon" href="/favicon.ico" sizes="any">',
+    '<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">',
+    '<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">',
+    '<link rel="apple-touch-icon" href="/apple-touch-icon.png">',
+))
+
+# Placeholders substituted into every rendered page.
+BASE_REPLACEMENTS = {"{{FAVICON}}": FAVICON_LINKS}
+
 
 @lru_cache(maxsize=None)
 def load_template(filename):
@@ -23,9 +33,13 @@ def load_template(filename):
 
 
 def render_template(filename, replacements):
-    """Render a template using plain placeholder replacement."""
+    """Render a template using plain placeholder replacement.
+
+    Base replacements shared by every page (e.g. the favicon links) are applied
+    automatically; callers only pass page-specific values.
+    """
     content = load_template(filename)
-    for key, value in replacements.items():
+    for key, value in {**BASE_REPLACEMENTS, **replacements}.items():
         content = content.replace(key, value)
     return content
 


### PR DESCRIPTION
## Summary

Bug fixes and cleanup across the ttyd proxy, found via a full audit of the `app/ttydproxy/` package (not just the recent favicon change). Each candidate was verified against the real code; several agent-flagged "bugs" were confirmed false positives and left untouched (see below).

### Correctness / security fixes (`app/ttydproxy/app.py`)
- **Guard `int(Content-Length)`** — a non-numeric header (`Content-Length: abc`) previously raised an unhandled `ValueError` → 500; now returns a clean 400. A negative value (`-1`) previously passed the size check and triggered `rfile.read(-1)`, blocking the worker thread until the connection closed; now rejected with 413.
- **Timing-safe CSRF comparison** — token comparison now uses `hmac.compare_digest` instead of `!=`, consistent with the signed-token verification already used for sessions.

### Cleanup & simplification
- **Dead code removed:** `build_ttyd_session`/`parse_ttyd_session` (no importers — `ttyd_proxy.py` is now a thin entry point), `BaseJSONServer`/`create_server` in `server.py`, and the never-passed `is_gzipped` param in `proxy.py`.
- **Deduplicated body loading:** `_load_login_payload`/`_load_json_payload` now share `_read_request_body()` + `_content_type()` (the latter using stdlib `headers.get_content_type()`).
- **Unified CSRF check:** a single `_check_csrf(payload=, status=, messages…)` serves both API (419) and login (403) flows; added a `_cookie(name)` helper to remove repeated cookie parsing.
- **Favicon DRY:** the shared `<link>` block is now `views.FAVICON_LINKS`, injected centrally via `BASE_REPLACEMENTS` in `render_template` (the `{{FAVICON}}` placeholder), removing the duplicated block from the three HTML templates.
- **Docs:** `CLAUDE.md` updated to describe the `ttydproxy` package layout (it still described the old monolithic `ttyd_proxy.py`).

### Verified-clean, intentionally not touched
TOCTOU/symlink in `cleanup.py` (guarded by `is_symlink()`+`unlink()`), socket close in `tunnel_sockets` (closed in `finally`), `RateLimiter` growth (periodic stale-key cleanup), the double-submit CSRF model, and the `time.sleep(0.5)` anti-enumeration delay in login.

## Env / ports / volumes
No new environment variables, port mappings, or volume changes.

## Testing
- `python -m pytest tests/` — **101 passed, 73 subtests passed**
- `ruff check app/` — clean
- Functional spot-checks: `Content-Length: abc`→400, `-1`→413; CSRF 419/403 messages and payload fallback; favicon present in all three rendered pages with no leftover placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)