### PR TITLE
feat: optional bubblewrap sandbox for terminal sessions (TTYD_SANDBOX)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,15 @@ MAX_TERMINALS=100           # Максимальное количество те
 MAX_UPLOAD_SIZE=10485760    # Лимит размера загружаемого изображения в байтах (по умолчанию 10 МБ)
 # UPLOAD_DIR=/home/hapi/.uploads  # Каталог для вставленных в терминал изображений (по умолчанию CLEANUP_ROOT/.uploads)
 
+# Sandbox (optional, multi-tenant isolation)
+TTYD_SANDBOX=false          # 'true' — каждую tmux-сессию запускать в bubblewrap (bwrap) джейле:
+                            #   изоляция per-user /home, системные каталоги read-only.
+                            #   Для мультитенантных деплоев (каждый терминал под своим Linux-юзером).
+                            #   ТРЕБУЕТ запуска контейнера с  --security-opt seccomp=unconfined
+                            #   (дефолтный seccomp Docker блокирует clone(CLONE_NEW*), bwrap падает).
+                            #   Сеть НЕ изолируется (AI CLI нужен интернет). FAIL-CLOSED: если bwrap
+                            #   не стартовал — терминал не открывается (без отката к неизолированному).
+
 # Locale/Encoding Configuration (UTF-8 is required for proper international character support)
 LANG=en_US.UTF-8            # Primary locale (set in Dockerfile, override only if needed)
 LC_ALL=en_US.UTF-8          # Override all locale settings (set in Dockerfile)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Docker container running hapi CLI runner alongside OpenSSH server, bundling AI C
 
 **Data flow:**
 ```
-Browser → HTTP/WS → ttyd_proxy (8080) → ttyd (127.0.0.1:768x) → tmux-wrapper → shell
+Browser → HTTP/WS → ttyd_proxy (8080) → ttyd (127.0.0.1:768x) → tmux-wrapper → [bwrap jail if TTYD_SANDBOX=true] → shell
 SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
@@ -141,6 +141,24 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 - `DROID_DAEMON_ENABLED` — set `true` to start `droid daemon --remote-access` at container start (default: false)
 - `DROID_COMPUTER_NAME` — required when `DROID_DAEMON_ENABLED=true`; limited to letters, numbers, dots, underscores, and dashes; used for non-interactive registration before daemon startup
 - `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
