### PR TITLE
Fix all 8 bugs from bug-hunt audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ PORT=8080                   # Порт HTTP прокси
 TTYD_USER=hapi              # Пользователь для терминала
 TTYD_PASSWORD=your_secure_password_here  # Пароль для доступа к веб-терминалу (обязательно)
 PASSWORD_SECRET=your_random_secret_here  # Секрет для HMAC подписей сессий (обязательно)
+# PASSWORD_SECRET_FILE=/run/secrets/password_secret  # Альтернатива: путь к файлу с секретом (имеет приоритет над PASSWORD_SECRET)
 VIRTUAL_KEYBOARD=true       # Виртуальная клавиатура для мобильных (true/false)
 CSRF_TOKEN_TTL=604800       # Срок жизни CSRF токена в секундах (по умолчанию 604800 = 7 дней)
 SECURE_COOKIES=false        # Добавлять флаг Secure к cookies (true/false)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 - `TTYD_USER` — terminal user (default: hapi)
 - `TTYD_PASSWORD` — optional global password (if not set, system passwords via PAM/shadow)
 - `PASSWORD_SECRET` — secret for HMAC signatures (entrypoint generates a random one if unset; set explicitly to persist sessions across restarts)
+- `PASSWORD_SECRET_FILE` — path to a file containing the secret (Docker secrets convention, takes precedence over `PASSWORD_SECRET`; entrypoint hands the secret to the proxy via root-only `/run/ttyd-proxy.secret` so it never appears in the proxy's environment)
 - `ROOT_PASSWORD` — optional root SSH password
 - `VIRTUAL_KEYBOARD` — mobile virtual keyboard (default: true)
 - `SESSION_TIMEOUT` — session token lifetime, seconds (default: 604800 = 1 week)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN NODE_VERSION="22.14.0" && \
       exit 1; \
     fi && \
     apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl gh git openssh-server python3-pip python3-venv tmux util-linux xz-utils && \
+    apt-get install -y --no-install-recommends ca-certificates curl gh git openssh-server python3-pip python3-venv tini tmux util-linux xz-utils && \
     curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
     tar -xJf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -C /usr/local --strip-components=1 --no-same-owner && \
     rm "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
@@ -102,5 +102,6 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
 
-ENTRYPOINT ["/entrypoint.sh"]
+# tini as PID 1 reaps zombies (orphaned subshells) and forwards signals
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/app/assets/tab_fix_script.html
+++ b/app/assets/tab_fix_script.html
@@ -21,8 +21,10 @@
 
   function waitForTerm(cb) {
     if (window.term) { cb(window.term); return; }
+    var attempts = 0;
     var i = setInterval(function() {
       if (window.term) { clearInterval(i); cb(window.term); }
+      else if (++attempts > 600) { clearInterval(i); console.warn('ttyd term not found after 30s, giving up'); }
     }, 50);
   }
 

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -2,20 +2,20 @@
 import os
 import re
 
-from ttydproxy.security import env_bool
+from ttydproxy.security import env_bool, env_int, env_secret
 
 
-PORT = int(os.environ.get("PORT", "8080"))
+PORT = env_int(os.environ.get("PORT"), 8080, name="PORT")
 TTYD_USER = os.environ.get("TTYD_USER", "hapi")
 TTYD_PASSWORD = os.environ.get("TTYD_PASSWORD", "")
-PASSWORD_SECRET = os.environ.get("PASSWORD_SECRET", "default-secret-change-me")
+PASSWORD_SECRET = env_secret("PASSWORD_SECRET", "default-secret-change-me")
 TTYD_BASE_PORT = 7681
 CLEANUP_ROOT = os.environ.get("CLEANUP_ROOT", "/home/hapi")
 HAPI_HOME = os.environ.get("HAPI_HOME", f"{CLEANUP_ROOT}/.hapi")
-MAX_TERMINALS = int(os.environ.get("MAX_TERMINALS", "100"))
-SESSION_TIMEOUT = int(os.environ.get("SESSION_TIMEOUT", "604800"))
+MAX_TERMINALS = env_int(os.environ.get("MAX_TERMINALS"), 100, name="MAX_TERMINALS")
+SESSION_TIMEOUT = env_int(os.environ.get("SESSION_TIMEOUT"), 604800, name="SESSION_TIMEOUT")
 VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
-CSRF_TOKEN_TTL = int(os.environ.get("CSRF_TOKEN_TTL", "604800"))
+CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL")
 SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
 

--- a/app/ttydproxy/manager.py
+++ b/app/ttydproxy/manager.py
@@ -111,6 +111,9 @@ class TTYDManager:
             port = self._allocate_port()
             if port is None:
                 return "limit"
+            # Consume the ID before starting the process: a failed start must
+            # not let the next terminal reuse the same ID.
+            self.next_id += 1
             try:
                 process = self._start_ttyd_process(terminal_id, port)
             except OSError as exc:
@@ -119,7 +122,6 @@ class TTYDManager:
 
             info = {"id": terminal_id, "port": port, "pid": process.pid, "process": process}
             self.terminals[terminal_id] = info
-            self.next_id += 1
 
         if wait and not self._wait_for_ready(port):
             self.delete_terminal(terminal_id)

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -2,8 +2,10 @@
 import base64
 import hashlib
 import hmac
+import os
 import secrets
 import subprocess
+import sys
 import time
 import re
 import pwd
@@ -22,6 +24,40 @@ def env_bool(value, default=False):
     if value in ("0", "false", "no", "off"):
         return False
     return default
+
+
+def env_int(value, default, name=None):
+    """Parse an integer env var value, falling back to default on garbage."""
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        return int(str(value).strip())
+    except ValueError:
+        label = name or "env var"
+        print(
+            f"Invalid integer for {label}: {value!r}, using default {default}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return default
+
+
+def env_secret(name, default):
+    """Resolve a secret env var, honoring the Docker *_FILE convention."""
+    path = os.environ.get(f"{name}_FILE")
+    if path:
+        try:
+            with open(path) as secret_file:
+                value = secret_file.read().strip()
+            if value:
+                return value
+        except OSError as exc:
+            print(
+                f"Cannot read {name}_FILE={path}: {exc}, falling back",
+                file=sys.stderr,
+                flush=True,
+            )
+    return os.environ.get(name) or default
 
 
 def parse_cookie_header(cookie_header):

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-PACKAGE_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cli-packages.txt"
+# docker build uses "." as context — always run from the repo root
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+PACKAGE_FILE="cli-packages.txt"
 
 # Получаем версию пакета с retry (соответствует паттерну из CLAUDE.md)
 get_version() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,10 @@ ssh-keygen -A >/dev/null 2>&1 || true
 
 # Configure root SSH access if ROOT_PASSWORD is set
 if [ -n "${ROOT_PASSWORD}" ]; then
-  echo "root:${ROOT_PASSWORD}" | chpasswd
+  # Heredoc keeps the password out of every process cmdline (/proc/<pid>/cmdline)
+  chpasswd <<EOF
+root:${ROOT_PASSWORD}
+EOF
   sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
   sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
   echo "Root SSH access enabled"
@@ -96,12 +99,17 @@ if [ "${HERMES_AUTO_UPDATE:-true}" != "false" ] && command -v hermes &>/dev/null
   fi
 fi
 
-# Start TTYD HTTP proxy (manages TTYD processes dynamically)
+# Start TTYD HTTP proxy (manages TTYD processes dynamically).
+# The secret goes through a root-only file (Docker *_FILE convention) so it
+# never appears in the proxy's /proc/<pid>/environ.
+PROXY_SECRET_FILE="/run/ttyd-proxy.secret"
+install -m 600 /dev/null "${PROXY_SECRET_FILE}"
+printf '%s' "${PASSWORD_SECRET}" > "${PROXY_SECRET_FILE}"
 echo "Starting TTYD HTTP proxy on port ${PORT}"
 PORT="${PORT}" \
 TTYD_USER="${TTYD_USER}" \
 TTYD_PASSWORD="${TTYD_PASSWORD}" \
-PASSWORD_SECRET="${PASSWORD_SECRET}" \
+PASSWORD_SECRET_FILE="${PROXY_SECRET_FILE}" \
 CLEANUP_ROOT="${CLEANUP_ROOT}" \
 HAPI_HOME="${HAPI_HOME}" \
 python3 /app/ttyd_proxy.py &
@@ -109,6 +117,9 @@ python3 /app/ttyd_proxy.py &
 # Start hapi server with relay in background (logs to file, force TCP relay)
 HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
 ensure_dir_owned "${HAPI_HOME}"
+# Pre-create the log so the URL-extraction loop's -f check passes immediately
+touch "${HAPI_SERVER_LOG}"
+chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"
 echo "Starting hapi server --relay in background (logs: ${HAPI_SERVER_LOG})..."
 run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay 2>&1 | tee \"${HAPI_SERVER_LOG}\"" &
 HAPI_SERVER_PID=$!

--- a/tests/unit/test_env_int.py
+++ b/tests/unit/test_env_int.py
@@ -1,0 +1,49 @@
+"""Tests for env_int() from production code."""
+import io
+import unittest
+from contextlib import redirect_stderr
+
+from ttydproxy.security import env_int
+
+
+class TestEnvIntValid(unittest.TestCase):
+    def test_valid_values(self):
+        self.assertEqual(env_int("8080", 1), 8080)
+        self.assertEqual(env_int("0", 1), 0)
+        self.assertEqual(env_int("-5", 1), -5)
+        self.assertEqual(env_int(42, 1), 42)
+
+    def test_whitespace_is_trimmed(self):
+        self.assertEqual(env_int("  100  ", 1), 100)
+
+
+class TestEnvIntDefault(unittest.TestCase):
+    def test_none_returns_default(self):
+        self.assertEqual(env_int(None, 8080), 8080)
+
+    def test_empty_returns_default(self):
+        self.assertEqual(env_int("", 8080), 8080)
+
+    def test_invalid_returns_default(self):
+        for value in ("abc", "12.5", "1e3", "0x10", "--1"):
+            with self.subTest(value=value):
+                self.assertEqual(env_int(value, 7), 7)
+
+    def test_invalid_warns_to_stderr(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            env_int("abc", 7, name="MAX_TERMINALS")
+        message = buf.getvalue()
+        self.assertIn("MAX_TERMINALS", message)
+        self.assertIn("abc", message)
+        self.assertIn("7", message)
+
+    def test_none_does_not_warn(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            env_int(None, 7, name="PORT")
+        self.assertEqual(buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_env_secret.py
+++ b/tests/unit/test_env_secret.py
@@ -1,0 +1,57 @@
+"""Tests for env_secret() — secret lookup with the Docker *_FILE convention."""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ttydproxy.security import env_secret
+
+
+class TestEnvSecret(unittest.TestCase):
+    def test_reads_secret_from_file(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".secret", delete=False) as f:
+            f.write("file-secret\n")
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"MY_SECRET_FILE": path}, clear=True):
+                self.assertEqual(env_secret("MY_SECRET", "default"), "file-secret")
+        finally:
+            os.unlink(path)
+
+    def test_file_takes_precedence_over_env(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".secret", delete=False) as f:
+            f.write("from-file")
+            path = f.name
+        try:
+            env = {"MY_SECRET_FILE": path, "MY_SECRET": "from-env"}
+            with patch.dict(os.environ, env, clear=True):
+                self.assertEqual(env_secret("MY_SECRET", "default"), "from-file")
+        finally:
+            os.unlink(path)
+
+    def test_falls_back_to_env_var(self):
+        with patch.dict(os.environ, {"MY_SECRET": "env-secret"}, clear=True):
+            self.assertEqual(env_secret("MY_SECRET", "default"), "env-secret")
+
+    def test_falls_back_to_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(env_secret("MY_SECRET", "default"), "default")
+
+    def test_unreadable_file_falls_back_to_env(self):
+        env = {"MY_SECRET_FILE": "/nonexistent/path", "MY_SECRET": "env-secret"}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(env_secret("MY_SECRET", "default"), "env-secret")
+
+    def test_empty_file_falls_back(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".secret", delete=False) as f:
+            f.write("\n")
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"MY_SECRET_FILE": path}, clear=True):
+                self.assertEqual(env_secret("MY_SECRET", "default"), "default")
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1,0 +1,62 @@
+"""Static checks for shell scripts (syntax + known-bug regressions)."""
+import pathlib
+import re
+import subprocess
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "entrypoint.sh"
+BUILD_SH = REPO_ROOT / "build.sh"
+
+
+class TestShellSyntax(unittest.TestCase):
+    def test_scripts_parse(self):
+        for script in (ENTRYPOINT, BUILD_SH):
+            with self.subTest(script=script.name):
+                result = subprocess.run(
+                    ["bash", "-n", str(script)], capture_output=True, text=True
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+
+class TestEntrypointRegressions(unittest.TestCase):
+    def setUp(self):
+        self.text = ENTRYPOINT.read_text()
+
+    def test_root_password_not_piped_through_echo(self):
+        # echo "root:$PW" | chpasswd exposes the password to process listing;
+        # the password must reach chpasswd via heredoc/stdin redirection.
+        self.assertNotRegex(self.text, r'echo\s+"root:.*\|\s*chpasswd')
+        self.assertIn("chpasswd", self.text)
+
+    def test_password_secret_passed_via_file(self):
+        # The proxy child process must receive PASSWORD_SECRET_FILE, not the
+        # secret value itself in its environment (/proc/<pid>/environ).
+        self.assertIn("PASSWORD_SECRET_FILE=", self.text)
+        self.assertNotRegex(
+            self.text, r'^PASSWORD_SECRET="\$\{PASSWORD_SECRET\}"', re.MULTILINE
+        )
+
+    def test_hapi_server_log_precreated(self):
+        # The log file must exist before the URL-extraction loop starts so the
+        # [ -f "$HAPI_SERVER_LOG" ] guard passes on the first iteration.
+        touch_pos = self.text.find('touch "${HAPI_SERVER_LOG}"')
+        server_start_pos = self.text.find("hapi server --relay 2>&1")
+        self.assertGreater(touch_pos, -1, "HAPI_SERVER_LOG is not pre-created")
+        self.assertLess(touch_pos, server_start_pos)
+
+
+class TestBuildShRegressions(unittest.TestCase):
+    def test_build_runs_from_script_dir(self):
+        # docker build uses "." as context, so the script must cd to its own
+        # directory first to work when invoked from elsewhere.
+        text = BUILD_SH.read_text()
+        cd_match = re.search(r'^cd "\$\(dirname "\$\{BASH_SOURCE\[0\]\}"\)"', text, re.MULTILINE)
+        build_match = re.search(r"^docker build", text, re.MULTILINE)
+        self.assertIsNotNone(cd_match, "build.sh does not cd to its own directory")
+        self.assertIsNotNone(build_match)
+        self.assertLess(cd_match.start(), build_match.start())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -34,7 +34,8 @@ class TestEntrypointRegressions(unittest.TestCase):
         # secret value itself in its environment (/proc/<pid>/environ).
         self.assertIn("PASSWORD_SECRET_FILE=", self.text)
         self.assertNotRegex(
-            self.text, r'^PASSWORD_SECRET="\$\{PASSWORD_SECRET\}"', re.MULTILINE
+            self.text,
+            re.compile(r'^PASSWORD_SECRET="\$\{PASSWORD_SECRET\}"', re.MULTILINE),
         )
 
     def test_hapi_server_log_precreated(self):

--- a/tests/unit/test_tab_fix_script.py
+++ b/tests/unit/test_tab_fix_script.py
@@ -41,5 +41,21 @@ class TestScrollFixOrder(unittest.TestCase):
         self.assertIn("</script>", self.script)
 
 
+class TestWaitForTermTimeout(unittest.TestCase):
+    """waitForTerm must stop polling if window.term never appears."""
+
+    def setUp(self):
+        start = TAB_FIX_SCRIPT.index("function waitForTerm")
+        end = TAB_FIX_SCRIPT.index("}", TAB_FIX_SCRIPT.index("}, 50);", start))
+        self.section = TAB_FIX_SCRIPT[start:end]
+
+    def test_has_attempt_counter(self):
+        self.assertIn("attempts", self.section)
+
+    def test_clears_interval_on_timeout(self):
+        # Two clearInterval calls: one on success, one when giving up.
+        self.assertEqual(self.section.count("clearInterval(i)"), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_ttyd_manager.py
+++ b/tests/unit/test_ttyd_manager.py
@@ -47,6 +47,17 @@ class TestCreateTerminal(unittest.TestCase):
         manager = TTYDManager(base_port=9000)
         self.assertIsNone(manager.create_terminal())
 
+    @patch("ttydproxy.manager.subprocess.Popen")
+    def test_failed_terminal_id_is_not_reused(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.pid = 100
+        mock_popen.side_effect = [OSError("No such file"), mock_proc]
+
+        manager = TTYDManager(base_port=9000)
+        self.assertIsNone(manager.create_terminal())
+        # The ID consumed by the failed attempt must never be handed out again.
+        self.assertEqual(manager.create_terminal()["id"], 2)
+
 
 class TestDeleteTerminal(unittest.TestCase):
     @patch("ttydproxy.manager.subprocess.run")


### PR DESCRIPTION
## Summary

Fixes all 8 confirmed bugs from the multi-agent bug-hunt audit, root-cause fixes only, TDD (failing tests written first).

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | 🔴 High | Container crash on invalid integer env vars | `env_int()` helper in `security.py`, applied to `PORT`/`MAX_TERMINALS`/`SESSION_TIMEOUT`/`CSRF_TOKEN_TTL` in `config.py` |
| 2 | 🔴 High | Terminal ID reuse after failed ttyd start | `next_id` consumed before process start in `manager.py` |
| 3 | 🟡 Medium | Eternal `setInterval` in `waitForTerm` | Attempt counter, gives up after 30s with `console.warn` |
| 4 | 🟡 Medium | `ROOT_PASSWORD` via `echo \| chpasswd` | Heredoc — password never appears in any process cmdline |
| 5 | 🟢 Low | `PASSWORD_SECRET` in proxy `/proc/<pid>/environ` | Docker `*_FILE` convention: `env_secret()` + root-only `/run/ttyd-proxy.secret` (0600) |
| 6 | 🟢 Low | Zombie subshell under PID 1 = sshd | `tini` as PID 1 in Dockerfile (reaps zombies, forwards signals) |
| 7 | 🟢 Low | Race: hapi server log missing on first loop iteration | Log pre-created with `touch` + `chown` before server start |
| 8 | 🟢 Low | `build.sh` fails when run from another directory | `cd` to script dir before `docker build` |

## Environment variables

- New: `PASSWORD_SECRET_FILE` — path to a file containing the HMAC secret (takes precedence over `PASSWORD_SECRET`). Documented in `.env.example` and CLAUDE.md.

## Ports / volumes

No changes.

## Tests

- New: `tests/unit/test_env_int.py`, `tests/unit/test_env_secret.py`, `tests/unit/test_shell_scripts.py` (bash -n + regression content checks)
- Extended: `test_ttyd_manager.py` (ID-reuse regression), `test_tab_fix_script.py` (waitForTerm timeout)
- Full suite: 136 passed
- Docker smoke: container with `MAX_TERMINALS=abc` starts with default + warning; PID 1 = tini; 0 zombies; proxy environ contains only `PASSWORD_SECRET_FILE`; full CSRF login flow works; `docker stop` is instant

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)