### PR TITLE
[codex] add droid agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # CLI_API_TOKEN=            # Required if HAPI_RUNNER_ENABLED=true
 # HAPI_API_URL=             # Required if HAPI_RUNNER_ENABLED=true
 
+# Droid daemon (optional remote access)
+DROID_DAEMON_ENABLED=false  # Set to 'true' to start `droid daemon --remote-access`
+
 # TTYD Configuration
 PORT=8080                   # Порт HTTP прокси (>= 1024 — прокси работает без root)
 TTYD_USER=hapi              # Пользователь для терминала (под ним же работает прокси)

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 
 # Droid daemon (optional remote access)
 DROID_DAEMON_ENABLED=false  # Set to 'true' to start `droid daemon --remote-access`
+# DROID_COMPUTER_NAME=clihost  # Required when DROID_DAEMON_ENABLED=true; used for non-interactive registration
 
 # TTYD Configuration
 PORT=8080                   # Порт HTTP прокси (>= 1024 — прокси работает без root)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Docker container running hapi CLI runner alongside OpenSSH server, bundling AI C
 - `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)
 - `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**; runs unprivileged as `TTYD_USER` (entrypoint drops root via `runuser`)
 - `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
-- `droid daemon --remote-access` — always starts as `hapi`; logs to `/home/hapi/.hapi/droid-daemon.log`
+- `droid daemon --remote-access` — optional remote-access gateway; starts as `hapi` only when `DROID_DAEMON_ENABLED=true`; logs to `/home/hapi/.hapi/droid-daemon.log`
 - `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
 - `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
 
@@ -67,7 +67,7 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 
@@ -137,7 +137,9 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 - `CLI_API_TOKEN`, `HAPI_API_URL` — required if runner enabled
 - `HAPI_HOST` (default: 0.0.0.0), `HAPI_PORT` (default: 80), `HAPI_USER` (default: hapi)
 
-**Other:** `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
+**Other:**
+- `DROID_DAEMON_ENABLED` — set `true` to start `droid daemon --remote-access` at container start (default: false)
+- `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
 
 Update `.env.example` when adding/changing variables.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Docker container running hapi CLI runner alongside OpenSSH server, bundling AI C
 - `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)
 - `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**; runs unprivileged as `TTYD_USER` (entrypoint drops root via `runuser`)
 - `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
-- `droid daemon --remote-access` — optional remote-access gateway; starts as `hapi` only when `DROID_DAEMON_ENABLED=true`; logs to `/home/hapi/.hapi/droid-daemon.log`
+- `droid daemon --remote-access` — optional remote-access gateway; starts as `hapi` only when `DROID_DAEMON_ENABLED=true`; requires `DROID_COMPUTER_NAME` for non-interactive `droid computer register <name> -y`; logs to `/home/hapi/.hapi/droid-daemon.log`
 - `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
 - `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
 
@@ -139,6 +139,7 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 
 **Other:**
 - `DROID_DAEMON_ENABLED` — set `true` to start `droid daemon --remote-access` at container start (default: false)
+- `DROID_COMPUTER_NAME` — required when `DROID_DAEMON_ENABLED=true`; limited to letters, numbers, dots, underscores, and dashes; used for non-interactive registration before daemon startup
 - `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
 
 Update `.env.example` when adding/changing variables.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,13 @@ python -m pytest tests/ -k "test_truthy_1"       # single test by name
 
 ## Architecture
 
-Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Hermes Agent), with an integrated multi-terminal web UI (TTYD).
+Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Droid, Hermes Agent), with an integrated multi-terminal web UI (TTYD).
 
 **Multi-process layout:**
 - `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)
 - `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**; runs unprivileged as `TTYD_USER` (entrypoint drops root via `runuser`)
 - `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
+- `droid daemon --remote-access` — always starts as `hapi`; logs to `/home/hapi/.hapi/droid-daemon.log`
 - `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
 - `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
 
@@ -66,7 +67,7 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ADD https://registry.npmjs.org/@openai/codex/latest /tmp/npm-manifests/codex.jso
 ADD https://registry.npmjs.org/@google/gemini-cli/latest /tmp/npm-manifests/gemini-cli.json
 ADD https://registry.npmjs.org/@github/copilot/latest /tmp/npm-manifests/copilot.json
 ADD https://registry.npmjs.org/opencode-ai/latest /tmp/npm-manifests/opencode-ai.json