+
+**Sandbox (optional):**
+- `TTYD_SANDBOX` — set `true` to launch each tmux session inside a bubblewrap (bwrap)
+  jail (default: false). Isolates per-user `/home` (other users' homes are invisible),
+  makes system dirs read-only. Intended for multi-tenant forks (e.g. clihost_cloud) where
+  each terminal runs as a different Linux user via `runuser`. **REQUIRES** the container to
+  start with `--security-opt seccomp=unconfined` — Docker's default seccomp blocks the
+  `clone(CLONE_NEW*)` syscalls bwrap needs, so without it the jail fails at namespace
+  creation. On Dokku: `dokku docker-options:add <app> deploy,run "--security-opt seccomp=unconfined"`.
+  Behavior is **fail-closed**: if `TTYD_SANDBOX=true` but the jail can't start, the terminal
+  does not open (it never falls back to an unsandboxed shell). The jail does NOT unshare the
+  network (AI CLIs need it) and inherits `/proc` read-only, so filesystem isolation is complete
+  but process hiding is not (host PIDs stay visible via `/proc/{pid}`; a later `hidepid` concern).
+  Cleanup note: when sandboxed, `manager.py`'s `tmux kill-session` becomes a no-op (the jailed
+  tmux uses a socket under `$HOME/.cache/tmux/`, not the default one); the real lifecycle
+  guarantee is `--die-with-parent`, and the orphaned tmux server is harmlessly reattached on
+  reconnect. Known limitation: a future nested bwrap (e.g. codex's own sandbox) breaks under the
+  outer `--unshare-user`; codex does not invoke bwrap today.
 
 Update `.env.example` when adding/changing variables.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN NODE_VERSION="22.14.0" && \
       exit 1; \
     fi && \
     apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl gh git openssh-server python3-pip python3-venv tini tmux util-linux xz-utils && \
+    apt-get install -y --no-install-recommends bubblewrap ca-certificates curl gh git openssh-server python3-pip python3-venv tini tmux util-linux xz-utils && \
     curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
     tar -xJf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -C /usr/local --strip-components=1 --no-same-owner && \
     rm "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Terminal iframe page и связанные JS/CSS-ассеты лежат в `ap
 | `ROOT_PASSWORD` | - | Enable root SSH access with this password |
 | `DROID_DAEMON_ENABLED` | false | Start `droid daemon --remote-access` for Droid remote access |
 | `DROID_COMPUTER_NAME` | - | Required when `DROID_DAEMON_ENABLED=true`; used for non-interactive `droid computer register <name> -y` |
+| `TTYD_SANDBOX` | false | Wrap each tmux session in a bubblewrap jail (see Multi-tenant sandbox below) |
+
+### Multi-tenant sandbox (optional)
+
+`TTYD_SANDBOX=true` launches every tmux session inside a [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) jail so that, in multi-tenant deployments where each terminal runs as a different Linux user, users can't read each other's `/home/*` and system directories are read-only. It is **off by default** — single-user clihost is unchanged.
+
+The jail **requires** the container to run with `--security-opt seccomp=unconfined` (Docker's default seccomp profile blocks the namespace syscalls bwrap needs). On Dokku:
+
+```bash
+dokku docker-options:add <app> deploy,run "--security-opt seccomp=unconfined"
+```
+
+The jail keeps network access (AI CLIs need it) and is **fail-closed**: if it can't start, the terminal doesn't open rather than falling back to an unsandboxed shell.
 
 ### Hapi Runner (Optional)
 

--- a/bin/tmux-wrapper.sh
+++ b/bin/tmux-wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # tmux-wrapper.sh - Присоединяется к существующей tmux сессии или создаёт новую
 # Обеспечивает постоянные сессии при переподключении к терминалу
 #
@@ -34,7 +35,7 @@ if [ "${TTYD_SANDBOX}" = "true" ]; then
   # bwrap падает, если SOURCE у --ro-bind отсутствует ("Can't find source path"),
   # поэтому каждый системный путь биндим только если он существует.
   binds=()
-  for p in /usr /bin /sbin /lib /lib64 /etc /usr/local; do
+  for p in /usr /bin /sbin /lib /lib64 /etc; do
     [ -e "$p" ] && binds+=(--ro-bind "$p" "$p")
   done
 

--- a/bin/tmux-wrapper.sh
+++ b/bin/tmux-wrapper.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 # tmux-wrapper.sh - Присоединяется к существующей tmux сессии или создаёт новую
 # Обеспечивает постоянные сессии при переподключении к терминалу
+#
+# Когда TTYD_SANDBOX=true, tmux-сессия запускается внутри bubblewrap (bwrap)
+# джейла: в мультитенантных деплоях (где каждый терминал запускается под своим
+# Linux-юзером) пользователи не видят чужие /home/* и не могут писать в систему.
+# По умолчанию (TTYD_SANDBOX не задан/false) поведение байт-в-байт как раньше.
+#
+# Требование для джейла: контейнер должен быть запущен с
+#   --security-opt seccomp=unconfined
+# иначе bwrap падает на создании namespace. Режим FAIL-CLOSED: если bwrap не
+# стартует, терминал не открывается (отката к неизолированному терминалу нет).
+# Очистка сессии (manager.py kill-session) при джейле становится no-op —
+# жизненный цикл держит --die-with-parent; осиротевший tmux-сервер безвреден и
+# переиспользуется при следующем переподключении (тот же сокет под $HOME).
 
 # Ensure UTF-8 encoding
 export LANG=en_US.UTF-8
@@ -8,6 +21,37 @@ export LC_ALL=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
 
 SESSION_NAME="${1:-ttyd-$(whoami)}"
+: "${TTYD_SANDBOX:=false}"
+
+if [ "${TTYD_SANDBOX}" = "true" ]; then
+  # Per-jail /tmp — свежий tmpfs, поэтому дефолтный сокет tmux (/tmp/tmux-UID/
+  # default) не переживает пере-запуск ttyd и `new-session -A` не находит старый
+  # сервер. Кладём сокет под bind-примонтированный $HOME (тот же inode внутри и
+  # снаружи джейла) — он переживает переподключения.
+  TMUX_SOCK="${HOME}/.cache/tmux/clihost.sock"
+  mkdir -p "${HOME}/.cache/tmux"
+
+  # bwrap падает, если SOURCE у --ro-bind отсутствует ("Can't find source path"),
+  # поэтому каждый системный путь биндим только если он существует.
+  binds=()
+  for p in /usr /bin /sbin /lib /lib64 /etc /usr/local; do
+    [ -e "$p" ] && binds+=(--ro-bind "$p" "$p")
+  done
+
+  # Сеть НЕ изолируем (нет unshare сетевого namespace): AI CLI
+  # (claude-code/codex/gemini) нужен доступ в интернет.
+  # --unshare-user обязателен для непривилегированного запуска.
+  # /proc наследуем read-only (свежий --proc не монтируется в части окружений):
+  # файловая изоляция полная, скрытие чужих процессов — нет.
+  exec bwrap \
+    "${binds[@]}" \
+    --ro-bind /proc /proc \
+    --bind "$HOME" "$HOME" \
+    --dev /dev --tmpfs /tmp --tmpfs /run \
+    --unshare-user --unshare-pid --unshare-ipc \
+    --die-with-parent \
+    -- tmux -S "${TMUX_SOCK}" new-session -A -s "$SESSION_NAME" -c "$HOME"
+fi
 
 # -A attaches when the session already exists; the tmux server serializes
 # session creation, so simultaneous clients cannot race each other.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@ fi
 : "${DROID_DAEMON_ENABLED:=false}"
 : "${DROID_COMPUTER_NAME:=}"
 : "${ROOT_PASSWORD:=}"
+: "${TTYD_SANDBOX:=false}"
 
 HAPI_USER="${HAPI_USER:-hapi}"
 HAPI_USER_HOME="/home/${HAPI_USER}"
@@ -186,6 +187,7 @@ TTYD_PASSWORD="${TTYD_PASSWORD}" \
 PASSWORD_SECRET_FILE="${PROXY_SECRET_FILE}" \
 CLEANUP_ROOT="${CLEANUP_ROOT}" \
 HAPI_HOME="${HAPI_HOME}" \
+TTYD_SANDBOX="${TTYD_SANDBOX}" \
 runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
 
 # Start hapi server with relay in background (logs to file, force TCP relay)

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -9,11 +9,12 @@ ENTRYPOINT = REPO_ROOT / "entrypoint.sh"
 BUILD_SH = REPO_ROOT / "build.sh"
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 CLI_PACKAGES = REPO_ROOT / "cli-packages.txt"
+TMUX_WRAPPER = REPO_ROOT / "bin/tmux-wrapper.sh"
 
 
 class TestShellSyntax(unittest.TestCase):
     def test_scripts_parse(self):
-        for script in (ENTRYPOINT, BUILD_SH):
+        for script in (ENTRYPOINT, BUILD_SH, TMUX_WRAPPER):
             with self.subTest(script=script.name):
                 result = subprocess.run(
                     ["bash", "-n", str(script)], capture_output=True, text=True
@@ -106,8 +107,74 @@ class TestEntrypointRegressions(unittest.TestCase):
             self.text,
         )
 
+    def test_sandbox_flag_passed_to_proxy(self):
+        # tmux-wrapper.sh only sees TTYD_SANDBOX if the entrypoint defaults it
+        # and adds it to the proxy's runuser env block (a closed allow-list);
+        # the proxy then inherits it down to the ttyd -> tmux-wrapper child.
+        self.assertIn(': "${TTYD_SANDBOX:=false}"', self.text)
+        self.assertIn('TTYD_SANDBOX="${TTYD_SANDBOX}"', self.text)
+
+
+class TestTmuxWrapperSandboxRegressions(unittest.TestCase):
+    def setUp(self):
+        self.text = TMUX_WRAPPER.read_text()
+
+    def test_sandbox_default_off(self):
+        # Single-user clihost stays unchanged unless explicitly opted in.
+        self.assertIn(': "${TTYD_SANDBOX:=false}"', self.text)
+
+    def test_sandbox_is_flag_gated(self):
+        self.assertIn('if [ "${TTYD_SANDBOX}" = "true" ]', self.text)
+
+    def test_default_path_is_byte_for_byte_original(self):
+        # The flag-off exec must be the original jail-free tmux launch AND the
+        # last line of the file (so the gated branch never shadows it).
+        last_exec = self.text.rstrip().splitlines()[-1]
+        self.assertEqual(
+            last_exec.strip(),
+            'exec tmux new-session -A -s "$SESSION_NAME" -c "$HOME"',
+        )
+
+    def test_sandbox_uses_bwrap(self):
+        self.assertIn("exec bwrap", self.text)
+
+    def test_required_unshare_flags_present(self):
+        for flag in ("--unshare-user", "--unshare-pid", "--unshare-ipc",
+                     "--die-with-parent"):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, self.text)
+
+    def test_network_namespace_not_unshared(self):
+        # AI CLIs (claude-code/codex/gemini) need network — net stays shared.
+        self.assertNotIn("--unshare-net", self.text)
+
+    def test_proc_inherited_readonly(self):
+        # A fresh --proc can't be mounted in some target envs; /proc is ro-bound.
+        self.assertIn("--ro-bind /proc /proc", self.text)
+
+    def test_binds_are_guarded(self):
+        # Each --ro-bind SOURCE is added only if it exists, else bwrap aborts.
+        self.assertRegex(self.text, r'\[ -e "\$p" \] && binds\+=\(--ro-bind')
+        for p in ("/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc"):
+            with self.subTest(path=p):
+                self.assertIn(p, self.text)
+
+    def test_home_is_writable_bind(self):
+        self.assertIn('--bind "$HOME" "$HOME"', self.text)
+
+    def test_tmux_socket_pinned_under_home(self):
+        # Per-jail tmpfs /tmp would break `new-session -A` reattach, so the tmux
+        # socket lives under the bound $HOME and survives reconnects.
+        self.assertIn("tmux -S", self.text)
+        self.assertIn('${HOME}/.cache/tmux', self.text)
+        self.assertIn("new-session -A -s", self.text)
+
 
 class TestDockerPackageRegressions(unittest.TestCase):
+    def test_bubblewrap_is_installed_for_codex_sandboxing(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn("bubblewrap", dockerfile)
+
     def test_droid_package_is_installed_and_cache_busted(self):
         packages = CLI_PACKAGES.read_text()
         dockerfile = DOCKERFILE.read_text()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -171,7 +171,7 @@ class TestTmuxWrapperSandboxRegressions(unittest.TestCase):
 
 
 class TestDockerPackageRegressions(unittest.TestCase):
-    def test_bubblewrap_is_installed_for_codex_sandboxing(self):
+    def test_bubblewrap_is_installed_for_ttyd_sandbox(self):
         dockerfile = DOCKERFILE.read_text()
         self.assertIn("bubblewrap", dockerfile)
 


### PR DESCRIPTION
## Что и зачем

Опциональный джейл **bubblewrap (`bwrap`)** вокруг каждой tmux-сессии. При `TTYD_SANDBOX=true` мультитенантные деплои (где каждый терминал запускается под своим Linux-юзером) получают изоляцию: пользователь не видит чужие `/home/*`, системные каталоги — только на чтение.

**По умолчанию OFF** — single-user clihost не меняется (flag-off путь байт-в-байт оригинальный `exec tmux new-session`).

Мотивация: используется как фундамент для мультиюзер-форка `clihost_cloud`, но полезно любому, кто хочет изолировать терминал. `bubblewrap` уже был в Dockerfile («for codex sandboxing») — теперь он реально задействован.

## Дизайн (подтверждён Docker proof-of-concept)

- **Точка вставки** — `bin/tmux-wrapper.sh`, под флагом `TTYD_SANDBOX`. Flag-off ветка не тронута.
- **Флаги джейла:** `--ro-bind` системных каталогов (с guard'ом «если путь существует» — иначе bwrap падает на отсутствующем источнике), `--bind $HOME` (RW), `/proc` наследуется read-only (свежий `--proc` не монтируется в части окружений), `--unshare-user/-pid/-ipc`, `--die-with-parent`. **Сеть НЕ изолируется** — AI CLI нужен интернет.
- **tmux-сокет** перенесён под `$HOME/.cache/tmux/clihost.sock`, чтобы `new-session -A` переподключался между запусками ttyd (per-jail tmpfs `/tmp` иначе ломает reattach).
- **Fail-closed:** если bwrap не стартует (например, нет `seccomp=unconfined`) — терминал не открывается, без отката к неизолированному шеллу.
- **entrypoint.sh** дефолтит `TTYD_SANDBOX` и пробрасывает его в env-блок прокси (закрытый allow-list), чтобы флаг дошёл до `ttyd → tmux-wrapper` (Popen наследует env).

## ⚠️ Требование к запуску

Джейл требует запуска контейнера с **`--security-opt seccomp=unconfined`** (дефолтный seccomp Docker блокирует `clone(CLONE_NEW*)`, нужный bwrap). На Dokku:
```
dokku docker-options:add <app> deploy,run "--security-opt seccomp=unconfined"
```

## Проверка

- **Unit:** новый класс `TestTmuxWrapperSandboxRegressions` (флаги, guarded binds, отсутствие сетевого unshare, сокет под `$HOME`, flag-off byte-for-byte), entrypoint pass-through тест, `tmux-wrapper.sh` добавлен в `bash -n`. **Весь сьют: 216 passed.**
- **Runtime (Docker, seccomp=unconfined):** реальный `tmux-wrapper.sh` в режиме джейла подтвердил — чужая `/home/secretuser` → `No such file or directory`; `ls /home` → только свой; запись в `/etc` → read-only; своя home пишется; tmux вызван с правильным сокетом.

## Известные ограничения (задокументированы в CLAUDE.md)

- Изоляция **процессов** неполная: `/proc` наследуется (свежий не монтируется на Docker Desktop), хостовые PID видны через `/proc/{pid}`. Файловая изоляция — полная. Скрытие процессов — отдельная задача (`hidepid`).
- Вложенный bwrap (будущая песочница codex внутри нашего джейла) ломается под внешним `--unshare-user`. Сейчас не критично — codex bwrap не вызывает.
- `manager.py` kill-session при джейле — no-op (другой сокет); жизненный цикл держит `--die-with-parent`, осиротевший tmux-сервер безвреден и переиспользуется при reattach.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)