### PR TITLE
Add image upload via paste/drop and virtual keyboard toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,15 +6,17 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # HAPI_API_URL=             # Required if HAPI_RUNNER_ENABLED=true
 
 # TTYD Configuration
-PORT=8080                   # Порт HTTP прокси
-TTYD_USER=hapi              # Пользователь для терминала
-TTYD_PASSWORD=your_secure_password_here  # Пароль для доступа к веб-терминалу (обязательно)
+PORT=8080                   # Порт HTTP прокси (>= 1024 — прокси работает без root)
+TTYD_USER=hapi              # Пользователь для терминала (под ним же работает прокси)
+TTYD_PASSWORD=your_secure_password_here  # Пароль для доступа к веб-терминалу (без него системный пароль принимается только для TTYD_USER)
 PASSWORD_SECRET=your_random_secret_here  # Секрет для HMAC подписей сессий (обязательно)
 # PASSWORD_SECRET_FILE=/run/secrets/password_secret  # Альтернатива: путь к файлу с секретом (имеет приоритет над PASSWORD_SECRET)
 VIRTUAL_KEYBOARD=true       # Виртуальная клавиатура для мобильных (true/false)
 CSRF_TOKEN_TTL=604800       # Срок жизни CSRF токена в секундах (по умолчанию 604800 = 7 дней)
 SECURE_COOKIES=false        # Добавлять флаг Secure к cookies (true/false)
 MAX_TERMINALS=100           # Максимальное количество терминалов (по умолчанию 100)
+MAX_UPLOAD_SIZE=10485760    # Лимит размера загружаемого изображения в байтах (по умолчанию 10 МБ)
+# UPLOAD_DIR=/home/hapi/.uploads  # Каталог для вставленных в терминал изображений (по умолчанию CLEANUP_ROOT/.uploads)
 
 # Locale/Encoding Configuration (UTF-8 is required for proper international character support)
 LANG=en_US.UTF-8            # Primary locale (set in Dockerfile, override only if needed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Docker container running hapi CLI runner alongside OpenSSH server, bundling AI C
 
 **Multi-process layout:**
 - `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)
-- `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**
+- `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**; runs unprivileged as `TTYD_USER` (entrypoint drops root via `runuser`)
 - `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
 - `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
 - `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
@@ -66,7 +66,7 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start ttyd proxy (it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 
@@ -100,6 +100,7 @@ hapi Client → HTTP API (HAPI_PORT) → hapi runner
 | `/terminals/{id}` | DELETE | cookie + CSRF | Kill terminal |
 | `/cleanup` | GET | cookie | List disk cleanup targets |
 | `/cleanup/delete` | POST | cookie + CSRF | Delete cleanup targets |
+| `/upload` | POST | cookie + CSRF | Save a pasted/dropped image (raw body), returns `{"path"}` |
 | `/ttyd{N}` | GET | cookie (redirect) | Terminal iframe page |
 | `/ttyd{N}/*` | GET/WS | cookie | HTTP/WebSocket proxy to that ttyd |
 
@@ -115,11 +116,11 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 ### Environment Variables
 
 **TTYD web terminal:**
-- `PORT` — HTTP proxy port (default: 8080)
-- `TTYD_USER` — terminal user (default: hapi)
-- `TTYD_PASSWORD` — optional global password (if not set, system passwords via PAM/shadow)
+- `PORT` — HTTP proxy port (default: 8080; must be >= 1024 — the proxy runs without root)
+- `TTYD_USER` — terminal user (default: hapi); the proxy process itself also runs as this user
+- `TTYD_PASSWORD` — optional global password (if not set, system passwords — but only for `TTYD_USER`: the unprivileged proxy verifies passwords via `su`/unix_chkpwd, which can only check its own user's password)
 - `PASSWORD_SECRET` — secret for HMAC signatures (entrypoint generates a random one if unset; set explicitly to persist sessions across restarts)
-- `PASSWORD_SECRET_FILE` — path to a file containing the secret (Docker secrets convention, takes precedence over `PASSWORD_SECRET`; entrypoint hands the secret to the proxy via root-only `/run/ttyd-proxy.secret` so it never appears in the proxy's environment)
+- `PASSWORD_SECRET_FILE` — path to a file containing the secret (Docker secrets convention, takes precedence over `PASSWORD_SECRET`; entrypoint hands the secret to the proxy via `/run/ttyd-proxy.secret` — mode 400, owned by `TTYD_USER` — so it never appears in the proxy's environment; an unreadable or empty secret file aborts proxy startup instead of silently falling back)
 - `ROOT_PASSWORD` — optional root SSH password
 - `VIRTUAL_KEYBOARD` — mobile virtual keyboard (default: true)
 - `SESSION_TIMEOUT` — session token lifetime, seconds (default: 604800 = 1 week)
@@ -127,6 +128,8 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 - `SECURE_COOKIES` — Secure flag on cookies for HTTPS (default: false)
 - `MAX_TERMINALS` — max concurrent terminals (default: 100)
 - `CLEANUP_ROOT` — root for cleanup dashboard targets (default: /home/hapi)
+- `MAX_UPLOAD_SIZE` — image upload size limit, bytes (default: 10485760 = 10 MB)
+- `UPLOAD_DIR` — where pasted/dropped terminal images are saved (default: `CLEANUP_ROOT/.uploads`; the cleanup dashboard's `uploads` target always points at `CLEANUP_ROOT/.uploads`, so overriding `UPLOAD_DIR` elsewhere decouples it from cleanup)
 
 **Hapi runner (optional):**
 - `HAPI_RUNNER_ENABLED` — enable runner (default: false)
@@ -154,6 +157,7 @@ The proxy injects a script into ttyd's HTML (`inject_tab_fix_script` in `proxy.p
 - **WebSocket capture**: the script intercepts the `window.WebSocket` constructor; the socket reference must live in `window._ttydSocket` (global), not a local inside the IIFE.
 - **Tab key**: sends ttyd protocol prefix `'0'` (INPUT) + `\t` over the WebSocket. Completion only works in shells that support it (bash); `/bin/sh` (dash) does not.
 - **Mouse wheel**: normal screen — intercepts `wheel` with `capture: true, passive: false`, calls `term.scrollLines(n)`; alternate screen (vim/less/htop, `term.buffer.active.type === 'alternate'`) — passes through. deltaMode: `1` = lines, `2` = pages (`term.rows`), `0` = pixels (÷40).
+- **Paste/drop triage**: capture-phase `paste`/`drop` listeners triage the payload — images upload to `POST /upload` (CSRF token read from the non-HttpOnly `csrf_token` cookie; up to 5 in parallel, returned paths typed in order + space), text types into the prompt (`term.paste`, bracketed-paste-safe; on iframe paste text stays on xterm's default path), anything else (non-image files) is silently skipped. Server validates by magic bytes only (png/jpg/gif/webp; SVG rejected) — the client Content-Type is never trusted. `terminal_parent_tab_handler.html` forwards paste/drop from the parent page into the iframe via `contentWindow.__handleDataTransfer(dataTransfer)`. `handle_ttyd` refreshes the `csrf_token` cookie so long-lived terminal tabs keep uploading.
 
 **tmux mouse mode** (`config/.tmux.conf`, copied to `/home/hapi/.tmux.conf` in Dockerfile): mouse is **off by default** so xterm.js keeps native browser text selection and Cmd+C (#40). `Ctrl+B m` toggles tmux mouse mode when tmux scroll/copy is needed. A direct Ctrl+M binding is impossible — C-m and Enter are the same byte (0x0D).
 

--- a/app/assets/tab_fix_script.html
+++ b/app/assets/tab_fix_script.html
@@ -50,6 +50,140 @@
     return isAlt;
   }
 
+  function getCsrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
+    return match ? match[1] : '';
+  }
+
+  function extractImageFiles(source) {
+    var files = [];
+    var i;
+    if (source && source.items) {
+      for (i = 0; i < source.items.length; i++) {
+        var item = source.items[i];
+        if (item.kind === 'file' && item.type.indexOf('image/') === 0) {
+          var file = item.getAsFile();
+          if (file) files.push(file);
+        }
+      }
+    }
+    // Safari screenshot pastes can populate .files while .items stays empty.
+    if (!files.length && source && source.files) {
+      for (i = 0; i < source.files.length; i++) {
+        if (source.files[i].type.indexOf('image/') === 0) files.push(source.files[i]);
+      }
+    }
+    return files;
+  }
+
+  var MAX_UPLOAD_FILES = 5;
+
+  function uploadImageFile(file, csrfToken) {
+    return fetch('/upload', {
+      method: 'POST',
+      headers: { 'X-CSRF-Token': csrfToken },
+      body: file
+    }).then(function(res) {
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      return res.json();
+    }).then(function(data) {
+      return data.path;
+    }).catch(function(err) {
+      console.warn('image upload failed:', err);
+      return null;
+    });
+  }
+
+  function uploadImageFiles(files) {
+    // Uploads run in parallel; the paths are typed afterwards in the
+    // original order, skipping files whose upload failed.
+    var csrfToken = getCsrfToken();
+    var uploads = files.slice(0, MAX_UPLOAD_FILES).map(function(file) {
+      return uploadImageFile(file, csrfToken);
+    });
+    return Promise.all(uploads).then(function(paths) {
+      paths.forEach(function(path) {
+        if (path === null) return;
+        if (!sendToTTYD(path + ' ')) {
+          console.warn('image uploaded but terminal socket not ready:', path);
+        }
+      });
+    }).catch(function(err) {
+      console.warn('upload pipeline error:', err);
+    });
+  }
+
+  function pasteTextToTerminal(text) {
+    // term.paste honours bracketed-paste mode; raw socket send is the fallback.
+    if (window.term && window.term.paste) {
+      window.term.paste(text);
+    } else if (!sendToTTYD(text)) {
+      console.warn('text transfer dropped: terminal not ready');
+    }
+  }
+
+  function containsFiles(source) {
+    // Same items/files coverage as extractImageFiles, but deliberately WITHOUT
+    // a MIME filter: any file (e.g. a dropped PDF) must block the text branch
+    // so a non-image transfer is silently skipped, not typed as its file:// URL.
+    if (!source) return false;
+    if (source.files && source.files.length) return true;
+    var items = source.items;
+    if (items) {
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].kind === 'file') return true;
+      }
+    }
+    return false;
+  }
+
+  function handleImageTransfer(source) {
+    var images = extractImageFiles(source);
+    if (!images.length) return false;
+    uploadImageFiles(images);
+    return true;
+  }
+
+  // Full triage of a paste/drop payload: images upload, plain text types
+  // into the prompt, anything else (non-image files) is silently skipped.
+  // Returns true when the transfer was consumed.
+  function handleDataTransfer(source) {
+    if (handleImageTransfer(source)) return true;
+    // A non-image file transfer is skipped entirely, even when the browser
+    // also exposes a text representation of it (e.g. a file:// URL).
+    if (!source || containsFiles(source) || !source.getData) return false;
+    var text = source.getData('text/plain');
+    if (!text) return false;
+    pasteTextToTerminal(text);
+    return true;
+  }
+
+  // The parent page delegates its paste/drop events through this global
+  // instead of duplicating the triage logic in its own document.
+  window.__handleDataTransfer = handleDataTransfer;
+
+  document.addEventListener('paste', function(e) {
+    // Only images are consumed on the iframe paste path: pasted text stays
+    // on xterm's own default handling (bracketed paste, IME, etc.).
+    if (handleImageTransfer(e.clipboardData)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+
+  document.addEventListener('dragover', function(e) {
+    e.preventDefault();
+  }, true);
+
+  document.addEventListener('drop', function(e) {
+    // Always prevent the default: a dropped file would otherwise navigate
+    // the iframe away from the terminal. That also swallows text drops, so
+    // the full triage types them into the prompt itself.
+    e.preventDefault();
+    e.stopPropagation();
+    handleDataTransfer(e.dataTransfer);
+  }, true);
+
   waitForTerm(function(term) {
     document.addEventListener('keydown', function(e) {
       if (e.key === 'Tab') {

--- a/app/assets/terminal_parent_tab_handler.html
+++ b/app/assets/terminal_parent_tab_handler.html
@@ -28,5 +28,41 @@
         focusTerminal();
       });
     }
+
+    // Paste/drop can land on the parent page when the iframe is not focused
+    // (e.g. right after load). The injected iframe script owns the triage
+    // (image → upload, text → type, other → skip); the parent only forwards
+    // the transfer through this same-origin global and mirrors whether it
+    // was consumed. The parent page has no inputs, so its default
+    // paste/drop would lose the text.
+    function forwardDataTransfer(dataTransfer) {
+      try {
+        var win = iframe && iframe.contentWindow;
+        if (win && win.__handleDataTransfer) return win.__handleDataTransfer(dataTransfer);
+      } catch (e) {}
+      // Only worth a warning when files were actually present: text-only
+      // pastes routinely land here while the iframe is still loading.
+      if (dataTransfer && dataTransfer.files && dataTransfer.files.length) {
+        console.warn('terminal iframe not ready for image upload');
+      }
+      return false;
+    }
+
+    document.addEventListener('paste', function(e) {
+      if (forwardDataTransfer(e.clipboardData)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }, true);
+
+    document.addEventListener('dragover', function(e) {
+      e.preventDefault();
+    }, true);
+
+    document.addEventListener('drop', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      forwardDataTransfer(e.dataTransfer);
+    }, true);
   })();
 </script>

--- a/app/assets/virtual_keyboard.html
+++ b/app/assets/virtual_keyboard.html
@@ -1,3 +1,4 @@
+<button id="vkbd-toggle" type="button" aria-label="Toggle virtual keyboard" aria-pressed="false" title="Toggle keyboard">&#9000;</button>
 <div class="vkbd" id="vkbd">
   <div class="vkbd-row">
     <button data-key="esc" class="key-action">ESC</button>
@@ -110,8 +111,49 @@
         if (e.target.dataset.key === 'scroll') e.target.classList.toggle('on');
       }
     });
+
+    // --- Keyboard toggle (issue #32) ---
+    var STORAGE_KEY = 'clihost:vkbd-open';
+    var toggleBtn = document.getElementById('vkbd-toggle');
+
+    function notifyTerminalResize() {
+      // The browser fires resize in the iframe when its box changes, but the
+      // re-fit can read stale dimensions (iOS layout timing) — nudge it again.
+      try {
+        var win = iframe.contentWindow;
+        if (win) win.dispatchEvent(new Event('resize'));
+      } catch (e) {}
+    }
+
+    function applyVkbdState(open) {
+      document.body.classList.toggle('vkbd-open', open);
+      toggleBtn.setAttribute('aria-pressed', open ? 'true' : 'false');
+    }
+
+    toggleBtn.addEventListener('click', function() {
+      var open = !document.body.classList.contains('vkbd-open');
+      applyVkbdState(open);
+      try { localStorage.setItem(STORAGE_KEY, open ? '1' : '0'); } catch (e) {}
+      // Flex resizes #terminal-shell synchronously; let layout settle, then
+      // re-fit the terminal (two frames for reliability on iOS).
+      requestAnimationFrame(function() {
+        notifyTerminalResize();
+        requestAnimationFrame(notifyTerminalResize);
+      });
+      focusTerminal();
+    });
+
+    // No stored choice yet: open on narrow (mobile) screens, closed on desktop.
+    var stored = null;
+    try { stored = localStorage.getItem(STORAGE_KEY); } catch (e) {}
+    applyVkbdState(stored === null
+      ? window.matchMedia('(max-width: 768px)').matches
+      : stored === '1');
+
     iframe.addEventListener('load', function() {
       focusTerminal();
+      // The terminal may have fitted before the class was applied — re-fit it.
+      notifyTerminalResize();
     });
   })();
 </script>