+ADD https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json
 ADD https://registry.npmjs.org/@twsxtd/hapi/latest /tmp/npm-manifests/hapi.json
 
 COPY cli-packages.txt /tmp/cli-packages.txt

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ hapi Client               → hapi runner (80)     → CLI tools
 | `sshd` | 22 | SSH-доступ, main-процесс контейнера |
 | `ttyd_proxy.py` | 8080 | Multithreaded HTTP/WS прокси с аутентификацией |
 | `ttyd` | 127.0.0.1:768x | Web-терминал (по одному на сессию, только localhost) |
-| `droid daemon --remote-access` | — | Droid gateway, logs to `/home/hapi/.hapi/droid-daemon.log` |
+| `droid daemon --remote-access` | — | Optional Droid gateway, logs to `/home/hapi/.hapi/droid-daemon.log` |
 | `hapi runner` | `HAPI_PORT` (default 80) | Запуск CLI-инструментов по API (опционально) |
 | `hapi server --relay` | — | Туннель для внешнего доступа |
 
@@ -90,6 +90,7 @@ Terminal iframe page и связанные JS/CSS-ассеты лежат в `ap
 | `TTYD_PASSWORD` | - | Global password for web terminal (uses system passwords if not set) |
 | `PASSWORD_SECRET` | auto | Secret for session signatures (auto-generated if not set) |
 | `ROOT_PASSWORD` | - | Enable root SSH access with this password |
+| `DROID_DAEMON_ENABLED` | false | Start `droid daemon --remote-access` for Droid remote access |
 
 ### Hapi Runner (Optional)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Terminal iframe page и связанные JS/CSS-ассеты лежат в `ap
 | `PASSWORD_SECRET` | auto | Secret for session signatures (auto-generated if not set) |
 | `ROOT_PASSWORD` | - | Enable root SSH access with this password |
 | `DROID_DAEMON_ENABLED` | false | Start `droid daemon --remote-access` for Droid remote access |
+| `DROID_COMPUTER_NAME` | - | Required when `DROID_DAEMON_ENABLED=true`; used for non-interactive `droid computer register <name> -y` |
 
 ### Hapi Runner (Optional)
 
@@ -125,6 +126,16 @@ docker run -p 22:22 -p 8080:8080 \
   -e HAPI_RUNNER_ENABLED=true \
   -e CLI_API_TOKEN=your_token \
   -e HAPI_API_URL=https://your-server.com \
+  clihost
+```
+
+With Droid remote access:
+
+```bash
+docker run -p 22:22 -p 8080:8080 \
+  -e DROID_DAEMON_ENABLED=true \
+  -e DROID_COMPUTER_NAME=clihost \
+  -v "$(pwd)/volume/hapi:/home/hapi" \
   clihost
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clihost
 
-Docker container with web terminal (TTYD) and AI CLI tools (Claude Code, Codex, Gemini CLI). The web terminal proxy uses a multithreaded HTTP server — concurrent connections do not block each other.
+Docker container with web terminal (TTYD) and AI CLI tools (Claude Code, Codex, Gemini CLI, Droid). The web terminal proxy uses a multithreaded HTTP server — concurrent connections do not block each other.
 
 ## Quick Start
 
@@ -51,6 +51,7 @@ hapi Client               → hapi runner (80)     → CLI tools
 | `sshd` | 22 | SSH-доступ, main-процесс контейнера |
 | `ttyd_proxy.py` | 8080 | Multithreaded HTTP/WS прокси с аутентификацией |
 | `ttyd` | 127.0.0.1:768x | Web-терминал (по одному на сессию, только localhost) |
+| `droid daemon --remote-access` | — | Droid gateway, logs to `/home/hapi/.hapi/droid-daemon.log` |
 | `hapi runner` | `HAPI_PORT` (default 80) | Запуск CLI-инструментов по API (опционально) |
 | `hapi server --relay` | — | Туннель для внешнего доступа |
 

