### PR TITLE
Replace ultrathink key with scroll toggle on virtual keyboard

### DIFF
--- a/app/assets/virtual_keyboard.html
+++ b/app/assets/virtual_keyboard.html
@@ -15,7 +15,7 @@
     <button data-key="bang" style="grid-area:bang">!</button>
     <button data-key="ctrl-l" style="grid-area:cl" class="key-mod">^L</button>
     <button data-key="up" style="grid-area:up">&#8593;</button>
-    <button data-key="u" style="grid-area:ut" class="key-ultra"><span>u</span></button>
+    <button data-key="scroll" style="grid-area:ut" class="key-scroll" title="Toggle scroll (tmux mouse mode)">&#8645;</button>
     <button data-key="enter" style="grid-area:enter" class="key-enter">&#8629;</button>
     <button data-key="ctrl-c" style="grid-area:cc" class="key-mod">^C</button>
     <button data-key="ctrl-v" style="grid-area:cv" class="key-mod">^V</button>
@@ -92,7 +92,8 @@
             case 'bang': data = '!'; break;
             case 'backspace': data = String.fromCharCode(127); break;
             case 'enter': data = '\r'; break;
-            case 'u': data = 'u'; break;
+            // tmux prefix (Ctrl+B) + m — toggles tmux mouse mode (scroll on/off)
+            case 'scroll': data = String.fromCharCode(2) + 'm'; break;
             case 'at': data = '@'; break;
           }
           if (data) {
@@ -106,6 +107,7 @@
     document.getElementById('vkbd').addEventListener('click', function(e) {
       if (e.target.tagName === 'BUTTON') {
         sendKey(e.target.dataset.key);
+        if (e.target.dataset.key === 'scroll') e.target.classList.toggle('on');
       }
     });
     iframe.addEventListener('load', function() {

--- a/app/assets/virtual_keyboard_style.css
+++ b/app/assets/virtual_keyboard_style.css
@@ -27,12 +27,10 @@
   background: linear-gradient(180deg, #1e4535, #16352a);
   font-size: 16px;
 }
-.vkbd button.key-ultra span {
-  background: linear-gradient(90deg, #ff4444, #ff8844, #ffcc44, #44cc44, #44cccc, #4488ff, #cc44ff);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  font-weight: bold; font-size: 15px;
+.vkbd button.key-scroll { font-size: 15px; }
+.vkbd button.key-scroll.on {
+  background: linear-gradient(180deg, #1e4535, #16352a);
+  color: #6fdc9c; border-color: rgba(111,220,156,0.4);
 }
 @media (max-width: 768px) {
   .vkbd { display: flex; }

--- a/tests/preview/vkbd_preview.html
+++ b/tests/preview/vkbd_preview.html
@@ -53,7 +53,7 @@
         <button data-key="bang" style="grid-area:bang">!</button>
         <button data-key="ctrl-l" style="grid-area:cl" class="key-mod">^L</button>
         <button data-key="up" style="grid-area:up">&#8593;</button>
-        <button data-key="u" style="grid-area:ut" class="key-ultra"><span>u</span></button>
+        <button data-key="scroll" style="grid-area:ut" class="key-scroll" title="Toggle scroll (tmux mouse mode)">&#8645;</button>
         <button data-key="enter" style="grid-area:enter" class="key-enter">&#8629;</button>
         <button data-key="ctrl-c" style="grid-area:cc" class="key-mod">^C</button>
         <button data-key="ctrl-v" style="grid-area:cv" class="key-mod">^V</button>


### PR DESCRIPTION
## Summary

The rainbow "u" key on the mobile virtual keyboard (used to type "ultrathink") is replaced with a scroll toggle button "⇅".

- The button sends `Ctrl+B m` — the existing tmux binding from `config/.tmux.conf` that toggles tmux mouse mode (touch/wheel scroll of the terminal buffer vs native browser text selection, see #40)
- tmux shows its own "Mouse: on/off" status message; additionally the button highlights green while scroll mode is on
- `tests/preview/vkbd_preview.html` markup kept in sync

## Environment variables / ports / volumes

No changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)