--- a/app/assets/virtual_keyboard_style.css
+++ b/app/assets/virtual_keyboard_style.css
@@ -1,4 +1,5 @@
 .vkbd { display: none; background: #0d0d1a; padding: 6px; gap: 4px; flex-direction: column; }
+body.vkbd-open .vkbd { display: flex; }
 .vkbd-row { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
 .vkbd-bottom {
   display: grid;
@@ -30,9 +31,20 @@
 .vkbd button.key-scroll { font-size: 15px; }
 .vkbd button.key-scroll.on {
   background: linear-gradient(180deg, #1e4535, #16352a);
-  color: #6fdc9c; border-color: rgba(111,220,156,0.4);
 }
-@media (max-width: 768px) {
-  .vkbd { display: flex; }
-  body { height: calc(100vh - 140px); }
+/* Floating keyboard toggle — always visible, raises/lowers the vkbd (issue #32). */
+#vkbd-toggle {
+  position: fixed; top: 8px; right: 8px; z-index: 1;
+  width: 34px; height: 34px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px; line-height: 1; color: #cdd6e6;
+  background: rgba(13, 13, 26, 0.8); border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 8px; cursor: pointer; opacity: 0.55;
+  touch-action: manipulation; transition: opacity 0.15s ease;
 }
+#vkbd-toggle:hover { opacity: 1; }
+#vkbd-toggle:active { transform: translateY(1px); }
+body.vkbd-open #vkbd-toggle { opacity: 0.85; }
+/* Shared "on" accent: the scroll key and the open keyboard toggle. */
+.vkbd button.key-scroll.on,
+body.vkbd-open #vkbd-toggle { color: #6fdc9c; border-color: rgba(111,220,156,0.4); }

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -1,6 +1,8 @@
 """HTTP handler and process wiring for the ttyd proxy application."""
 import hmac
 import json
+import os
+import pwd
 import sys
 import signal
 import time
@@ -24,11 +26,14 @@ from ttydproxy.config import (
     CSRF_TOKEN_TTL,
     SECURE_COOKIES,
     HAPI_URL_FILE,
+    MAX_UPLOAD_SIZE,
+    UPLOAD_DIR,
     TTYD_ROUTE_PATTERN,
 )
 from ttydproxy.manager import TTYDManager
 from ttydproxy.proxy import is_websocket_request, proxy_ttyd_http, proxy_ttyd_websocket
 from ttydproxy.ratelimit import RateLimiter
+from ttydproxy.uploads import save_upload
 from ttydproxy.security import (
     build_csrf_token,
     build_session_token,
@@ -110,6 +115,8 @@ class TTYDProxyHandler(BaseHandler):
             self.handle_cleanup_delete()
         elif parsed.path == "/terminals":
             self.handle_terminals_create()
+        elif parsed.path == "/upload":
+            self.handle_upload()
         else:
             self.send_json(404, {"error": "Not found"})
 
@@ -181,18 +188,25 @@ class TTYDProxyHandler(BaseHandler):
             return False
         return True
 
-    def _read_request_body(self):
-        """Read and UTF-8 decode the request body. Returns text or None on error."""
+    def _read_binary_request_body(self, max_size):
+        """Read the raw request body. Returns bytes or None on error."""
         try:
             content_length = int(self.headers.get("Content-Length", 0))
         except ValueError:
             self.send_json(400, {"error": "Invalid Content-Length"})
             return None
-        if content_length < 0 or content_length > 1048576:
+        if content_length < 0 or content_length > max_size:
             self.send_json(413, {"error": "Request too large"})
             return None
+        return self.rfile.read(content_length)
+
+    def _read_request_body(self):
+        """Read and UTF-8 decode the request body. Returns text or None on error."""
+        data = self._read_binary_request_body(1048576)
+        if data is None:
+            return None
         try:
-            return self.rfile.read(content_length).decode("utf-8")
+            return data.decode("utf-8")
         except UnicodeDecodeError:
             self.send_json(400, {"error": "Invalid encoding"})
             return None
@@ -300,6 +314,27 @@ class TTYDProxyHandler(BaseHandler):
         else:
             self.send_json(404, {"error": f"Terminal {terminal_id} not found"})
 
+    def handle_upload(self):
+        username = self._check_auth()
+        if not username or not self._check_csrf():
+            return
+        data = self._read_binary_request_body(MAX_UPLOAD_SIZE)
+        if data is None:
+            return
+        if not data:
+            self.send_json(400, {"error": "Empty upload"})
+            return
+        try:
+            path = save_upload(data, UPLOAD_DIR, TTYD_USER)
+        except ValueError as exc:
+            # save_upload is the single validator and owns the message.
+            self.send_json(415, {"error": str(exc)})
+            return
+        except OSError:
+            self.send_json(500, {"error": "Failed to save upload"})
+            return
+        self.send_json(201, {"path": path})
+
     def handle_cleanup_delete(self):
         username = self._check_auth()
         if not username or not self._check_csrf():
@@ -397,7 +432,14 @@ class TTYDProxyHandler(BaseHandler):
             self.send_json(404, {"error": f"Terminal ttyd{terminal_id} not found"})
             return
         vkbd_enabled = resolve_vkbd_enabled(self.path, VIRTUAL_KEYBOARD)
-        self.send_html(200, render_terminal_page(terminal_id, username, vkbd_enabled))
+        # Refresh the CSRF cookie: image uploads from a long-lived terminal
+        # tab must not outlive the token minted on the last dashboard visit.
+        extra_headers, _csrf_token = self._auth_cookie_headers()
+        self.send_html(
+            200,
+            render_terminal_page(terminal_id, username, vkbd_enabled),
+            extra_headers=extra_headers,
+        )
 
     def handle_ttyd_proxy(self, terminal_id):
         username = self._check_auth()
@@ -421,8 +463,26 @@ class TTYDProxyHandler(BaseHandler):
             proxy_ttyd_http(self, upstream_path, port)
 
 
+def _warn_on_user_mismatch():
+    """Warn when running unprivileged as a user other than TTYD_USER."""
+    if os.geteuid() == 0:
+        return
+    try:
+        current_user = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        current_user = f"uid {os.geteuid()}"
+    if current_user != TTYD_USER:
+        print(
+            f"WARNING: proxy running as {current_user}, not root; cannot switch to "
+            f"TTYD_USER={TTYD_USER} — terminals will run as {current_user}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
 def main():
     """Start the ttyd proxy server."""
+    _warn_on_user_mismatch()
     server_address = ("0.0.0.0", PORT)
     print(f"Starting TTYD HTTP proxy on {server_address}...", flush=True)
 

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -36,6 +36,16 @@ STATIC_TARGETS = (
         "strategy": "remove-tree",
     },
     {
+        "id": "uploads",
+        "label": ".uploads/",
+        "relative_path": ".uploads",
+        "description": "Images pasted/dropped into the web terminal",
+        "category": "runtime",
+        "risk": "low",
+        "order": 25,
+        "strategy": "remove-tree",
+    },
+    {
         "id": "cache-home",
         "label": "~/.cache",
         "relative_path": ".cache",
@@ -68,9 +78,13 @@ STATIC_TARGETS = (
 )
 
 PROJECT_CATEGORY_ORDER = 100
-# runtime/ is exposed as a dedicated static cleanup target, so it must not also
-# show up in the discovered project/work-directory list.
-RESERVED_TOP_LEVEL_NAMES = {"runtime"}
+# Top-level static targets (runtime/, ...) must not also show up in the
+# discovered project/work-directory list. Derived from STATIC_TARGETS so adding
+# a target keeps the two in sync; dot-prefixed entries (.hapi, .uploads, ...)
+# are already excluded by the callers' hidden-name filters.
+RESERVED_TOP_LEVEL_NAMES = {
+    spec["relative_path"] for spec in STATIC_TARGETS if "/" not in spec["relative_path"]
+}
 MAX_SIZE_WALK_ENTRIES = 5000
 
 

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -18,5 +18,7 @@ VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
 CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL")
 SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
+MAX_UPLOAD_SIZE = env_int(os.environ.get("MAX_UPLOAD_SIZE"), 10485760, name="MAX_UPLOAD_SIZE")
+UPLOAD_DIR = os.environ.get("UPLOAD_DIR", f"{CLEANUP_ROOT}/.uploads")
 
 TTYD_ROUTE_PATTERN = re.compile(r"^/ttyd(\d+)(/.*)?$")

--- a/app/ttydproxy/manager.py
+++ b/app/ttydproxy/manager.py
@@ -1,4 +1,5 @@
 """Lifecycle management for ttyd child processes."""
+import os
 import socket
 import subprocess
 import sys
@@ -40,17 +41,22 @@ class TTYDManager:
     def _tmux_session_name(self, terminal_id):
         return f"ttyd-{terminal_id}"
 
+    def _as_ttyd_user(self, command):
+        """Wrap a command with runuser when root; unprivileged proxies run it directly."""
+        if os.geteuid() == 0:
+            return ["runuser", "-u", self.ttyd_user, "--", *command]
+        return command
+
     def _start_ttyd_process(self, terminal_id, port):
         tmux_session = self._tmux_session_name(terminal_id)
         return subprocess.Popen(
-            [
-                "runuser", "-u", self.ttyd_user, "--",
+            self._as_ttyd_user([
                 self.ttyd_binary,
                 "-p", str(port),
                 "-i", "127.0.0.1",
                 "-W",
                 self.tmux_wrapper, tmux_session,
-            ],
+            ]),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -73,10 +79,9 @@ class TTYDManager:
     def _kill_tmux_session(self, terminal_id):
         try:
             subprocess.run(
-                [
-                    "runuser", "-u", self.ttyd_user, "--",
-                    "tmux", "kill-session", "-t", self._tmux_session_name(terminal_id),
-                ],
+                self._as_ttyd_user(
+                    ["tmux", "kill-session", "-t", self._tmux_session_name(terminal_id)]
+                ),
                 capture_output=True,
                 timeout=5,
             )

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -43,20 +43,27 @@ def env_int(value, default, name=None):
 
 
 def env_secret(name, default):
-    """Resolve a secret env var, honoring the Docker *_FILE convention."""
+    """Resolve a secret env var, honoring the Docker *_FILE convention.
+
+    When <NAME>_FILE is set it is authoritative: an unreadable or empty file
+    aborts startup instead of silently falling back to a guessable default.
+    """
     path = os.environ.get(f"{name}_FILE")
     if path:
         try:
             with open(path) as secret_file:
                 value = secret_file.read().strip()
-            if value:
-                return value
         except OSError as exc:
             print(
-                f"Cannot read {name}_FILE={path}: {exc}, falling back",
+                f"ERROR: Cannot read {name}_FILE={path}: {exc}",
                 file=sys.stderr,
                 flush=True,
             )
+            sys.exit(1)
+        if not value:
+            print(f"ERROR: {name}_FILE={path} is empty", file=sys.stderr, flush=True)
+            sys.exit(1)
+        return value
     return os.environ.get(name) or default
 
 
@@ -200,7 +207,10 @@ def verify_pam_password(username, password):
 
         shadow_info = spwd.getspnam(username)
         crypt_module = crypt_import
-    except (ImportError, KeyError, FileNotFoundError):
+    except (ImportError, KeyError, OSError):
+        # OSError covers PermissionError when the proxy runs unprivileged and
+        # cannot read /etc/shadow; fall through to su(1), whose setgid
+        # unix_chkpwd helper can verify the proxy's own user's password.
         shadow_info = None
 
     if shadow_info and crypt_module:

--- a/app/ttydproxy/uploads.py
+++ b/app/ttydproxy/uploads.py
@@ -1,0 +1,161 @@
+"""Save images pasted/dropped into the web terminal to disk."""
+import os
+import pwd
+import secrets
+import time
+
+# Magic-byte signatures drive both validation and the saved extension; the
+# client-supplied Content-Type and filename are never trusted. SVG is
+# deliberately excluded (script-bearing format).
+_SIGNATURES = (
+    (b"\x89PNG\r\n\x1a\n", "png"),
+    (b"\xff\xd8\xff", "jpg"),
+    (b"GIF87a", "gif"),
+    (b"GIF89a", "gif"),
+)
+
+
+def detect_image_extension(data):
+    """Return the file extension for known image magic bytes, else None."""
+    for signature, extension in _SIGNATURES:
+        if data.startswith(signature):
+            return extension
+    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def _lookup_owner_ids(username):
+    """Return (uid, gid) for username, or None if it can't be resolved.
+
+    The proxy may run unprivileged in dev/test, where the owner doesn't exist;
+    callers treat None as "skip chown".
+    """
+    try:
+        record = pwd.getpwnam(username)
+    except KeyError:
+        return None
+    return record.pw_uid, record.pw_gid
+
+
+def _fchown_best_effort(fd, ids):
+    """chown an open fd to ids=(uid, gid); ignore errors (unprivileged dev/test)."""
+    if ids is None:
+        return
+    try:
+        os.fchown(fd, ids[0], ids[1])
+    except OSError:
+        pass
+
+
+def _open_upload_dir_nofollow(upload_dir, ids):
+    """Open upload_dir as a directory fd without following symlinks anywhere.
+
+    upload_dir must already be absolute (save_upload normalizes it).
+    Returns an fd for upload_dir, creating missing levels as needed. The walk
+    starts from the deepest already-existing ancestor (which the proxy did not
+    create — e.g. /home/hapi) and descends one component at a time. Both the
+    anchor open and each descent step use O_NOFOLLOW, so a symlink planted in
+    the anchor (TOCTOU swap) or ANY component below it raises OSError instead
+    of letting the privileged process escape the tree. Newly created levels are
+    chowned to ids; pre-existing ancestors are left untouched. Caller must
+    os.close the result.
+    """
+    path = upload_dir
+    # Split into the deepest existing prefix + the components we must descend
+    # (and create). The islink() check keeps a symlinked component in `missing`
+    # even when isdir() would follow it, so O_NOFOLLOW still rejects it below.
+    missing = []
+    while not os.path.isdir(path) or os.path.islink(path):
+        parent, comp = os.path.split(path)
+        if not comp or parent == path:
+            # Reached the filesystem root without an existing directory; let the
+            # normal open below surface the error.
+            break
+        missing.append(comp)
+        path = parent
+    missing.reverse()
+
+    # O_NOFOLLOW on the anchor too: the deepest existing ancestor was a real
+    # directory when the walk computed it, but an attacker can swap it for a
+    # symlink before this open (TOCTOU). It only constrains the final path
+    # component, so legitimate symlinked prefixes (e.g. /var -> /private/var)
+    # are unaffected — the anchor itself must be a real directory.
+    parent_fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY)
+    try:
+        for comp in missing:
+            try:
+                child_fd = os.open(
+                    comp, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY, dir_fd=parent_fd
+                )
+            except FileNotFoundError:
+                # No atomic create-or-open for directories; mkdir then re-open
+                # relative to parent_fd. The parent fd is pinned to an inode we
+                # already opened with O_NOFOLLOW, so a symlink can't be swapped
+                # in underneath us between mkdir and open.
+                created = True
+                try:
+                    os.mkdir(comp, dir_fd=parent_fd)
+                except FileExistsError:
+                    # A concurrent upload created it first (5 parallel uploads
+                    # per gesture race here on a fresh/just-cleaned dir). The
+                    # O_NOFOLLOW re-open below still rejects a planted symlink,
+                    # so just adopt the existing directory without chowning it.
+                    created = False
+                child_fd = os.open(
+                    comp, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY, dir_fd=parent_fd
+                )
+                if created:
+                    _fchown_best_effort(child_fd, ids)
+            os.close(parent_fd)
+            parent_fd = child_fd
+        return parent_fd
+    except BaseException:
+        os.close(parent_fd)
+        raise
+
+
+def save_upload(data, upload_dir, owner):
+    """Write image bytes to a generated path under upload_dir; return the path.
+
+    The proxy may run as root while upload_dir lives under the terminal user's
+    home, so the path is attacker-controlled: the user can replace upload_dir,
+    or any parent component of it, with a symlink between calls. To keep the
+    privileged chown/write from following such a link, the directory is reached
+    via a component-by-component O_NOFOLLOW descent (see
+    _open_upload_dir_nofollow) and every privileged operation is bound to a
+    directory/file fd (an inode), never re-resolved from the string path. A
+    symlink anywhere in the path raises OSError instead of escaping the tree.
+    All of this hardening matters only in root mode; if root mode is ever
+    dropped, it can collapse to os.makedirs + an O_EXCL open.
+    """
+    extension = detect_image_extension(data)
+    if extension is None:
+        raise ValueError("Unsupported image type")
+    upload_dir = os.path.abspath(upload_dir)
+    # chown matters only in root mode; an unprivileged proxy creates entries
+    # with the right owner already, so skip the per-request passwd lookup.
+    ids = _lookup_owner_ids(owner) if os.geteuid() == 0 else None
+    # The cleanup dashboard can delete the whole directory at any time, so
+    # recreate it (and any missing parents) on every save.
+    dir_fd = _open_upload_dir_nofollow(upload_dir, ids)
+    try:
+        name = f"img-{time.strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(4)}.{extension}"
+        # Resolve `name` relative to the open directory inode (dir_fd), not by
+        # walking upload_dir again; O_EXCL keeps the "xb" semantics and
+        # O_NOFOLLOW rejects a symlink someone planted under that name.
+        file_fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        try:
+            _fchown_best_effort(file_fd, ids)
+            with open(file_fd, "wb", closefd=False) as upload_file:
+                upload_file.write(data)
+        finally:
+            os.close(file_fd)
+    finally:
+        os.close(dir_fd)
+    return os.path.join(upload_dir, name)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ HAPI_USER="${HAPI_USER:-hapi}"
 HAPI_USER_HOME="/home/${HAPI_USER}"
 : "${CLEANUP_ROOT:=${HAPI_USER_HOME}}"
 : "${HAPI_HOME:=${HAPI_USER_HOME}/.hapi}"
+: "${UPLOAD_DIR:=${CLEANUP_ROOT}/.uploads}"
 HAPI_RUN_PATH="/usr/local/bin:/usr/bin:/bin"
 
 echo "Starting clihost container..."
@@ -99,20 +100,36 @@ if [ "${HERMES_AUTO_UPDATE:-true}" != "false" ] && command -v hermes &>/dev/null
   fi
 fi
 
-# Start TTYD HTTP proxy (manages TTYD processes dynamically).
-# The secret goes through a root-only file (Docker *_FILE convention) so it
-# never appears in the proxy's /proc/<pid>/environ.
+# Start TTYD HTTP proxy (manages TTYD processes dynamically; drops root and
+# runs as TTYD_USER). The secret goes through a TTYD_USER-only file (Docker
+# *_FILE convention) so it never appears in the proxy's /proc/<pid>/environ.
+# Validate PORT is numeric first: `[ "$PORT" -lt 1024 ]` on a non-numeric value
+# exits 2 (error, not false), which would let the range guard silently pass.
+case "${PORT}" in
+  ''|*[!0-9]*)
+    echo "ERROR: PORT=${PORT} must be a positive integer" >&2
+    exit 1
+    ;;
+esac
+if [ "${PORT}" -lt 1024 ]; then
+  echo "ERROR: PORT=${PORT} is a privileged port; the proxy runs as ${TTYD_USER} and needs PORT >= 1024" >&2
+  exit 1
+fi
+# The proxy runs as TTYD_USER and creates upload files itself; pre-create and
+# chown UPLOAD_DIR so a bind-mounted /home/hapi (often not writable by the hapi
+# UID) doesn't make pasted-image uploads fail with 500.
+ensure_dir_owned "${UPLOAD_DIR}"
 PROXY_SECRET_FILE="/run/ttyd-proxy.secret"
-install -m 600 /dev/null "${PROXY_SECRET_FILE}"
+install -m 400 -o "${TTYD_USER}" /dev/null "${PROXY_SECRET_FILE}"
 printf '%s' "${PASSWORD_SECRET}" > "${PROXY_SECRET_FILE}"
-echo "Starting TTYD HTTP proxy on port ${PORT}"
+echo "Starting TTYD HTTP proxy on port ${PORT} as ${TTYD_USER}"
 PORT="${PORT}" \
 TTYD_USER="${TTYD_USER}" \
 TTYD_PASSWORD="${TTYD_PASSWORD}" \
 PASSWORD_SECRET_FILE="${PROXY_SECRET_FILE}" \
 CLEANUP_ROOT="${CLEANUP_ROOT}" \
 HAPI_HOME="${HAPI_HOME}" \
-python3 /app/ttyd_proxy.py &
+runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
 
 # Start hapi server with relay in background (logs to file, force TCP relay)
 HAPI_SERVER_LOG="${HAPI_HOME}/server.log"

--- a/tests/preview/vkbd_preview.html
+++ b/tests/preview/vkbd_preview.html
@@ -25,14 +25,19 @@
       color: #444; font-family: monospace; font-size: 13px;
     }
 
-    .phone-frame .vkbd { display: flex !important; }
+    /* Preview only: pin the toggle to the phone frame instead of the viewport
+       (production uses position: fixed against the real viewport). */
+    .phone-frame #vkbd-toggle { position: absolute; }
   </style>
   <link rel="stylesheet" href="../../app/assets/virtual_keyboard_style.css">
 </head>
-<body>
+<body class="vkbd-open">
 
   <div class="phone-frame">
     <div class="phone-notch"></div>
+    <!-- Copy of the toggle from app/assets/virtual_keyboard.html
+         (aria-pressed=true: the preview starts open) -->
+    <button id="vkbd-toggle" type="button" aria-label="Toggle virtual keyboard" aria-pressed="true" title="Toggle keyboard">&#9000;</button>
     <div class="terminal-mock">~ $ _</div>
 
     <!-- Copy of app/assets/virtual_keyboard.html markup (no JS) -->
@@ -67,6 +72,10 @@
   </div>
 
   <script>
+    document.getElementById('vkbd-toggle').addEventListener('click', function() {
+      var open = document.body.classList.toggle('vkbd-open');
+      this.setAttribute('aria-pressed', open ? 'true' : 'false');
+    });
     document.getElementById('vkbd').addEventListener('click', function(e) {
       if (e.target.tagName === 'BUTTON') {
         console.log('Key:', e.target.dataset.key);

--- a/tests/unit/handler_stubs.py
+++ b/tests/unit/handler_stubs.py
@@ -1,0 +1,21 @@
+"""Shared test stubs for TTYDProxyHandler-based API tests."""
+from ttydproxy.app import TTYDProxyHandler
+
+
+class RecordingHandler(TTYDProxyHandler):
+    """Handler stub that skips socket setup, passes auth/CSRF, and records
+    the JSON response as (status, data)."""
+
+    def __init__(self):
+        self.response = None
+
+    def send_json(self, status, data, extra_headers=None):
+        del extra_headers
+        self.response = (status, data)
+
+    def _check_auth(self, redirect=False):
+        del redirect
+        return "alice"
+
+    def _check_csrf(self):
+        return True

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -52,6 +52,19 @@ class TestCleanupTargets(unittest.TestCase):
         self.assertEqual(project_b["risk"], "high")
         self.assertTrue(project_b["size_bytes"] >= 512)
 
+    def test_uploads_is_a_static_target_not_a_project(self):
+        write_file(self.root / ".uploads" / "img-1.png", 64)
+        targets = list_cleanup_targets(self.root, self.hapi_home)
+        target_ids = [target["id"] for target in targets]
+
+        self.assertIn("uploads", target_ids)
+        # Hidden dir: must not be duplicated as a discovered project dir.
+        self.assertNotIn("project:.uploads", target_ids)
+
+        uploads = next(target for target in targets if target["id"] == "uploads")
+        self.assertEqual(uploads["risk"], "low")
+        self.assertEqual(uploads["strategy"], "remove-tree")
+
     def test_skips_targets_resolving_outside_root(self):
         outside = Path(self.tempdir.name).parent / "outside-cleanup-target"
         outside.mkdir(exist_ok=True)
@@ -153,6 +166,15 @@ class TestCleanupDeletion(unittest.TestCase):
         self.assertFalse((self.hapi_home / "trash").exists())
         self.assertFalse((self.root / ".cache").exists())
         self.assertFalse((self.root / "project-a").exists())
+
+    def test_delete_uploads_target_removes_directory(self):
+        write_file(self.root / ".uploads" / "img-1.png", 64)
+
+        result = delete_cleanup_targets(["uploads"], self.root, self.hapi_home)
+
+        self.assertEqual(result["errors"], [])
+        self.assertEqual([item["id"] for item in result["deleted"]], ["uploads"])
+        self.assertFalse((self.root / ".uploads").exists())
 
     def test_unknown_target_is_skipped(self):
         result = delete_cleanup_targets(["unknown-target"], self.root, self.hapi_home)

--- a/tests/unit/test_cleanup_api.py
+++ b/tests/unit/test_cleanup_api.py
@@ -2,23 +2,7 @@
 import unittest
 from unittest.mock import patch
 
-from ttydproxy.app import TTYDProxyHandler
-
-
-class RecordingCleanupHandler(TTYDProxyHandler):
-    def __init__(self):
-        self.response = None
-
-    def send_json(self, status, data, extra_headers=None):
-        del extra_headers
-        self.response = (status, data)
-
-    def _check_auth(self, redirect=False):
-        del redirect
-        return "alice"
-
-    def _check_csrf(self):
-        return True
+from tests.unit.handler_stubs import RecordingHandler
 
 
 class TestCleanupAPI(unittest.TestCase):
@@ -28,7 +12,7 @@ class TestCleanupAPI(unittest.TestCase):
         mock_list_cleanup_targets.return_value = [{"id": "cache-home", "label": "~/.cache"}]
         mock_summarize_cleanup_targets.return_value = {"count": 1, "total_size_bytes": 128, "total_size_human": "128 B"}
 
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler.handle_cleanup_list()
 
         self.assertEqual(
@@ -46,7 +30,7 @@ class TestCleanupAPI(unittest.TestCase):
     def test_handle_cleanup_delete(self, mock_delete_cleanup_targets):
         mock_delete_cleanup_targets.return_value = {"deleted": [{"id": "cache-home", "label": "~/.cache"}], "skipped": [], "errors": []}
 
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": ["cache-home"]}
         handler.handle_cleanup_delete()
 
@@ -56,28 +40,28 @@ class TestCleanupAPI(unittest.TestCase):
         )
 
     def test_handle_cleanup_delete_rejects_invalid_ids(self):
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": "cache-home"}
         handler.handle_cleanup_delete()
 
         self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
 
     def test_handle_cleanup_delete_rejects_empty_ids(self):
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": []}
         handler.handle_cleanup_delete()
 
         self.assertEqual(handler.response, (400, {"error": "ids must be a non-empty array"}))
 
     def test_handle_cleanup_delete_rejects_too_many_ids(self):
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": [f"id-{index}" for index in range(51)]}
         handler.handle_cleanup_delete()
 
         self.assertEqual(handler.response, (400, {"error": "ids must contain at most 50 items"}))
 
     def test_handle_cleanup_delete_rejects_too_long_ids(self):
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": ["x" * 129]}
         handler.handle_cleanup_delete()
 
@@ -90,7 +74,7 @@ class TestCleanupAPI(unittest.TestCase):
     def test_handle_cleanup_delete_allows_duplicate_ids(self, mock_delete_cleanup_targets):
         mock_delete_cleanup_targets.return_value = {"deleted": [{"id": "cache-home", "label": "~/.cache"}], "skipped": [], "errors": []}
 
-        handler = RecordingCleanupHandler()
+        handler = RecordingHandler()
         handler._load_json_payload = lambda: {"ids": ["cache-home", "cache-home"]}
         handler.handle_cleanup_delete()
 

--- a/tests/unit/test_env_secret.py
+++ b/tests/unit/test_env_secret.py
@@ -37,18 +37,24 @@ class TestEnvSecret(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(env_secret("MY_SECRET", "default"), "default")
 
-    def test_unreadable_file_falls_back_to_env(self):
+    def test_unreadable_file_exits(self):
+        # <NAME>_FILE is authoritative: a broken file must abort startup, not
+        # silently fall back to the env var or a guessable default secret.
         env = {"MY_SECRET_FILE": "/nonexistent/path", "MY_SECRET": "env-secret"}
         with patch.dict(os.environ, env, clear=True):
-            self.assertEqual(env_secret("MY_SECRET", "default"), "env-secret")
+            with self.assertRaises(SystemExit) as ctx:
+                env_secret("MY_SECRET", "default")
+        self.assertEqual(ctx.exception.code, 1)
 
-    def test_empty_file_falls_back(self):
+    def test_empty_file_exits(self):
         with tempfile.NamedTemporaryFile("w", suffix=".secret", delete=False) as f:
             f.write("\n")
             path = f.name
         try:
             with patch.dict(os.environ, {"MY_SECRET_FILE": path}, clear=True):
-                self.assertEqual(env_secret("MY_SECRET", "default"), "default")
+                with self.assertRaises(SystemExit) as ctx:
+                    env_secret("MY_SECRET", "default")
+            self.assertEqual(ctx.exception.code, 1)
         finally:
             os.unlink(path)
 

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -38,6 +38,32 @@ class TestEntrypointRegressions(unittest.TestCase):
             re.compile(r'^PASSWORD_SECRET="\$\{PASSWORD_SECRET\}"', re.MULTILINE),
         )
 
+    def test_proxy_started_as_ttyd_user(self):
+        # The proxy must drop root (issue #52): launched via runuser, with the
+        # secret file owned by TTYD_USER so the unprivileged proxy can read it.
+        self.assertIn(
+            'runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &', self.text
+        )
+        self.assertIn('install -m 400 -o "${TTYD_USER}"', self.text)
+
+    def test_port_validated_numeric_before_range_check(self):
+        # A non-numeric PORT must fail loudly: `[ "$PORT" -lt 1024 ]` returns
+        # exit 2 (error, not "false"), so the range guard silently passes and
+        # the proxy starts on the default 8080. A numeric pre-check prevents it.
+        case_pos = self.text.find("*[!0-9]*")
+        range_pos = self.text.find('[ "${PORT}" -lt 1024 ]')
+        self.assertGreater(case_pos, -1, "PORT is not validated as numeric")
+        self.assertLess(case_pos, range_pos)
+
+    def test_upload_dir_prepared_before_proxy(self):
+        # The unprivileged proxy creates upload files itself; a bind-mounted
+        # /home/hapi may not be writable by the hapi UID, so the entrypoint
+        # must create+chown UPLOAD_DIR before starting the proxy.
+        prep_pos = self.text.find('ensure_dir_owned "${UPLOAD_DIR}"')
+        proxy_pos = self.text.find('runuser -u "${TTYD_USER}" -- python3')
+        self.assertGreater(prep_pos, -1, "UPLOAD_DIR is not pre-created")
+        self.assertLess(prep_pos, proxy_pos)
+
     def test_hapi_server_log_precreated(self):
         # The log file must exist before the URL-extraction loop starts so the
         # [ -f "$HAPI_SERVER_LOG" ] guard passes on the first iteration.

--- a/tests/unit/test_tab_fix_script.py
+++ b/tests/unit/test_tab_fix_script.py
@@ -4,6 +4,12 @@ import unittest
 from ttydproxy.assets import TAB_FIX_SCRIPT
 
 
+def script_section(script, start_marker, end_marker="}, true);"):
+    """Slice script from start_marker up to the following end_marker."""
+    start = script.index(start_marker)
+    return script[start:script.index(end_marker, start)]
+
+
 class TestScrollFixOrder(unittest.TestCase):
     def setUp(self):
         self.script = TAB_FIX_SCRIPT
@@ -55,6 +61,133 @@ class TestWaitForTermTimeout(unittest.TestCase):
     def test_clears_interval_on_timeout(self):
         # Two clearInterval calls: one on success, one when giving up.
         self.assertEqual(self.section.count("clearInterval(i)"), 2)
+
+
+class TestImageUpload(unittest.TestCase):
+    """Pasted/dropped images upload via POST /upload, path typed into the terminal."""
+
+    def setUp(self):
+        self.script = TAB_FIX_SCRIPT
+
+    def _section(self, start_marker, end_marker="}, true);"):
+        return script_section(self.script, start_marker, end_marker)
+
+    def test_paste_listener_in_capture_phase(self):
+        # The slice ends at the listener's own "}, true);" (the capture flag);
+        # if the flag is lost, the slice runs into the next listener and the
+        # single-registration assertion below fails.
+        section = self._section("addEventListener('paste'")
+        self.assertEqual(section.count("addEventListener"), 1)
+
+    def test_paste_ignores_text_only_clipboard(self):
+        section = self._section("addEventListener('paste'")
+        # Only images are consumed on the iframe paste path; pasted text
+        # stays on xterm's default handling (bracketed paste, IME, etc.).
+        self.assertIn("if (handleImageTransfer(e.clipboardData))", section)
+        self.assertNotIn("handleDataTransfer", section)
+
+    def test_image_gate_checks_mime_prefix(self):
+        self.assertIn("indexOf('image/') === 0", self.script)
+
+    def test_extract_covers_items_and_files(self):
+        extract = self._section("function extractImageFiles", "function uploadImageFile")
+        self.assertIn(".items", extract)
+        self.assertIn("getAsFile()", extract)
+        self.assertIn(".files", extract)
+
+    def test_dragover_and_drop_prevent_default(self):
+        for event_name in ("dragover", "drop"):
+            with self.subTest(event=event_name):
+                section = self._section(f"addEventListener('{event_name}'")
+                self.assertIn("e.preventDefault()", section)
+
+    def test_drop_reads_data_transfer(self):
+        section = self._section("addEventListener('drop'")
+        # Drop always prevents the default (a file drop would navigate away),
+        # so the full triage runs to type dropped text into the terminal.
+        self.assertIn("handleDataTransfer(e.dataTransfer)", section)
+
+    def test_upload_posts_with_csrf(self):
+        self.assertIn("fetch('/upload'", self.script)
+        self.assertIn("method: 'POST'", self.script)
+        self.assertIn("'X-CSRF-Token': csrfToken", self.script)
+        # The token is read once per gesture, not once per file.
+        self.assertIn("var csrfToken = getCsrfToken();", self.script)
+
+    def test_success_types_path_with_trailing_space(self):
+        self.assertIn("sendToTTYD(path + ' ')", self.script)
+
+    def test_failure_warns_without_typing(self):
+        self.assertIn("console.warn('image upload failed", self.script)
+
+    def test_upload_count_capped(self):
+        self.assertIn("var MAX_UPLOAD_FILES = 5", self.script)
+        self.assertIn("slice(0, MAX_UPLOAD_FILES)", self.script)
+
+    def test_upload_api_exposed_for_parent_page(self):
+        self.assertIn("window.__handleDataTransfer = handleDataTransfer", self.script)
+
+
+class TestTransferTriage(unittest.TestCase):
+    """Text types into the prompt, images upload, anything else silently skips."""
+
+    def setUp(self):
+        self.script = TAB_FIX_SCRIPT
+        self.triage = script_section(
+            self.script, "function handleDataTransfer", "window.__handleDataTransfer"
+        )
+
+    def test_text_typed_via_bracketed_paste_with_socket_fallback(self):
+        # term.paste honours bracketed-paste mode (safe multi-line text);
+        # the raw socket send stays as the fallback.
+        body = script_section(
+            self.script, "function pasteTextToTerminal", "function containsFiles"
+        )
+        self.assertIn("term.paste(text)", body)
+        self.assertIn("sendToTTYD(text)", body)
+
+    def test_images_win_over_text(self):
+        self.assertIn("if (handleImageTransfer(source)) return true;", self.triage)
+        self.assertLess(
+            self.triage.index("handleImageTransfer(source)"),
+            self.triage.index("getData('text/plain')"),
+        )
+
+    def test_non_image_files_silently_skipped(self):
+        # Pin the actual gate: a non-image file transfer never reaches the
+        # text branch, even when it exposes a text representation.
+        self.assertIn(
+            "if (!source || containsFiles(source) || !source.getData) return false;",
+            self.triage,
+        )
+
+    def test_contains_files_covers_items_and_files(self):
+        # The gate must share extractImageFiles' items/files coverage, or a
+        # files-via-items-only transfer (Safari quirk) slips into text typing.
+        body = script_section(
+            self.script, "function containsFiles", "function handleImageTransfer"
+        )
+        self.assertIn(".files", body)
+        self.assertIn(".items", body)
+
+    def test_contains_files_has_no_mime_filter(self):
+        # Invariant: containsFiles must NOT filter by image/ MIME — any file
+        # (including a PDF) blocks the text branch, which is what makes a
+        # non-image drop a silent skip rather than its text being typed.
+        body = script_section(
+            self.script, "function containsFiles", "function handleImageTransfer"
+        )
+        self.assertNotIn("image/", body)
+
+    def test_upload_pipeline_has_catch(self):
+        # The parallel Promise.all chain needs a terminal .catch so a throw in
+        # the then-callback (e.g. sendToTTYD) is logged, not an unhandled
+        # rejection in the console.
+        body = script_section(
+            self.script, "function uploadImageFiles", "function pasteTextToTerminal"
+        )
+        self.assertIn("Promise.all(", body)
+        self.assertIn(".catch(", body[body.index("Promise.all("):])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_terminal_parent_tab_handler.py
+++ b/tests/unit/test_terminal_parent_tab_handler.py
@@ -21,5 +21,34 @@ class TestTerminalParentTabHandler(unittest.TestCase):
                 self.assertNotIn(f"addEventListener('{event_name}'", self.script)
 
 
+class TestImageUploadForwarding(unittest.TestCase):
+    """Paste/drop on the parent page must forward image files into the iframe,
+    where the injected script owns the actual upload."""
+
+    def setUp(self):
+        self.script = TERMINAL_PARENT_TAB_HANDLER
+
+    def test_paste_drop_dragover_listeners_present(self):
+        for event_name in ("paste", "dragover", "drop"):
+            with self.subTest(event_name=event_name):
+                self.assertIn(f"addEventListener('{event_name}'", self.script)
+
+    def test_delegates_to_iframe_upload_api(self):
+        # The full triage (image → upload, text → type, other → skip) lives
+        # in the iframe's injected script; the parent must not duplicate it,
+        # only forward the transfer.
+        self.assertIn("__handleDataTransfer(dataTransfer)", self.script)
+        self.assertNotIn("function extractImageFiles", self.script)
+        self.assertNotIn("fetch('/upload'", self.script)
+
+    def test_forwarding_is_defensive(self):
+        # Same try/catch style as focusTerminal: the iframe may not have the
+        # injected script yet.
+        api_start = self.script.index("function forwardDataTransfer")
+        section = self.script[api_start : self.script.index("return false;", api_start)]
+        self.assertIn("try {", section)
+        self.assertIn("console.warn", section)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_ttyd_manager.py
+++ b/tests/unit/test_ttyd_manager.py
@@ -145,6 +145,42 @@ class TestListAndGet(unittest.TestCase):
         self.assertIsNone(manager.get_terminal(1))
 
 
+class TestSpawnPrivileges(unittest.TestCase):
+    """Root wraps child commands in runuser; an unprivileged proxy runs them directly."""
+
+    def _commands(self, euid):
+        """Create and delete a terminal under euid; return (manager, spawn argv, kill argv)."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 100
+        with patch("ttydproxy.manager.os.geteuid", return_value=euid), patch(
+            "ttydproxy.manager.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen, patch("ttydproxy.manager.subprocess.run") as mock_run:
+            manager = TTYDManager(base_port=9000, ttyd_user="hapi")
+            manager.create_terminal()
+            manager.delete_terminal(1)
+        return manager, mock_popen.call_args[0][0], mock_run.call_args[0][0]
+
+    def test_root_spawns_via_runuser(self):
+        manager, spawn, _kill = self._commands(euid=0)
+        self.assertEqual(spawn[:4], ["runuser", "-u", "hapi", "--"])
+        self.assertIn(manager.ttyd_binary, spawn)
+
+    def test_nonroot_spawns_directly(self):
+        manager, spawn, _kill = self._commands(euid=1000)
+        self.assertEqual(spawn[0], manager.ttyd_binary)
+        self.assertNotIn("runuser", spawn)
+
+    def test_root_kills_tmux_via_runuser(self):
+        _manager, _spawn, kill = self._commands(euid=0)
+        self.assertEqual(kill[:4], ["runuser", "-u", "hapi", "--"])
+        self.assertIn("kill-session", kill)
+
+    def test_nonroot_kills_tmux_directly(self):
+        _manager, _spawn, kill = self._commands(euid=1000)
+        self.assertEqual(kill[0], "tmux")
+        self.assertNotIn("runuser", kill)
+
+
 class TestAllocatePort(unittest.TestCase):
     def test_first_port(self):
         self.assertEqual(TTYDManager(base_port=9000)._allocate_port(), 9000)

--- a/tests/unit/test_uploads.py
+++ b/tests/unit/test_uploads.py
@@ -1,0 +1,221 @@
+"""Tests for uploads.py — image sniffing and saving pasted images."""
+import os
+import pathlib
+import tempfile
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ttydproxy.uploads import detect_image_extension, save_upload
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+JPEG_BYTES = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 16
+GIF87_BYTES = b"GIF87a" + b"\x00" * 16
+GIF89_BYTES = b"GIF89a" + b"\x00" * 16
+WEBP_BYTES = b"RIFF\x10\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+
+
+class TestDetectImageExtension(unittest.TestCase):
+    def test_known_formats(self):
+        cases = (
+            (PNG_BYTES, "png"),
+            (JPEG_BYTES, "jpg"),
+            (GIF87_BYTES, "gif"),
+            (GIF89_BYTES, "gif"),
+            (WEBP_BYTES, "webp"),
+        )
+        for data, expected in cases:
+            with self.subTest(expected=expected):
+                self.assertEqual(detect_image_extension(data), expected)
+
+    def test_riff_but_not_webp(self):
+        self.assertIsNone(detect_image_extension(b"RIFF\x10\x00\x00\x00WAVEfmt "))
+
+    def test_truncated_webp(self):
+        self.assertIsNone(detect_image_extension(b"RIFF\x10\x00"))
+
+    def test_non_images(self):
+        for data in (b"", b"#!/bin/sh\necho hi\n", b"<svg xmlns='...'></svg>"):
+            with self.subTest(data=data[:10]):
+                self.assertIsNone(detect_image_extension(data))
+
+
+class TestSaveUpload(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = self.tmp.name
+        # Hermetic default regardless of who runs the tests: owner lookup
+        # fails, so chown is skipped. Owner-specific tests re-patch inside.
+        patcher = patch("ttydproxy.uploads.pwd.getpwnam", side_effect=KeyError)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_saves_png_and_returns_absolute_path(self):
+        path = save_upload(PNG_BYTES, self.dir, "hapi")
+        self.assertTrue(os.path.isabs(path))
+        self.assertEqual(pathlib.Path(path).parent, pathlib.Path(self.dir))
+        self.assertEqual(pathlib.Path(path).read_bytes(), PNG_BYTES)
+
+    def test_filename_is_generated_not_client_derived(self):
+        path = save_upload(PNG_BYTES, self.dir, "hapi")
+        name = pathlib.Path(path).name
+        self.assertRegex(name, r"^img-\d{8}-\d{6}-[0-9a-f]{8}\.png$")
+
+    def test_extension_follows_magic_bytes(self):
+        path = save_upload(WEBP_BYTES, self.dir, "hapi")
+        self.assertTrue(path.endswith(".webp"))
+
+    def test_creates_missing_directory(self):
+        target = os.path.join(self.dir, "uploads")
+        path = save_upload(PNG_BYTES, target, "hapi")
+        self.assertTrue(os.path.isdir(target))
+        self.assertTrue(os.path.isfile(path))
+
+    def test_chowns_dir_and_file_to_owner(self):
+        record = MagicMock()
+        record.pw_uid, record.pw_gid = 1234, 5678
+        # chown only happens in root mode, and pre-existing directories are
+        # deliberately left untouched — save into a missing subdir to exercise
+        # both chowns. They go through fchown on the directory and file fds;
+        # capture the (uid, gid) of each call (fd values are non-deterministic).
+        target = os.path.join(self.dir, "uploads")
+        with patch("ttydproxy.uploads.os.geteuid", return_value=0), patch(
+            "ttydproxy.uploads.pwd.getpwnam", return_value=record
+        ), patch("ttydproxy.uploads.os.fchown") as mock_fchown:
+            save_upload(PNG_BYTES, target, "hapi")
+        owners = {call.args[1:] for call in mock_fchown.call_args_list}
+        self.assertEqual(owners, {(1234, 5678)})
+        # Two chowns: one for the created directory fd, one for the file fd.
+        self.assertEqual(mock_fchown.call_count, 2)
+
+    def test_unknown_owner_still_saves(self):
+        with patch("ttydproxy.uploads.os.geteuid", return_value=0), patch(
+            "ttydproxy.uploads.os.fchown"
+        ) as mock_fchown:
+            path = save_upload(PNG_BYTES, self.dir, "nosuchuser")
+        self.assertTrue(os.path.isfile(path))
+        mock_fchown.assert_not_called()
+
+    def test_chown_permission_error_still_saves(self):
+        record = MagicMock()
+        record.pw_uid, record.pw_gid = 1234, 5678
+        with patch("ttydproxy.uploads.os.geteuid", return_value=0), patch(
+            "ttydproxy.uploads.pwd.getpwnam", return_value=record
+        ), patch("ttydproxy.uploads.os.fchown", side_effect=PermissionError):
+            path = save_upload(PNG_BYTES, self.dir, "hapi")
+        self.assertTrue(os.path.isfile(path))
+
+    def test_nonroot_skips_owner_lookup_and_chown(self):
+        # An unprivileged proxy creates entries with the right owner already;
+        # the passwd lookup and fchown calls must not happen at all.
+        with patch("ttydproxy.uploads.os.geteuid", return_value=1000), patch(
+            "ttydproxy.uploads.pwd.getpwnam"
+        ) as mock_getpwnam, patch("ttydproxy.uploads.os.fchown") as mock_fchown:
+            path = save_upload(PNG_BYTES, self.dir, "hapi")
+        self.assertTrue(os.path.isfile(path))
+        mock_getpwnam.assert_not_called()
+        mock_fchown.assert_not_called()
+
+    def test_rejects_symlinked_upload_dir(self):
+        # An attacker replaces the upload dir with a symlink to another dir;
+        # save_upload must refuse to follow it (no write, no chown escape).
+        victim = os.path.join(self.dir, "victim")
+        os.mkdir(victim)
+        link = os.path.join(self.dir, "uploads")
+        os.symlink(victim, link)
+        with self.assertRaises(OSError):
+            save_upload(PNG_BYTES, link, "hapi")
+        self.assertEqual(os.listdir(victim), [])
+
+    def test_rejects_symlink_planted_as_target_file(self):
+        # Even if the directory itself is real, a symlink planted under the
+        # generated filename must not be followed (O_NOFOLLOW on the file).
+        outside = os.path.join(self.dir, "outside")
+        with open(outside, "wb"):
+            pass
+        fixed_name = "img-20260101-000000-deadbeef.png"
+        os.symlink(outside, os.path.join(self.dir, fixed_name))
+        with patch(
+            "ttydproxy.uploads.secrets.token_hex", return_value="deadbeef"
+        ), patch("ttydproxy.uploads.time.strftime", return_value="20260101-000000"):
+            with self.assertRaises(OSError):
+                save_upload(PNG_BYTES, self.dir, "hapi")
+        # The symlink target outside the intended file must stay empty.
+        self.assertEqual(os.path.getsize(outside), 0)
+
+    def test_rejects_symlinked_existing_ancestor_swapped_in(self):
+        # TOCTOU: the deepest existing ancestor is a real dir when the walk
+        # computes it, but an attacker swaps it for a symlink before the anchor
+        # is opened. The anchor open must use O_NOFOLLOW so the swap is rejected
+        # instead of letting the privileged write/chown escape the tree.
+        victim = os.path.join(self.dir, "victim")
+        os.mkdir(victim)
+        anchor = os.path.join(self.dir, "anchor")
+        os.mkdir(anchor)
+        target = os.path.join(anchor, "uploads")  # missing leaf -> anchor is `anchor`
+
+        real_open = os.open
+        swapped = {"done": False}
+
+        def swapping_open(path, flags, *args, **kwargs):
+            # On the first directory open (the anchor, addressed by path string,
+            # not a dir_fd), perform the swap to simulate the race, then open.
+            if not swapped["done"] and "dir_fd" not in kwargs and path == anchor:
+                swapped["done"] = True
+                os.rmdir(anchor)
+                os.symlink(victim, anchor)
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch("ttydproxy.uploads.os.open", side_effect=swapping_open):
+            with self.assertRaises(OSError):
+                save_upload(PNG_BYTES, target, "hapi")
+        # Nothing must have been written through the symlink into the victim.
+        self.assertEqual(os.listdir(victim), [])
+
+    def test_non_image_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            save_upload(b"plain text", self.dir, "hapi")
+        self.assertEqual(os.listdir(self.dir), [])
+
+    def test_same_second_saves_get_distinct_paths(self):
+        first = save_upload(PNG_BYTES, self.dir, "hapi")
+        second = save_upload(PNG_BYTES, self.dir, "hapi")
+        self.assertNotEqual(first, second)
+
+    def test_concurrent_uploads_into_missing_dir_all_succeed(self):
+        # ThreadingHTTPServer runs one thread per request and the client sends
+        # up to 5 images per gesture; when uploads/ does not exist yet (fresh
+        # container or just cleaned), every thread races to create it. None of
+        # them may fail — the directory creation must tolerate the race. The
+        # race window is tiny, so repeat across fresh dirs to surface it.
+        worker_count = 8
+        errors = []
+        lock = threading.Lock()
+
+        for attempt in range(40):
+            target = os.path.join(self.dir, f"uploads-{attempt}")
+            barrier = threading.Barrier(worker_count)
+
+            def worker():
+                barrier.wait()
+                try:
+                    save_upload(PNG_BYTES, target, "hapi")
+                except OSError as exc:
+                    with lock:
+                        errors.append(f"{type(exc).__name__}: {exc}")
+
+            threads = [threading.Thread(target=worker) for _ in range(worker_count)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            self.assertEqual(
+                len(os.listdir(target)), worker_count, f"attempt {attempt}: lost files"
+            )
+
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_uploads_api.py
+++ b/tests/unit/test_uploads_api.py
@@ -1,0 +1,151 @@
+"""Tests for the POST /upload handler and binary body reading."""
+import io
+import unittest
+from unittest.mock import patch
+
+from tests.unit.handler_stubs import RecordingHandler
+from ttydproxy.config import TTYD_USER, UPLOAD_DIR
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+class TestReadBinaryRequestBody(unittest.TestCase):
+    def _handler(self, body=b"", content_length=None):
+        handler = RecordingHandler()
+        handler.headers = {} if content_length is None else {"Content-Length": content_length}
+        handler.rfile = io.BytesIO(body)
+        return handler
+
+    def test_missing_content_length_returns_empty(self):
+        handler = self._handler(b"ignored")
+        self.assertEqual(handler._read_binary_request_body(100), b"")
+        self.assertIsNone(handler.response)
+
+    def test_invalid_content_length(self):
+        handler = self._handler(content_length="abc")
+        self.assertIsNone(handler._read_binary_request_body(100))
+        self.assertEqual(handler.response, (400, {"error": "Invalid Content-Length"}))
+
+    def test_negative_content_length(self):
+        handler = self._handler(content_length="-1")
+        self.assertIsNone(handler._read_binary_request_body(100))
+        self.assertEqual(handler.response, (413, {"error": "Request too large"}))
+
+    def test_oversized_body(self):
+        handler = self._handler(b"x" * 101, content_length="101")
+        self.assertIsNone(handler._read_binary_request_body(100))
+        self.assertEqual(handler.response, (413, {"error": "Request too large"}))
+
+    def test_body_at_exact_limit(self):
+        handler = self._handler(b"x" * 100, content_length="100")
+        self.assertEqual(handler._read_binary_request_body(100), b"x" * 100)
+
+    def test_returns_raw_bytes(self):
+        handler = self._handler(PNG_BYTES, content_length=str(len(PNG_BYTES)))
+        self.assertEqual(handler._read_binary_request_body(100), PNG_BYTES)
+
+
+class TestHandleUpload(unittest.TestCase):
+    def _handler(self, body):
+        handler = RecordingHandler()
+        handler._read_binary_request_body = lambda max_size: body
+        return handler
+
+    def _assert_rejected_before_body(self, **overrides):
+        """handle_upload must bail before reading the body or saving."""
+        handler = RecordingHandler()
+        for name, stub in overrides.items():
+            setattr(handler, name, stub)
+
+        def fail_read(max_size):
+            self.fail("body must not be read before auth/CSRF pass")
+
+        handler._read_binary_request_body = fail_read
+        with patch("ttydproxy.app.save_upload") as mock_save:
+            handler.handle_upload()
+        mock_save.assert_not_called()
+
+    def test_requires_auth_and_never_reads_body(self):
+        self._assert_rejected_before_body(_check_auth=lambda redirect=False: None)
+
+    def test_requires_csrf(self):
+        self._assert_rejected_before_body(_check_csrf=lambda: False)
+
+    @patch("ttydproxy.app.save_upload")
+    def test_body_error_already_responded(self, mock_save):
+        handler = self._handler(None)
+        handler.handle_upload()
+        self.assertIsNone(handler.response)
+        mock_save.assert_not_called()
+
+    @patch("ttydproxy.app.save_upload")
+    def test_empty_body(self, mock_save):
+        handler = self._handler(b"")
+        handler.handle_upload()
+        self.assertEqual(handler.response, (400, {"error": "Empty upload"}))
+        mock_save.assert_not_called()
+
+    @patch("ttydproxy.app.save_upload", side_effect=ValueError("Unsupported image type"))
+    def test_non_image_rejected(self, mock_save):
+        # save_upload is the single validator; its ValueError maps to 415.
+        handler = self._handler(b"not an image")
+        handler.handle_upload()
+        self.assertEqual(handler.response, (415, {"error": "Unsupported image type"}))
+
+    @patch("ttydproxy.app.save_upload")
+    def test_valid_png_saved(self, mock_save):
+        mock_save.return_value = "/home/hapi/uploads/img-20260611-120000-deadbeef.png"
+        handler = self._handler(PNG_BYTES)
+        handler.handle_upload()
+        self.assertEqual(
+            handler.response,
+            (201, {"path": "/home/hapi/uploads/img-20260611-120000-deadbeef.png"}),
+        )
+        mock_save.assert_called_once_with(PNG_BYTES, UPLOAD_DIR, TTYD_USER)
+
+    @patch("ttydproxy.app.save_upload", side_effect=OSError("disk full"))
+    def test_save_failure(self, mock_save):
+        handler = self._handler(PNG_BYTES)
+        handler.handle_upload()
+        self.assertEqual(handler.response, (500, {"error": "Failed to save upload"}))
+
+
+class TestUploadRouting(unittest.TestCase):
+    def test_post_upload_dispatches_to_handler(self):
+        handler = RecordingHandler()
+        handler.path = "/upload"
+        called = []
+        handler.handle_upload = lambda: called.append(True)
+        handler.do_POST()
+        self.assertEqual(called, [True])
+
+
+class TestTerminalPageCsrfRefresh(unittest.TestCase):
+    """handle_ttyd must refresh the csrf_token cookie so long-lived terminal
+    tabs can keep uploading images after the original token expires."""
+
+    @patch("ttydproxy.app.render_terminal_page", return_value="<html></html>")
+    @patch("ttydproxy.app.ttyd_manager")
+    def test_terminal_page_sets_csrf_cookie(self, mock_manager, _mock_render):
+        mock_manager.get_terminal.return_value = {"id": 1, "port": 7681}
+        handler = RecordingHandler()
+        handler.path = "/ttyd1"
+        captured = {}
+
+        def record_html(status, html, extra_headers=None, csp=None):
+            captured["status"] = status
+            captured["extra_headers"] = extra_headers
+
+        handler.send_html = record_html
+        handler.handle_ttyd(1)
+
+        self.assertEqual(captured["status"], 200)
+        headers = captured["extra_headers"] or {}
+        self.assertTrue(
+            headers.get("Set-Cookie", "").startswith("csrf_token="),
+            f"csrf_token cookie not refreshed: {headers}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_verify_pam_password.py
+++ b/tests/unit/test_verify_pam_password.py
@@ -10,13 +10,17 @@ from ttydproxy import security
 VALID_HASH = "$6$saltsalt$hashedpasswordvalue"
 
 
-def _fake_modules(password_hash, crypt_func):
+def _fake_modules(password_hash, crypt_func, getspnam_error=None):
     """Build fake spwd/crypt modules for sys.modules injection.
 
     password_hash=None simulates a missing shadow entry (getspnam raises
-    KeyError), which sends verify_pam_password down the su fallback path.
+    KeyError); getspnam_error simulates an unreadable /etc/shadow (e.g.
+    PermissionError under an unprivileged proxy). Both send
+    verify_pam_password down the su fallback path.
     """
     def getspnam(username):
+        if getspnam_error is not None:
+            raise getspnam_error
         if password_hash is None:
             raise KeyError(username)
         return SimpleNamespace(sp_pwdp=password_hash)
@@ -54,15 +58,34 @@ class VerifyPamPasswordTest(unittest.TestCase):
     def test_crypt_returning_none_rejected(self):
         self.assertFalse(self._verify(VALID_HASH, lambda password, salt: None))
 
-    def test_missing_shadow_entry_falls_back_to_su(self):
-        su_result = SimpleNamespace(returncode=0)
-        with mock.patch.dict(sys.modules, _fake_modules(None, mock.Mock())):
+    def _su_fallback(self, modules, su_returncode):
+        """Run verify_pam_password with mocked su; assert su was consulted."""
+        su_result = SimpleNamespace(returncode=su_returncode)
+        with mock.patch.dict(sys.modules, modules):
             with mock.patch.object(security, "user_exists", return_value=True):
                 with mock.patch.object(
                     security.subprocess, "run", return_value=su_result
                 ) as run_mock:
-                    self.assertTrue(security.verify_pam_password("hapi", "secret"))
+                    result = security.verify_pam_password("hapi", "secret")
         run_mock.assert_called_once()
+        return result
+
+    def test_missing_shadow_entry_falls_back_to_su(self):
+        self.assertTrue(self._su_fallback(_fake_modules(None, mock.Mock()), 0))
+
+    def test_unreadable_shadow_falls_back_to_su(self):
+        # Unprivileged proxy: spwd.getspnam raises PermissionError (EACCES on
+        # /etc/shadow); the su fallback must take over instead of crashing.
+        modules = _fake_modules(
+            None, mock.Mock(), getspnam_error=PermissionError(13, "Permission denied")
+        )
+        self.assertTrue(self._su_fallback(modules, 0))
+
+    def test_unreadable_shadow_su_rejects_wrong_password(self):
+        modules = _fake_modules(
+            None, mock.Mock(), getspnam_error=PermissionError(13, "Permission denied")
+        )
+        self.assertFalse(self._su_fallback(modules, 1))
 
     def test_unknown_user_rejected(self):
         with mock.patch.object(security, "user_exists", return_value=False):

--- a/tests/unit/test_vkbd_html.py
+++ b/tests/unit/test_vkbd_html.py
@@ -24,11 +24,19 @@ class TestVKBDEnabled(unittest.TestCase):
         self.assertIn('class="vkbd-bottom"', self.html)
 
     def test_mobile_styles_present(self):
-        self.assertIn("@media (max-width: 768px)", self.html)
+        self.assertIn("body.vkbd-open .vkbd", self.html)
         self.assertIn("touch-action: manipulation", self.html)
         self.assertIn("overflow: hidden", self.html)
         self.assertIn("overscroll-behavior: none", self.html)
         self.assertIn("touch-action: none", self.html)
+
+    def test_toggle_button_present(self):
+        self.assertIn('id="vkbd-toggle"', self.html)
+        self.assertIn('aria-label="Toggle virtual keyboard"', self.html)
+        self.assertIn("clihost:vkbd-open", self.html)
+        self.assertIn("dispatchEvent(new Event('resize'))", self.html)
+        # Static keyboard height was replaced by flex-driven layout.
+        self.assertNotIn("calc(100vh - 140px)", self.html)
 
     def test_updated_javascript_present(self):
         self.assertIn("function sendKey(key)", self.html)
@@ -54,7 +62,7 @@ class TestVKBDDisabled(unittest.TestCase):
         html = render_terminal_page(1, "testuser", vkbd_enabled=False)
         self.assertNotIn('id="vkbd"', html)
         self.assertNotIn("navigator.clipboard.readText()", html)
-        self.assertNotIn("@media (max-width: 768px)", html)
+        self.assertNotIn('id="vkbd-toggle"', html)
         self.assertIn('src="/ttyd1/"', html)
 
 


### PR DESCRIPTION
Closes #32

## Summary

- **Image upload via paste/drop**: paste or drop images into the web terminal; they upload to `POST /upload` (CSRF-protected, validated by magic bytes — png/jpg/gif/webp, SVG rejected) and the saved paths are typed into the prompt in order. Non-image files are silently skipped; plain text keeps its native paste path.
- **Virtual keyboard toggle** (closes #32): a small floating ⌨ button in the top-right corner raises/lowers the virtual keyboard on any device, including desktop. Mobile (≤768px) defaults to open, desktop to closed; an explicit choice persists in `localStorage`. Keyboard visibility is now driven by a `body.vkbd-open` class + flex layout (the static `calc(100vh - 140px)` media query is gone), and the terminal iframe receives a synthetic `resize` event so xterm re-fits after a toggle. The button only renders when the keyboard asset is enabled (`VIRTUAL_KEYBOARD`/`?vkbd=`).

## Environment variables

- `MAX_UPLOAD_SIZE` — image upload size limit, bytes (default: 10485760 = 10 MB)
- `UPLOAD_DIR` — where pasted/dropped terminal images are saved (default: `CLEANUP_ROOT/.uploads`)

## Ports & volumes

No changes.

## Testing

- `python -m pytest tests/` — 201 passed (incl. new upload and vkbd-toggle assertions)
- Visual check of `tests/preview/vkbd_preview.html`: toggle button, open/closed states, active accent
- Note for smoke test: worth verifying on iOS Safari that the bottom keyboard row isn't hidden behind the toolbar now that the static body height is gone (if it is, the fix is `100dvh` in terminal.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)