--- a/cli-packages.txt
+++ b/cli-packages.txt
@@ -3,5 +3,5 @@
 @google/gemini-cli@latest
 @github/copilot@latest
 opencode-ai@latest
+droid@latest
 @twsxtd/hapi@latest
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ fi
 : "${HAPI_API_URL:=}"
 : "${HAPI_RUNNER_ENABLED:=false}"
 : "${DROID_DAEMON_ENABLED:=false}"
+: "${DROID_COMPUTER_NAME:=}"
 : "${ROOT_PASSWORD:=}"
 
 HAPI_USER="${HAPI_USER:-hapi}"
@@ -106,6 +107,23 @@ ensure_dir_owned "${HAPI_HOME}"
 # Start Droid daemon with remote access in background
 if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
   if PATH="${HAPI_RUN_PATH}" command -v droid >/dev/null 2>&1; then
+    if [ -z "${DROID_COMPUTER_NAME}" ]; then
+      echo "ERROR: DROID_DAEMON_ENABLED=true requires DROID_COMPUTER_NAME for non-interactive registration" >&2
+      exit 1
+    fi
+    case "${DROID_COMPUTER_NAME}" in
+      *[!A-Za-z0-9_.-]*)
+        echo "ERROR: DROID_COMPUTER_NAME may only contain letters, numbers, dot, underscore, and dash" >&2
+        exit 1
+        ;;
+    esac
+
+    echo "Registering Droid computer '${DROID_COMPUTER_NAME}'..."
+    if ! run_as_hapi "droid computer register \"${DROID_COMPUTER_NAME}\" -y 2>&1"; then
+      echo "ERROR: Droid computer registration failed; daemon not started" >&2
+      exit 1
+    fi
+
     DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"
     touch "${DROID_DAEMON_LOG}"
     chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ fi
 : "${CLI_API_TOKEN:=}"
 : "${HAPI_API_URL:=}"
 : "${HAPI_RUNNER_ENABLED:=false}"
+: "${DROID_DAEMON_ENABLED:=false}"
 : "${ROOT_PASSWORD:=}"
 
 HAPI_USER="${HAPI_USER:-hapi}"
@@ -103,16 +104,20 @@ fi
 ensure_dir_owned "${HAPI_HOME}"
 
 # Start Droid daemon with remote access in background
-DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"
-touch "${DROID_DAEMON_LOG}"
-chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"
-if PATH="${HAPI_RUN_PATH}" command -v droid >/dev/null 2>&1; then
-  echo "Starting droid daemon --remote-access in background (logs: ${DROID_DAEMON_LOG})..."
-  run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \"${DROID_DAEMON_LOG}\"" &
-  DROID_DAEMON_PID=$!
-  echo "Droid daemon started with PID: ${DROID_DAEMON_PID}"
+if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
+  if PATH="${HAPI_RUN_PATH}" command -v droid >/dev/null 2>&1; then
+    DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"
+    touch "${DROID_DAEMON_LOG}"
+    chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"
+    echo "Starting droid daemon --remote-access in background (logs: ${DROID_DAEMON_LOG})..."
+    run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \"${DROID_DAEMON_LOG}\"" &
+    DROID_DAEMON_PID=$!
+    echo "Droid daemon started with PID: ${DROID_DAEMON_PID}"
+  else
+    echo "droid CLI not found; skipping droid daemon startup" >&2
+  fi
 else
-  echo "droid CLI not found; skipping droid daemon startup" >&2
+  echo "Droid daemon disabled (set DROID_DAEMON_ENABLED=true to enable remote access)"
 fi
 
 # Start TTYD HTTP proxy (manages TTYD processes dynamically; drops root and

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,6 +100,21 @@ if [ "${HERMES_AUTO_UPDATE:-true}" != "false" ] && command -v hermes &>/dev/null
   fi
 fi
 
