### PR TITLE
Fix WebSocket tunnel data loss, SIGTERM deadlock, and auth/shell bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 # Build with auto-detection of new npm package versions (recommended)
+# Hashes versions of packages from cli-packages.txt to bust Docker cache when a CLI tool updates
 ./build.sh
 
 # Build without checking for updates (uses Docker cache)
@@ -24,155 +25,136 @@ docker run -p 22:22 -p 8080:8080 \
 
 # Health check
 curl http://localhost:8080/health
-# Expected: {"status": "ok", "uptime": N, "ttyd": "running", "terminal_count": N, "terminals": [...], "memory_mb": N}
+# {"status": "ok", "uptime": N, "ttyd": "running", "terminal_count": N, "terminals": [...], "memory_mb": N}
 ```
+
+To add a new bundled npm CLI tool: add a line to `cli-packages.txt` and the corresponding install step in `Dockerfile`. `build.sh` reads `cli-packages.txt` to compute the cache-busting hash. Hermes Agent is installed via pip from GitHub (not npm) and auto-updates at container start unless `HERMES_AUTO_UPDATE=false`.
+
+## Testing
+
+```bash
+python -m pytest tests/                          # all tests
+python -m pytest tests/unit/                     # unit tests only
+python -m pytest tests/unit/test_csrf.py         # single file
+python -m pytest tests/ -k "test_truthy_1"       # single test by name
+```
+
+`tests/conftest.py` adds `app/` to `sys.path`, so tests import modules directly (`from ttydproxy.security import ...`).
+
+- `tests/unit/` — pure-function and module tests (security/CSRF, TTYDManager, cleanup, terminals API, asset injection, threading). Run on any OS without Linux-only deps.
+  - `test_threading.py` verifies `ThreadingHTTPServer` handles concurrent requests in parallel (3 × 0.3s requests must finish in ~0.3s, not 0.9s)
+- `tests/integration/` — TTYD handler tests that simulate handler behavior without importing the full app wiring (avoids Linux-only deps like `crypt`/PAM).
+- `tests/preview/vkbd_preview.html` — manual visual preview of the virtual keyboard.
+
+**Manual smoke test:** build image, run container, verify logs show "Hapi runner startup complete" (or fallback message) and sshd stays running. Web terminal: open http://localhost:8080, login with system credentials.
 
 ## Architecture
 
-Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI), with an integrated web terminal (TTYD).
+Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Hermes Agent), with an integrated multi-terminal web UI (TTYD).
 
-### Container Structure
-
-**Entry point flow** (entrypoint.sh):
-1. Fixes permissions for hapi home directory (Railway volume mount overwrites permissions)
-2. Creates config directories (.config/gh, .claude) for persistence on volume
-3. Configures SSH server (optionally enables root access if ROOT_PASSWORD set)
-4. Cleans old hapi runner state files and lock files
-5. Starts TTYD process on 127.0.0.1:7681 (as hapi user via tmux-wrapper)
-6. Starts TTYD HTTP proxy server (Python, port 8080 by default)
-7. Starts hapi server with relay in background (extracts tunnel URL and token)
-8. Starts hapi runner in background if HAPI_RUNNER_ENABLED=true
-9. Runs sshd as main process (keeps container alive)
-
-**Multi-process architecture:**
-- `sshd` (port 22) - SSH access, main process
-- `hapi server --relay` - relay server (always starts, provides tunnel URL)
-- `hapi runner` (HAPI_PORT, default 80) - CLI tool runner (optional, requires HAPI_RUNNER_ENABLED=true)
-- `ttyd` (127.0.0.1:7681) - Web terminal process
-- `ttyd_proxy.py` (PORT, default 8080) - HTTP/WebSocket reverse proxy
+**Multi-process layout:**
+- `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)
+- `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**
+- `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
+- `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
+- `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
 
 **Data flow:**
 ```
-Browser → WebSocket → HTTP Proxy (8080) → TTYD (127.0.0.1:7681) → tmux-wrapper → Shell
-SSH Client → SSHD (22) → Shell Access
-hapi Client → HTTP API (HAPI_PORT) → hapi Runner
+Browser → HTTP/WS → ttyd_proxy (8080) → ttyd (127.0.0.1:768x) → tmux-wrapper → shell
+SSH Client → sshd (22) → shell
+hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Volume mount:**
-- `/home/hapi`: Persistent runner state, logs, runtime files
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start ttyd proxy (it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
 
-### Key Components
+**Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 
-**app/server.py** - Base HTTP server with common utilities (JSON/HTML responses, silent logging, security headers)
+### ttyd proxy package (app/)
 
-**app/ttyd_proxy.py** - TTYD reverse proxy (`ThreadingHTTPServer`) with:
-- Cookie-based HMAC-signed session authentication
-- PAM/shadow password verification (or global password via TTYD_PASSWORD)
-- WebSocket tunneling to TTYD process
-- Rate limiting (5 attempts per 60s per IP, 5 per 300s per account)
-- CSRF double-submit token protection
-- Username validation (alphanumeric, max 32 chars) and command injection prevention
-- `env_bool()` utility for parsing boolean environment variables (used for feature toggles like VIRTUAL_KEYBOARD, SECURE_COOKIES)
-- Routes: `/` (dashboard/menu), `/login` (login form), `/health` (health check), `/ttyd` (terminal), `/ttyd/*` (WebSocket proxy)
+`app/ttyd_proxy.py` is only a **backward-compatible shim**; all logic lives in the `app/ttydproxy/` package:
 
-**app/index.html, app/login.html** - HTML templates with variable substitution (`{{USERNAME}}`, `{{CSRF_TOKEN}}`, `{{HAPI_LINK}}`). Values are escaped via `html.escape()` to prevent XSS.
+- `config.py` — env-based configuration constants and `TTYD_ROUTE_PATTERN`
+- `security.py` — HMAC session/CSRF tokens, PAM/shadow password check, `env_bool`, username validation
+- `manager.py` — `TTYDManager`: spawn/kill ttyd processes, port allocation from TTYD_BASE_PORT (7681), dead-process reaping, tmux session cleanup
+- `proxy.py` — HTTP/WebSocket proxying to ttyd, gzip-aware HTML injection (`inject_tab_fix_script`)
+- `ratelimit.py` — in-memory `RateLimiter`
+- `views.py` — render login/menu/terminal pages from templates
+- `cleanup.py` — disk cleanup targets listing/deletion for the dashboard
+- `assets.py` — loads static assets from `app/assets/` **at import time** into module constants (editing an asset requires proxy restart)
+- `app.py` — `TTYDProxyHandler` routing + `main()` (creates the first terminal, installs SIGTERM/SIGINT handlers that kill all terminals)
 
-**Dashboard UI (app/index.html)** - Terminal list and controls are built dynamically in JavaScript (not static HTML), so searching for button text in HTML will not find them. Key UI elements:
-- **Terminal row** (`terminal-row` class): each active ttyd instance gets a row with an open link + close button
-- **Close terminal button** (`delete-btn` class, red ×): closes a terminal session — calls `deleteTerminal(id)` → `DELETE /terminals/{id}`. This is what users refer to as "кнопка закрытия сессии" (session close button). It is **not** a logout button.
-- **New terminal button** (`new-terminal` class): calls `createTerminal()` → `POST /terminals`
-- **No logout button exists** — there is no route or UI element to invalidate the login session cookie
+`app/server.py` — shared `BaseHTTPHandler` (JSON/HTML/binary responses, silent logging, security headers). Server is `ThreadingHTTPServer` (one thread per request) — never switch to plain `HTTPServer`, slow WebSocket connections would block everything.
 
-**bin/tmux-wrapper.sh** - tmux session persistence wrapper (auto-attach or create new session)
+**Templates & assets:** `app/index.html` (dashboard), `app/login.html`, `app/terminal.html` — variable substitution like `{{USERNAME}}`, `{{CSRF_TOKEN}}`, values escaped via `html.escape()`. Front-end JS/CSS injected into pages lives in `app/assets/` (tab_fix_script.html, virtual_keyboard.html/.css, terminal_parent_tab_handler.html, favicons).
 
-**bin/glm** - Anthropic API wrapper that routes through z.ai proxy, requires `ZAI_TOKEN` env var
+### HTTP routes
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `/` | GET | cookie (redirect) | Dashboard with terminal list |
+| `/login` | GET/POST | CSRF | Login form / authentication |
+| `/health` | GET | none | Health JSON |
+| `/favicon*`, `/apple-touch-icon.png` | GET | none | Favicons |
+| `/terminals` | GET/POST | cookie (+CSRF on POST) | List / create terminal |
+| `/terminals/{id}` | DELETE | cookie + CSRF | Kill terminal |
+| `/cleanup` | GET | cookie | List disk cleanup targets |
+| `/cleanup/delete` | POST | cookie + CSRF | Delete cleanup targets |
+| `/ttyd{N}` | GET | cookie (redirect) | Terminal iframe page |
+| `/ttyd{N}/*` | GET/WS | cookie | HTTP/WebSocket proxy to that ttyd |
+
+State-changing requests use a CSRF double-submit token (`X-CSRF-Token` header must match the `csrf_token` cookie and verify against PASSWORD_SECRET). Login is rate-limited: 5 attempts per 60s per IP and 5 per 300s per IP+account.
+
+### Dashboard UI (app/index.html)
+
+Terminal list and controls are built **dynamically in JavaScript**, not static HTML — searching for button text in the HTML will not find them:
+- **Close terminal button** (`delete-btn` class, red ×): calls `deleteTerminal(id)` → `DELETE /terminals/{id}`. This is what users mean by "кнопка закрытия сессии". It is **not** a logout button.
+- **New terminal button** (`new-terminal` class): `createTerminal()` → `POST /terminals`
+- **No logout button exists** — there is no route or UI to invalidate the session cookie.
 
 ### Environment Variables
 
 **TTYD web terminal:**
-- `PORT` - HTTP proxy port (default: 8080)
-- `TTYD_USER` - terminal user (default: hapi)
-- `TTYD_PASSWORD` - optional global password (if not set, uses system passwords)
-- `PASSWORD_SECRET` - secret for HMAC session signatures (CHANGE IN PRODUCTION)
-- `ROOT_PASSWORD` - optional root SSH password
-- `VIRTUAL_KEYBOARD` - enable virtual keyboard for mobile devices (default: true)
-- `SESSION_TIMEOUT` - session token lifetime in seconds (default: 604800 = 1 week)
-- `CSRF_TOKEN_TTL` - CSRF token time-to-live in seconds (default: 604800 = 7 days)
-- `SECURE_COOKIES` - set Secure flag on cookies for HTTPS (default: false)
-- `MAX_TERMINALS` - maximum number of concurrent terminal instances (default: 100)
+- `PORT` — HTTP proxy port (default: 8080)
+- `TTYD_USER` — terminal user (default: hapi)
+- `TTYD_PASSWORD` — optional global password (if not set, system passwords via PAM/shadow)
+- `PASSWORD_SECRET` — secret for HMAC signatures (entrypoint generates a random one if unset; set explicitly to persist sessions across restarts)
+- `ROOT_PASSWORD` — optional root SSH password
+- `VIRTUAL_KEYBOARD` — mobile virtual keyboard (default: true)
+- `SESSION_TIMEOUT` — session token lifetime, seconds (default: 604800 = 1 week)
+- `CSRF_TOKEN_TTL` — CSRF token TTL, seconds (default: 604800)
+- `SECURE_COOKIES` — Secure flag on cookies for HTTPS (default: false)
+- `MAX_TERMINALS` — max concurrent terminals (default: 100)
+- `CLEANUP_ROOT` — root for cleanup dashboard targets (default: /home/hapi)
 
 **Hapi runner (optional):**
-- `HAPI_RUNNER_ENABLED` - enable hapi runner (default: false)
-- `CLI_API_TOKEN` - authentication token (required if runner enabled)
-- `HAPI_API_URL` - hapi server endpoint (required if runner enabled)
-- `HAPI_HOST` - bind address (default: 0.0.0.0)
-- `HAPI_PORT` - port where hapi client connects (default: 80)
-- `HAPI_USER` - user to run hapi runner as (default: hapi)
+- `HAPI_RUNNER_ENABLED` — enable runner (default: false)
+- `CLI_API_TOKEN`, `HAPI_API_URL` — required if runner enabled
+- `HAPI_HOST` (default: 0.0.0.0), `HAPI_PORT` (default: 80), `HAPI_USER` (default: hapi)
+
+**Other:** `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
+
+Update `.env.example` when adding/changing variables.
 
 ## Coding Conventions
 
 - Shell scripts use Bash with `set -euo pipefail`
 - Environment variables are UPPERCASE with defaults via `${VAR:=default}`
 - Dockerfile changes grouped by purpose (base OS, tools, user setup)
-- Python uses standard library only (http.server, hmac, crypt, etc.)
-- HTTP server uses `ThreadingHTTPServer` (not `HTTPServer`) — one thread per request so slow/long-lived connections don't block others
+- Python uses standard library only (http.server, hmac, crypt, …) — no pip dependencies in app code
 - Commits: short imperative subjects (e.g., "Add feature", "Fix bug")
-- Retry logic for network operations: use `for i in 1 2 3 4 5; do ... && break || sleep 10; done` pattern
+- Retry logic for network operations: `for i in 1 2 3 4 5; do ... && break || sleep 10; done`
 
-## TTYD Module Details
+## Injected Terminal Fixes (app/assets/tab_fix_script.html)
 
-The TTYD module provides secure web terminal access. Key implementation details:
+The proxy injects a script into ttyd's HTML (`inject_tab_fix_script` in `proxy.py`). Implementation notes:
 
-- **Session tokens**: HMAC-SHA256 signed, base64url-encoded (username:port:signature)
-- **WebSocket proxying**: Bidirectional socket tunneling using non-blocking I/O + select
-- **Authentication flow**: POST /login → Set ttyd_session cookie → Redirect to /ttyd
-- **Security**: TTYD bound to localhost only, proxy enforces authentication, rate limiting, CSRF protection
+- **Gzip handling**: ttyd serves gzip-compressed HTML; injection decompresses, inserts, re-compresses.
+- **WebSocket capture**: the script intercepts the `window.WebSocket` constructor; the socket reference must live in `window._ttydSocket` (global), not a local inside the IIFE.
+- **Tab key**: sends ttyd protocol prefix `'0'` (INPUT) + `\t` over the WebSocket. Completion only works in shells that support it (bash); `/bin/sh` (dash) does not.
+- **Mouse wheel**: normal screen — intercepts `wheel` with `capture: true, passive: false`, calls `term.scrollLines(n)`; alternate screen (vim/less/htop, `term.buffer.active.type === 'alternate'`) — passes through. deltaMode: `1` = lines, `2` = pages (`term.rows`), `0` = pixels (÷40).
 
-### Tab Key Fix
-
-The proxy injects a JavaScript fix into TTYD HTML to enable Tab key for shell completion. Technical notes:
-
-- **Gzip handling**: TTYD returns gzip-compressed HTML. The `inject_tab_fix_script()` function decompresses before injection and re-compresses after.
-- **WebSocket capture**: The injected script intercepts `window.WebSocket` constructor to capture the TTYD socket. The socket reference must be stored in `window._ttydSocket` (global), not as a local variable inside IIFE.
-- **Tab sending**: Uses TTYD protocol prefix `'0'` (INPUT command) + tab character (`\t`) via WebSocket.
-- **Shell requirement**: Tab completion only works in shells that support it (bash). Default `/bin/sh` (dash) does not have completion.
-
-### Mouse Wheel Scroll Fix
-
-The same injected script also fixes mouse wheel scroll (added alongside the Tab fix in `TAB_FIX_SCRIPT`):
-
-- **Normal screen** (bash/zsh): intercepts `wheel` events with `capture: true, passive: false`, calls `term.scrollLines(n)` and prevents xterm.js default (which sends ArrowUp/ArrowDown).
-- **Alternate screen** (vim/less/htop): detected via `term.buffer.active.type === 'alternate'`; event passes through untouched.
-- **deltaMode handling**: `1` = lines (use as-is), `2` = page (use `term.rows`), `0` = pixels (divide by 40).
-
-Reference: `TTYD_MODULE.md` in repository root for comprehensive documentation.
-
-## Testing
-
-```bash
-# Run all tests
-python -m pytest tests/
-
-# Run unit tests only
-python -m pytest tests/unit/
-
-# Run a single test file
-python -m pytest tests/unit/test_env_bool.py
-
-# Run a single test by name
-python -m pytest tests/ -k "test_truthy_1"
-```
-
-Note: `conftest.py` adds `app/` to `sys.path` for imports.
-
-**Test structure:**
-- `tests/unit/` - Pure function tests (`env_bool`, virtual keyboard HTML generation, threading). Run without Linux-specific dependencies.
-  - `test_threading.py` — verifies `ThreadingHTTPServer` handles concurrent requests in parallel (3 × 0.3s requests must finish in ~0.3s total, not 0.9s)
-- `tests/integration/` - TTYD handler tests. Simulate handler behavior without importing full ttyd_proxy.py (avoids Linux-only deps like `crypt`, PAM).
-
-**Manual smoke test:** build image, run container, verify logs show "Hapi runner startup complete" (or fallback message) and sshd stays running.
-
-**Web terminal test:** Open http://localhost:8080 in browser, login with system credentials.
+**tmux mouse mode** (`config/.tmux.conf`, copied to `/home/hapi/.tmux.conf` in Dockerfile): mouse is **off by default** so xterm.js keeps native browser text selection and Cmd+C (#40). `Ctrl+B m` toggles tmux mouse mode when tmux scroll/copy is needed. A direct Ctrl+M binding is impossible — C-m and Enter are the same byte (0x0D).
 
 ## Pull Request Guidelines
 
@@ -183,21 +165,14 @@ PRs should include:
 
 ## CI/CD
 
-- `.github/workflows/claude.yml` - Claude Code action, triggers on @claude mentions in issues/PR comments
-- `.github/workflows/claude-code-review.yml` - Automatic code review on PR open/synchronize
+- `.github/workflows/claude.yml` — Claude Code action, triggers on @claude mentions in issues/PR comments
+- `.github/workflows/claude-code-review.yml` — automatic code review on PR open/synchronize
 
 ## Debugging Commands
 
 ```bash
-# View container logs
-docker logs <container_id>
-
-# Enter running container for debugging
-docker exec -it <container_id> bash
-
-# Check hapi runner status
-docker exec <container_id> hapi runner status
-
-# Run hapi diagnostics
-docker exec <container_id> hapi doctor
+docker logs <container_id>                       # container logs
+docker exec -it <container_id> bash              # shell inside container
+docker exec <container_id> hapi runner status    # runner status
+docker exec <container_id> hapi doctor           # hapi diagnostics
 ```

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -421,7 +421,10 @@ def main():
             terminal_ids = list(ttyd_manager.terminals.keys())
         for terminal_id in terminal_ids:
             ttyd_manager.delete_terminal(terminal_id)
-        httpd.shutdown()
+        # Never call httpd.shutdown() here: the handler runs in the main
+        # thread, which is inside serve_forever(); shutdown() waits for
+        # serve_forever() to exit and deadlocks. SystemExit unwinds
+        # serve_forever() and the finally clause closes the server.
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, signal_handler)

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -23,6 +23,9 @@ HOP_BY_HOP_HEADERS = {
     "content-length", "authorization",
 }
 
+TUNNEL_RECV_SIZE = 8192
+TUNNEL_MAX_PENDING = 1048576  # 1 MiB per direction before backpressure kicks in
+
 
 def is_websocket_request(handler):
     """Check if the current request is a WebSocket upgrade request."""
@@ -75,30 +78,71 @@ def inject_tab_fix_script(data, is_gzipped=False):
 
 
 def tunnel_sockets(handler, upstream):
-    """Bidirectional socket tunneling."""
+    """Bidirectional socket tunneling with write buffering and backpressure.
+
+    Non-blocking sockets require partial-send accounting: sendall() would
+    raise BlockingIOError on a full kernel buffer after possibly sending
+    only part of the data, silently dropping bytes and killing the tunnel.
+    """
     client = handler.connection
     client.setblocking(False)
     upstream.setblocking(False)
-    sockets = [client, upstream]
+    peer = {client: upstream, upstream: client}
+    pending = {client: bytearray(), upstream: bytearray()}
+    eof = {client: False, upstream: False}
     try:
         while True:
-            readable, _, _ = select.select(sockets, [], [], 60)
-            if not readable:
+            for sock in (client, upstream):
+                if eof[sock] and not pending[peer[sock]]:
+                    return
+
+            # Stop reading a side whose peer's outbound buffer is full;
+            # may overshoot the cap by at most one recv chunk.
+            read_set = [
+                sock for sock in (client, upstream)
+                if not eof[sock] and len(pending[peer[sock]]) < TUNNEL_MAX_PENDING
+            ]
+            write_set = [sock for sock in (client, upstream) if pending[sock]]
+            if not read_set and not write_set:
+                return
+
+            readable, writable, _ = select.select(read_set, write_set, [], 60)
+            if not readable and not writable:
                 continue
+
+            for sock in writable:
+                buf = pending[sock]
+                try:
+                    sent = sock.send(buf)
+                except (BlockingIOError, InterruptedError):
+                    continue
+                except (OSError, ConnectionError):
+                    return
+                if sent:
+                    del buf[:sent]
+
             for sock in readable:
                 try:
-                    data = sock.recv(8192)
-                except BlockingIOError:
+                    data = sock.recv(TUNNEL_RECV_SIZE)
+                except (BlockingIOError, InterruptedError):
                     continue
                 except (OSError, ConnectionError):
                     return
                 if not data:
-                    return
-                target = upstream if sock is client else client
-                try:
-                    target.sendall(data)
-                except (OSError, ConnectionError):
-                    return
+                    eof[sock] = True
+                    continue
+                target = peer[sock]
+                buf = pending[target]
+                if not buf:
+                    try:
+                        sent = target.send(data)
+                    except (BlockingIOError, InterruptedError):
+                        sent = 0
+                    except (OSError, ConnectionError):
+                        return
+                    data = data[sent:]
+                if data:
+                    buf.extend(data)
     except Exception:
         return
 

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -93,16 +93,23 @@ def tunnel_sockets(handler, upstream):
     eof = {client: False, upstream: False}
     try:
         while True:
-            for sock in (client, upstream):
-                if eof[sock] and not pending[peer[sock]]:
-                    return
+            # Once either side EOFs, the tunnel is logically done: stop
+            # ingesting new data, drain BOTH pending buffers, then close.
+            # Returning before pending[client] is flushed would drop ttyd
+            # output that the (possibly half-closed) client can still read.
+            draining = eof[client] or eof[upstream]
+            if draining and not pending[client] and not pending[upstream]:
+                return
 
-            # Stop reading a side whose peer's outbound buffer is full;
-            # may overshoot the cap by at most one recv chunk.
-            read_set = [
-                sock for sock in (client, upstream)
-                if not eof[sock] and len(pending[peer[sock]]) < TUNNEL_MAX_PENDING
-            ]
+            if draining:
+                read_set = []
+            else:
+                # Stop reading a side whose peer's outbound buffer is full;
+                # may overshoot the cap by at most one recv chunk.
+                read_set = [
+                    sock for sock in (client, upstream)
+                    if len(pending[peer[sock]]) < TUNNEL_MAX_PENDING
+                ]
             write_set = [sock for sock in (client, upstream) if pending[sock]]
             if not read_set and not write_set:
                 return

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -25,6 +25,7 @@ HOP_BY_HOP_HEADERS = {
 
 TUNNEL_RECV_SIZE = 8192
 TUNNEL_MAX_PENDING = 1048576  # 1 MiB per direction before backpressure kicks in
+TUNNEL_SELECT_TIMEOUT = 60
 
 
 def is_websocket_request(handler):
@@ -114,8 +115,16 @@ def tunnel_sockets(handler, upstream):
             if not read_set and not write_set:
                 return
 
-            readable, writable, _ = select.select(read_set, write_set, [], 60)
+            readable, writable, _ = select.select(
+                read_set, write_set, [], TUNNEL_SELECT_TIMEOUT
+            )
             if not readable and not writable:
+                if write_set:
+                    # A peer with pending data was unwritable for the whole
+                    # timeout: it vanished without a FIN (crashed client,
+                    # network partition). Bail out instead of spinning until
+                    # the OS TCP keepalive notices, hours later.
+                    return
                 continue
 
             for sock in writable:

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -169,10 +169,14 @@ def verify_pam_password(username, password):
 
     if shadow_info and crypt_module:
         password_hash = shadow_info.sp_pwdp
-        if password_hash in ("*", "!"):
+        # Empty or "!"/"*"-prefixed hashes mean a locked/disabled account
+        # (covers "!", "!!", "!<hash>" from passwd -l, "*", "*LK*", "*NP*").
+        if not password_hash or password_hash.startswith(("!", "*")):
             return False
         crypted = crypt_module.crypt(password, password_hash)
-        return crypted == password_hash
+        if crypted is None:
+            return False
+        return hmac.compare_digest(crypted, password_hash)
 
     try:
         result = subprocess.run(

--- a/bin/tmux-wrapper.sh
+++ b/bin/tmux-wrapper.sh
@@ -9,8 +9,6 @@ export LC_CTYPE=en_US.UTF-8
 
 SESSION_NAME="${1:-ttyd-$(whoami)}"
 
-if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-    exec tmux attach-session -t "$SESSION_NAME"
-else
-    exec tmux new-session -s "$SESSION_NAME" -c "$HOME"
-fi
+# -A attaches when the session already exists; the tmux server serializes
+# session creation, so simultaneous clients cannot race each other.
+exec tmux new-session -A -s "$SESSION_NAME" -c "$HOME"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,13 +80,20 @@ cleanup_runner_state
 # Update Hermes Agent to latest version
 if [ "${HERMES_AUTO_UPDATE:-true}" != "false" ] && command -v hermes &>/dev/null; then
   echo "Updating Hermes Agent..."
-  HERMES_UPDATE_DIR=$(mktemp -d) && \
-  git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$HERMES_UPDATE_DIR" && \
-  cd "$HERMES_UPDATE_DIR" && \
-  pip install --break-system-packages '.[all,messaging]' && \
-  cd / && \
-  rm -rf "$HERMES_UPDATE_DIR" && \
-  echo "Hermes Agent updated" || echo "Hermes Agent update failed, using installed version"
+  HERMES_UPDATE_DIR=""
+  # The subshell keeps the parent cwd intact when any step fails.
+  if HERMES_UPDATE_DIR=$(mktemp -d) && (
+       git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$HERMES_UPDATE_DIR" &&
+       cd "$HERMES_UPDATE_DIR" &&
+       pip install --break-system-packages '.[all,messaging]'
+     ); then
+    echo "Hermes Agent updated"
+  else
+    echo "Hermes Agent update failed, using installed version"
+  fi
+  if [ -n "${HERMES_UPDATE_DIR}" ]; then
+    rm -rf "${HERMES_UPDATE_DIR}"
+  fi
 fi
 
 # Start TTYD HTTP proxy (manages TTYD processes dynamically)

--- a/tests/integration/test_graceful_shutdown.py
+++ b/tests/integration/test_graceful_shutdown.py
@@ -1,0 +1,68 @@
+"""Graceful shutdown: SIGTERM must terminate the proxy, not deadlock.
+
+The old handler called httpd.shutdown() from the signal handler, which runs
+in the same main thread as serve_forever() — shutdown() then waits forever
+for serve_forever() to exit, leaving a zombie process that no longer serves
+requests.
+"""
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import unittest
+
+
+APP_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "app",
+)
+
+
+class GracefulShutdownTest(unittest.TestCase):
+    def test_sigterm_exits_promptly(self):
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+
+        env = dict(os.environ, PORT=str(port))
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "from ttydproxy.app import main; main()"],
+            cwd=APP_DIR,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            deadline = time.time() + 10
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    self.fail(
+                        f"server died on startup: {proc.stdout.read()[:500]!r}"
+                    )
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=1):
+                        break
+                except OSError:
+                    time.sleep(0.1)
+            else:
+                self.fail("server never started listening")
+
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.fail(
+                    "proxy did not exit within 5s after SIGTERM "
+                    "(shutdown deadlock)"
+                )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            proc.stdout.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_graceful_shutdown.py
+++ b/tests/integration/test_graceful_shutdown.py
@@ -27,8 +27,16 @@ class GracefulShutdownTest(unittest.TestCase):
             port = probe.getsockname()[1]
 
         env = dict(os.environ, PORT=str(port))
+        # Skip real ttyd spawning: on hosts with runuser but no ttyd binary,
+        # create_terminal(wait=True) burns 15s in _wait_for_ready before the
+        # HTTP server binds, overrunning this test's listen deadline.
+        child_code = (
+            "from ttydproxy import app\n"
+            "app.ttyd_manager.create_terminal = lambda wait=False: None\n"
+            "app.main()\n"
+        )
         proc = subprocess.Popen(
-            [sys.executable, "-c", "from ttydproxy.app import main; main()"],
+            [sys.executable, "-c", child_code],
             cwd=APP_DIR,
             env=env,
             stdout=subprocess.PIPE,

--- a/tests/unit/test_tunnel_sockets.py
+++ b/tests/unit/test_tunnel_sockets.py
@@ -1,0 +1,174 @@
+"""Tests for bidirectional socket tunneling in the ttyd proxy."""
+import socket
+import threading
+import time
+import unittest
+
+from ttydproxy import proxy
+
+
+class FakeHandler:
+    def __init__(self, conn):
+        self.connection = conn
+
+
+def _recv_exactly(sock, expected_length, chunk_size=4096, delay=0):
+    """Read until EOF or expected_length bytes, optionally pacing reads."""
+    received = bytearray()
+    while len(received) < expected_length:
+        chunk = sock.recv(chunk_size)
+        if not chunk:
+            break
+        received.extend(chunk)
+        if delay:
+            time.sleep(delay)
+    return bytes(received)
+
+
+class TunnelSocketsTest(unittest.TestCase):
+    def setUp(self):
+        self.client_inner, self.client_outer = socket.socketpair()
+        self.upstream_inner, self.upstream_outer = socket.socketpair()
+        self.client_outer.settimeout(10)
+        self.upstream_outer.settimeout(10)
+        self.thread = None
+
+    def tearDown(self):
+        for sock in (
+            self.client_inner,
+            self.client_outer,
+            self.upstream_inner,
+            self.upstream_outer,
+        ):
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    def start_tunnel(self):
+        def run():
+            proxy.tunnel_sockets(FakeHandler(self.client_inner), self.upstream_inner)
+            # Close inner ends so the outer ends observe EOF after the
+            # tunnel returns, mirroring proxy_ttyd_websocket cleanup.
+            for sock in (self.client_inner, self.upstream_inner):
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+        self.thread = threading.Thread(target=run, daemon=True)
+        self.thread.start()
+
+    def join_tunnel(self):
+        self.thread.join(timeout=10)
+        self.assertFalse(self.thread.is_alive(), "tunnel thread did not finish")
+
+    def test_bidirectional_small_payloads(self):
+        self.start_tunnel()
+        self.client_outer.sendall(b"input from browser")
+        self.upstream_outer.sendall(b"output from ttyd")
+
+        self.assertEqual(
+            _recv_exactly(self.upstream_outer, len(b"input from browser")),
+            b"input from browser",
+        )
+        self.assertEqual(
+            _recv_exactly(self.client_outer, len(b"output from ttyd")),
+            b"output from ttyd",
+        )
+
+        self.client_outer.close()
+        self.join_tunnel()
+
+    def test_large_burst_to_slow_reader_no_data_loss(self):
+        # Regression test: with non-blocking sendall() the tunnel dropped
+        # bytes and disconnected once the kernel send buffer filled up.
+        self.client_inner.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.client_outer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+        self.start_tunnel()
+
+        payload = bytes(range(256)) * 2048  # 512 KiB of patterned data
+
+        def write_payload():
+            self.upstream_outer.sendall(payload)
+            self.upstream_outer.shutdown(socket.SHUT_WR)
+
+        writer = threading.Thread(target=write_payload, daemon=True)
+        writer.start()
+
+        received = _recv_exactly(
+            self.client_outer, len(payload), chunk_size=2048, delay=0.0005
+        )
+        writer.join(timeout=10)
+        self.assertFalse(writer.is_alive(), "writer thread did not finish")
+        self.assertEqual(len(received), len(payload))
+        self.assertEqual(received, payload)
+
+    def test_eof_drains_pending_buffer(self):
+        self.client_inner.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.client_outer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+        self.start_tunnel()
+
+        payload = b"x" * 65536
+        self.upstream_outer.sendall(payload)
+        self.upstream_outer.shutdown(socket.SHUT_WR)
+
+        # Read past the payload: the next recv must return EOF only after
+        # every buffered byte has been delivered.
+        received = _recv_exactly(
+            self.client_outer, len(payload) + 1, chunk_size=2048, delay=0.0005
+        )
+        self.assertEqual(received, payload)
+        self.join_tunnel()
+
+    def test_returns_when_client_closes(self):
+        self.start_tunnel()
+        self.client_outer.close()
+        self.join_tunnel()
+
+    def test_backpressure_caps_buffering(self):
+        original_cap = proxy.TUNNEL_MAX_PENDING
+        proxy.TUNNEL_MAX_PENDING = 16384
+        self.addCleanup(setattr, proxy, "TUNNEL_MAX_PENDING", original_cap)
+
+        self.client_inner.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.client_outer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+        self.upstream_outer.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.start_tunnel()
+
+        # Client never reads: the tunnel must stop accepting upstream data
+        # once its pending buffer hits the cap, instead of buffering forever.
+        self.upstream_outer.setblocking(False)
+        chunk = b"y" * 4096
+        accepted = 0
+        stalled_since = None
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                accepted += self.upstream_outer.send(chunk)
+                stalled_since = None
+            except (BlockingIOError, InterruptedError):
+                if stalled_since is None:
+                    stalled_since = time.time()
+                elif time.time() - stalled_since > 0.5:
+                    break
+                time.sleep(0.01)
+        else:
+            self.fail("upstream writes never stalled — no backpressure")
+
+        # Cap + recv overshoot + kernel socket buffers, with generous slack.
+        self.assertLess(accepted, 524288)
+        self.assertTrue(self.thread.is_alive(), "tunnel died under backpressure")
+
+        # Drain everything: no byte may be lost.
+        self.upstream_outer.setblocking(True)
+        self.upstream_outer.settimeout(10)
+        self.upstream_outer.shutdown(socket.SHUT_WR)
+        received = _recv_exactly(self.client_outer, accepted, chunk_size=4096)
+        self.assertEqual(len(received), accepted)
+        self.assertEqual(received, b"y" * accepted)
+        self.join_tunnel()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tunnel_sockets.py
+++ b/tests/unit/test_tunnel_sockets.py
@@ -126,6 +126,26 @@ class TunnelSocketsTest(unittest.TestCase):
         self.client_outer.close()
         self.join_tunnel()
 
+    def test_client_half_close_still_drains_pending_data(self):
+        # Regression test: an early-exit on client EOF used to discard
+        # ttyd output still buffered for the (half-closed) client.
+        self.client_inner.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.client_outer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+        self.start_tunnel()
+
+        payload = b"z" * 65536
+        self.upstream_outer.sendall(payload)
+        # Let the tunnel ingest the burst into its pending buffer before
+        # the client half-closes its write side.
+        time.sleep(0.3)
+        self.client_outer.shutdown(socket.SHUT_WR)
+
+        received = _recv_exactly(
+            self.client_outer, len(payload) + 1, chunk_size=2048, delay=0.0005
+        )
+        self.assertEqual(received, payload)
+        self.join_tunnel()
+
     def test_backpressure_caps_buffering(self):
         original_cap = proxy.TUNNEL_MAX_PENDING
         proxy.TUNNEL_MAX_PENDING = 16384

--- a/tests/unit/test_tunnel_sockets.py
+++ b/tests/unit/test_tunnel_sockets.py
@@ -146,6 +146,26 @@ class TunnelSocketsTest(unittest.TestCase):
         self.assertEqual(received, payload)
         self.join_tunnel()
 
+    def test_stalled_peer_does_not_leak_tunnel_thread(self):
+        # Regression test: a client that vanishes without a FIN (crash,
+        # network partition) used to pin the tunnel thread forever — every
+        # select() timed out and the drain loop just continued.
+        original_timeout = proxy.TUNNEL_SELECT_TIMEOUT
+        proxy.TUNNEL_SELECT_TIMEOUT = 0.2
+        self.addCleanup(setattr, proxy, "TUNNEL_SELECT_TIMEOUT", original_timeout)
+
+        self.client_inner.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+        self.client_outer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+        self.start_tunnel()
+
+        # Fill the client's kernel buffer and the tunnel's pending buffer,
+        # then EOF upstream to enter drain mode. The client never reads, so
+        # its socket never becomes writable again.
+        self.upstream_outer.sendall(b"w" * 65536)
+        self.upstream_outer.shutdown(socket.SHUT_WR)
+
+        self.join_tunnel()
+
     def test_backpressure_caps_buffering(self):
         original_cap = proxy.TUNNEL_MAX_PENDING
         proxy.TUNNEL_MAX_PENDING = 16384

--- a/tests/unit/test_verify_pam_password.py
+++ b/tests/unit/test_verify_pam_password.py
@@ -1,0 +1,73 @@
+"""Tests for verify_pam_password shadow-hash handling."""
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from ttydproxy import security
+
+
+VALID_HASH = "$6$saltsalt$hashedpasswordvalue"
+
+
+def _fake_modules(password_hash, crypt_func):
+    """Build fake spwd/crypt modules for sys.modules injection.
+
+    password_hash=None simulates a missing shadow entry (getspnam raises
+    KeyError), which sends verify_pam_password down the su fallback path.
+    """
+    def getspnam(username):
+        if password_hash is None:
+            raise KeyError(username)
+        return SimpleNamespace(sp_pwdp=password_hash)
+
+    return {
+        "spwd": SimpleNamespace(getspnam=getspnam),
+        "crypt": SimpleNamespace(crypt=crypt_func),
+    }
+
+
+class VerifyPamPasswordTest(unittest.TestCase):
+    def _verify(self, password_hash, crypt_func, password="secret"):
+        modules = _fake_modules(password_hash, crypt_func)
+        with mock.patch.dict(sys.modules, modules):
+            with mock.patch.object(security, "user_exists", return_value=True):
+                return security.verify_pam_password("hapi", password)
+
+    def test_locked_and_empty_hashes_rejected_without_crypt(self):
+        crypt_mock = mock.Mock()
+        for password_hash in ("", "!", "!!", "!$6$abc$def", "*", "*LK*", "*NP*"):
+            with self.subTest(password_hash=password_hash):
+                self.assertFalse(self._verify(password_hash, crypt_mock))
+        crypt_mock.assert_not_called()
+
+    def test_correct_password_accepted(self):
+        self.assertTrue(
+            self._verify(VALID_HASH, lambda password, salt: VALID_HASH)
+        )
+
+    def test_wrong_password_rejected(self):
+        self.assertFalse(
+            self._verify(VALID_HASH, lambda password, salt: "$6$saltsalt$other")
+        )
+
+    def test_crypt_returning_none_rejected(self):
+        self.assertFalse(self._verify(VALID_HASH, lambda password, salt: None))
+
+    def test_missing_shadow_entry_falls_back_to_su(self):
+        su_result = SimpleNamespace(returncode=0)
+        with mock.patch.dict(sys.modules, _fake_modules(None, mock.Mock())):
+            with mock.patch.object(security, "user_exists", return_value=True):
+                with mock.patch.object(
+                    security.subprocess, "run", return_value=su_result
+                ) as run_mock:
+                    self.assertTrue(security.verify_pam_password("hapi", "secret"))
+        run_mock.assert_called_once()
+
+    def test_unknown_user_rejected(self):
+        with mock.patch.object(security, "user_exists", return_value=False):
+            self.assertFalse(security.verify_pam_password("ghost", "secret"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes 5 bugs found during a full audit, each verified with regression tests (and the two main ones e2e in Docker with an A/B against the old code):

1. **WebSocket data loss / disconnects** (`app/ttydproxy/proxy.py`): `tunnel_sockets()` set both sockets non-blocking but wrote via `sendall()`, which raises `BlockingIOError` after a possible partial send when the kernel buffer fills — silently dropping bytes and killing the tunnel on large output bursts or slow clients. Rewritten as a buffered select loop with per-direction pending buffers, partial-send accounting, a 1 MiB backpressure cap, and drain-before-close on EOF. A/B in Docker: old code dropped the connection after a 2s client stall; new code survives and stays interactive.
2. **SIGTERM deadlock** (`app/ttydproxy/app.py`): the signal handler called `httpd.shutdown()` from the main thread, which is inside `serve_forever()` — the process hung forever (terminals killed, port dead, process alive). Now exits via `SystemExit`; the `finally` clause closes the server.
3. **Locked accounts could authenticate** (`app/ttydproxy/security.py`): `verify_pam_password` only rejected hashes exactly `*` or `!`, missing `!<hash>` (`passwd -l`), `!!`, `*LK*`, and empty hashes. Also guards `crypt()` returning `None` and uses `hmac.compare_digest`.
4. **tmux session race** (`bin/tmux-wrapper.sh`): TOCTOU between `has-session` and `new-session` made the second simultaneous client fail with "session already exists". Replaced with atomic `tmux new-session -A`.
5. **Hermes update block** (`entrypoint.sh`): a failed `pip install` left the script cwd inside the temp clone dir and leaked it. The clone+install now runs in a subshell with unconditional cleanup.

Also rewrites `CLAUDE.md` to match the post-refactor architecture (`ttydproxy` package, multi-terminal `/terminals` API, cleanup dashboard, route table) — the old version still described the pre-refactor monolith.

## Environment variables

No new or changed variables. No port or volume mapping changes.

## Test plan

- [x] `python -m pytest tests/` — 113 passed + 80 subtests (12 new tests in 3 files)
- [x] New regression tests proven to fail on the old code (tunnel: 3 failures; shutdown: hang) and pass on the fix
- [x] Docker e2e: real WS client login → tunnel survives 2s read stall under continuous output, stays interactive; `kill -TERM` → proxy exits cleanly
- [x] `bash -n` on both shell scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)