+ensure_dir_owned "${HAPI_HOME}"
+
+# Start Droid daemon with remote access in background
+DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"
+touch "${DROID_DAEMON_LOG}"
+chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"
+if PATH="${HAPI_RUN_PATH}" command -v droid >/dev/null 2>&1; then
+  echo "Starting droid daemon --remote-access in background (logs: ${DROID_DAEMON_LOG})..."
+  run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \"${DROID_DAEMON_LOG}\"" &
+  DROID_DAEMON_PID=$!
+  echo "Droid daemon started with PID: ${DROID_DAEMON_PID}"
+else
+  echo "droid CLI not found; skipping droid daemon startup" >&2
+fi
+
 # Start TTYD HTTP proxy (manages TTYD processes dynamically; drops root and
 # runs as TTYD_USER). The secret goes through a TTYD_USER-only file (Docker
 # *_FILE convention) so it never appears in the proxy's /proc/<pid>/environ.
@@ -133,7 +148,6 @@ runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
 
 # Start hapi server with relay in background (logs to file, force TCP relay)
 HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
-ensure_dir_owned "${HAPI_HOME}"
 # Pre-create the log so the URL-extraction loop's -f check passes immediately
 touch "${HAPI_SERVER_LOG}"
 chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -75,6 +75,8 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertLess(touch_pos, server_start_pos)
 
     def test_droid_daemon_started_as_hapi_with_log(self):
+        self.assertIn(': "${DROID_DAEMON_ENABLED:=false}"', self.text)
+        self.assertIn('[ "${DROID_DAEMON_ENABLED}" = "true" ]', self.text)
         self.assertIn('DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"', self.text)
         self.assertIn('PATH="${HAPI_RUN_PATH}" command -v droid', self.text)
         self.assertIn(

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -76,7 +76,10 @@ class TestEntrypointRegressions(unittest.TestCase):
 
     def test_droid_daemon_started_as_hapi_with_log(self):
         self.assertIn(': "${DROID_DAEMON_ENABLED:=false}"', self.text)
+        self.assertIn(': "${DROID_COMPUTER_NAME:=}"', self.text)
         self.assertIn('[ "${DROID_DAEMON_ENABLED}" = "true" ]', self.text)
+        self.assertIn("DROID_DAEMON_ENABLED=true requires DROID_COMPUTER_NAME", self.text)
+        self.assertIn('droid computer register \\"${DROID_COMPUTER_NAME}\\" -y', self.text)
         self.assertIn('DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"', self.text)
         self.assertIn('PATH="${HAPI_RUN_PATH}" command -v droid', self.text)
         self.assertIn(

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -7,6 +7,8 @@ import unittest
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 ENTRYPOINT = REPO_ROOT / "entrypoint.sh"
 BUILD_SH = REPO_ROOT / "build.sh"
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+CLI_PACKAGES = REPO_ROOT / "cli-packages.txt"
 
 
 class TestShellSyntax(unittest.TestCase):
@@ -71,6 +73,25 @@ class TestEntrypointRegressions(unittest.TestCase):
         server_start_pos = self.text.find("hapi server --relay 2>&1")
         self.assertGreater(touch_pos, -1, "HAPI_SERVER_LOG is not pre-created")
         self.assertLess(touch_pos, server_start_pos)
+
+    def test_droid_daemon_started_as_hapi_with_log(self):
+        self.assertIn('DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"', self.text)
+        self.assertIn('PATH="${HAPI_RUN_PATH}" command -v droid', self.text)
+        self.assertIn(
+            'run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \\"${DROID_DAEMON_LOG}\\"" &',
+            self.text,
+        )
+
+
+class TestDockerPackageRegressions(unittest.TestCase):
+    def test_droid_package_is_installed_and_cache_busted(self):
+        packages = CLI_PACKAGES.read_text()
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn("droid@latest", packages)
+        self.assertIn(
+            "https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json",
+            dockerfile,
+        )
 
 
 class TestBuildShRegressions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `droid@latest` to the bundled npm CLI package list and Docker cache-busting manifests.
- Start `droid daemon --remote-access` as the `hapi` user during container startup, logging to `${HAPI_HOME}/droid-daemon.log`.
- Document the Droid process and add static regression coverage for package wiring and startup behavior.

## Validation
- `bash -n entrypoint.sh build.sh`
- `python -m pytest tests/unit/test_shell_scripts.py`
- `python3 -m pytest tests/unit/`