### PR TITLE
feat: модульная сборка образа через build-time флаги INSTALL_* (#57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,27 @@
+# ============================================================================
+# Модульный состав образа — BUILD-TIME флаги (issue #57)
+# ============================================================================
+# ВНИМАНИЕ: это НЕ runtime-переменные. CLI-инструменты устанавливаются на этапе
+# `docker build`, поэтому состав задаётся через --build-arg, а не через `docker run`.
+# По умолчанию все = true (ставится всё, поведение не меняется). Поставьте
+# false, чтобы исключить инструмент и получить более лёгкий образ.
+#
+#   docker build --build-arg INSTALL_CODEX=false --build-arg INSTALL_GEMINI=false -t clihost .
+#   # или, с авто-определением версий npm:
+#   INSTALL_CODEX=false INSTALL_GEMINI=false ./build.sh
+#
+# Railway: задайте эти имена в разделе Build-time variables сервиса (не в обычных
+# переменных окружения) — Railway пробросит их в `docker build` как build args.
+#
+# INSTALL_CLAUDE_CODE=true   # @anthropic-ai/claude-code
+# INSTALL_CODEX=true         # @openai/codex
+# INSTALL_GEMINI=true        # @google/gemini-cli
+# INSTALL_COPILOT=true       # @github/copilot
+# INSTALL_OPENCODE=true      # opencode-ai
+# INSTALL_DROID=true         # droid
+# INSTALL_HAPI=true          # @twsxtd/hapi (ядро рантайма: туннель/runner/URL на дашборде)
+# INSTALL_HERMES=true        # Hermes Agent (Nous Research, ставится через pip из GitHub)
+
 # Hapi Runner Configuration (optional)
 HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # HAPI_HOST=0.0.0.0         # Bind address (default: 0.0.0.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Each bundled CLI tool can be dropped from the image to build a lighter, deploy-s
 - `bin/install-cli.sh` reads `cli-packages.txt` and installs only the npm tools whose `INSTALL_<KEY>` env var is not `false`. The `Dockerfile` declares one `ARG INSTALL_<KEY>=true` per component and promotes them into the env for that `RUN`. Hermes has its own `INSTALL_HERMES`-gated `RUN`.
 - `build.sh` forwards every `INSTALL_<KEY>` (read from the shell environment, default `true`) to `docker build` as `--build-arg`, and excludes disabled tools from the cache-busting hash (so bumping a disabled tool's version no longer invalidates the cache).
 - Keys: `INSTALL_CLAUDE_CODE`, `INSTALL_CODEX`, `INSTALL_GEMINI`, `INSTALL_COPILOT`, `INSTALL_OPENCODE`, `INSTALL_DROID`, `INSTALL_HAPI`, `INSTALL_HERMES`. Disabling `INSTALL_HAPI` removes the runtime core (tunnel/runner/dashboard URL); the entrypoint skips hapi startup when the binary is absent and warns if `HAPI_RUNNER_ENABLED=true`.
+- Every `INSTALL_<KEY>` must be exactly `true` or `false` — `install-cli.sh`, `build.sh`, and the Hermes `RUN` all fail closed on anything else (`False`, `0`, typos) so a misconfigured build never silently ships a tool. Caveat: an invalid value passed straight to `docker build` (bypassing `build.sh`) still fails the build, but for an npm tool the manifest stage `FROM npm-manifest-<tool>-${INSTALL_<KEY>}` errors first with an opaque "base name not found" instead of the friendly message — the strict check in `install-cli.sh` is the readable one.
 
 Examples — drop Codex and Gemini:
 ```bash
@@ -85,7 +86,7 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → start `hapi server --relay` and extract connection URL → optionally start hapi runner → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → drop any stale dashboard URL → if `hapi` is installed, start `hapi server --relay`, extract connection URL, and optionally start hapi runner (otherwise warn and skip) → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Each bundled CLI tool can be dropped from the image to build a lighter, deploy-s
 
 - `bin/install-cli.sh` reads `cli-packages.txt` and installs only the npm tools whose `INSTALL_<KEY>` env var is not `false`. The `Dockerfile` declares one `ARG INSTALL_<KEY>=true` per component and promotes them into the env for that `RUN`. Hermes has its own `INSTALL_HERMES`-gated `RUN`.
 - `build.sh` forwards every `INSTALL_<KEY>` (read from the shell environment, default `true`) to `docker build` as `--build-arg`, and excludes disabled tools from the cache-busting hash (so bumping a disabled tool's version no longer invalidates the cache).
-- Keys: `INSTALL_CLAUDE_CODE`, `INSTALL_CODEX`, `INSTALL_GEMINI`, `INSTALL_COPILOT`, `INSTALL_OPENCODE`, `INSTALL_DROID`, `INSTALL_HAPI`, `INSTALL_HERMES`. Disabling `INSTALL_HAPI` removes the runtime core (tunnel/runner/dashboard URL) — only do it for images that don't need hapi.
+- Keys: `INSTALL_CLAUDE_CODE`, `INSTALL_CODEX`, `INSTALL_GEMINI`, `INSTALL_COPILOT`, `INSTALL_OPENCODE`, `INSTALL_DROID`, `INSTALL_HAPI`, `INSTALL_HERMES`. Disabling `INSTALL_HAPI` removes the runtime core (tunnel/runner/dashboard URL); the entrypoint skips hapi startup when the binary is absent and warns if `HAPI_RUNNER_ENABLED=true`.
 
 Examples — drop Codex and Gemini:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,25 @@ curl http://localhost:8080/health
 # {"status": "ok", "uptime": N, "ttyd": "running", "terminal_count": N, "terminals": [...], "memory_mb": N}
 ```
 
-To add a new bundled npm CLI tool: add a line to `cli-packages.txt` and the corresponding install step in `Dockerfile`. `build.sh` reads `cli-packages.txt` to compute the cache-busting hash. Hermes Agent is installed via pip from GitHub (not npm) and auto-updates at container start unless `HERMES_AUTO_UPDATE=false`.
+To add a new bundled npm CLI tool: add a line `COMPONENT_KEY pkg@latest` to `cli-packages.txt`, a matching `ADD https://registry.npmjs.org/<pkg>/latest ...` cache-bust manifest, and an `ARG INSTALL_<COMPONENT_KEY>=true` to `Dockerfile`. The actual `npm install -g` is centralized in `bin/install-cli.sh` (no per-tool install step needed). `build.sh` parses `cli-packages.txt` (first token = key, second = npm spec) to compute the cache-busting hash. Hermes Agent is installed via pip from GitHub (not npm) and auto-updates at container start unless `HERMES_AUTO_UPDATE=false`.
+
+### Modular image composition (build-time, issue #57)
+
+Each bundled CLI tool can be dropped from the image to build a lighter, deploy-specific image. This is a **build-time** mechanism (the tools install during `docker build`), driven by `INSTALL_<KEY>` build args that default to `true`:
+
+- `bin/install-cli.sh` reads `cli-packages.txt` and installs only the npm tools whose `INSTALL_<KEY>` env var is not `false`. The `Dockerfile` declares one `ARG INSTALL_<KEY>=true` per component and promotes them into the env for that `RUN`. Hermes has its own `INSTALL_HERMES`-gated `RUN`.
+- `build.sh` forwards every `INSTALL_<KEY>` (read from the shell environment, default `true`) to `docker build` as `--build-arg`, and excludes disabled tools from the cache-busting hash (so bumping a disabled tool's version no longer invalidates the cache).
+- Keys: `INSTALL_CLAUDE_CODE`, `INSTALL_CODEX`, `INSTALL_GEMINI`, `INSTALL_COPILOT`, `INSTALL_OPENCODE`, `INSTALL_DROID`, `INSTALL_HAPI`, `INSTALL_HERMES`. Disabling `INSTALL_HAPI` removes the runtime core (tunnel/runner/dashboard URL) — only do it for images that don't need hapi.
+
+Examples — drop Codex and Gemini:
+```bash
+docker build --build-arg INSTALL_CODEX=false --build-arg INSTALL_GEMINI=false -t clihost .
+# or, with npm version auto-detection for the cache hash:
+INSTALL_CODEX=false INSTALL_GEMINI=false ./build.sh
+```
+On Railway, set these names as **Build-time variables** on the service (not regular runtime env vars) — Railway passes them into `docker build` as build args. They have no effect at `docker run` time.
+
+Keep the `INSTALL_<KEY>` keys in sync across `cli-packages.txt`, `Dockerfile`, `build.sh`, and `.env.example`.
 
 ## Testing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,11 @@ RUN echo 'export TERM=xterm-256color' >> /home/hapi/.bashrc && \
     echo 'export LANG=en_US.UTF-8' >> /home/hapi/.bashrc && \
     echo 'export LC_ALL=en_US.UTF-8' >> /home/hapi/.bashrc
 
-# Invalidate the CLI install layer when enabled packages publish new versions.
-# The selected manifest stages keep remote ADD cache-busting for enabled tools,
-# while disabled tools copy a stable local file and never fetch their manifest.
-# Keep in sync with cli-packages.txt.
+# Per-tool npm manifest stages (issue #57). For each tool a selector stage
+# resolves to either its remote manifest ADD (enabled → cache-busts on a new
+# published version) or the stable disabled placeholder below (disabled → never
+# fetches, never invalidates the shared install layer). Keep in sync with
+# cli-packages.txt.
 FROM scratch AS npm-manifest-disabled
 # Stable, constant placeholder (NOT cli-packages.txt): editing a disabled tool's
 # row must not change this stage's output, or it would invalidate the shared

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,10 @@ RUN echo 'export TERM=xterm-256color' >> /home/hapi/.bashrc && \
 # while disabled tools copy a stable local file and never fetch their manifest.
 # Keep in sync with cli-packages.txt.
 FROM scratch AS npm-manifest-disabled
-COPY cli-packages.txt /manifest.json
+# Stable, constant placeholder (NOT cli-packages.txt): editing a disabled tool's
+# row must not change this stage's output, or it would invalidate the shared
+# install layer for the enabled tools.
+COPY bin/npm-manifest-placeholder.json /manifest.json
 
 FROM scratch AS npm-manifest-claude-code-true
 ADD https://registry.npmjs.org/@anthropic-ai/claude-code/latest /manifest.json
@@ -152,15 +155,21 @@ RUN chmod +x /tmp/install-cli.sh && \
 
 # Install Hermes Agent (Nous Research) — git clone + pip, no venv/uv.
 # Gated by INSTALL_HERMES so it can be dropped from lighter images (issue #57).
-RUN if [ "${INSTALL_HERMES}" = "false" ]; then \
-      echo "Skipping Hermes Agent (INSTALL_HERMES=false)"; \
-    else \
-      git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && \
-      cd /tmp/hermes-agent && \
-      pip install --break-system-packages '.[all,messaging]' && \
-      which hermes && \
-      rm -rf /tmp/hermes-agent; \
-    fi
+# Strict boolean: only true/false accepted; fail closed on anything else (e.g.
+# "False", "0") so a misconfigured build never silently ships Hermes.
+RUN case "${INSTALL_HERMES}" in \
+      false) \
+        echo "Skipping Hermes Agent (INSTALL_HERMES=false)" ;; \
+      true) \
+        git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && \
+        cd /tmp/hermes-agent && \
+        pip install --break-system-packages '.[all,messaging]' && \
+        which hermes && \
+        rm -rf /tmp/hermes-agent ;; \
+      *) \
+        echo "ERROR: INSTALL_HERMES='${INSTALL_HERMES}' is invalid; must be 'true' or 'false'" >&2; \
+        exit 1 ;; \
+    esac
 
 # Create app directory for TTYD proxy
 RUN mkdir -p /app /bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM debian:bookworm-slim
+ARG INSTALL_CLAUDE_CODE=true
+ARG INSTALL_CODEX=true
+ARG INSTALL_GEMINI=true
+ARG INSTALL_COPILOT=true
+ARG INSTALL_OPENCODE=true
+ARG INSTALL_DROID=true
+ARG INSTALL_HAPI=true
+
+FROM debian:bookworm-slim AS runtime-base
 
 # Install Node.js 22.x directly from Node.js official binary
 RUN NODE_VERSION="22.14.0" && \
@@ -58,17 +66,49 @@ RUN echo 'export TERM=xterm-256color' >> /home/hapi/.bashrc && \
     echo 'export LANG=en_US.UTF-8' >> /home/hapi/.bashrc && \
     echo 'export LC_ALL=en_US.UTF-8' >> /home/hapi/.bashrc
 
-# Invalidate the CLI install layer when any package publishes a new version.
-# Docker refetches these URLs every build; the manifest JSON changes only when
-# the package's latest version changes, so the cache survives unchanged packages.
+# Invalidate the CLI install layer when enabled packages publish new versions.
+# The selected manifest stages keep remote ADD cache-busting for enabled tools,
+# while disabled tools copy a stable local file and never fetch their manifest.
 # Keep in sync with cli-packages.txt.
-ADD https://registry.npmjs.org/@anthropic-ai/claude-code/latest /tmp/npm-manifests/claude-code.json
-ADD https://registry.npmjs.org/@openai/codex/latest /tmp/npm-manifests/codex.json
-ADD https://registry.npmjs.org/@google/gemini-cli/latest /tmp/npm-manifests/gemini-cli.json
-ADD https://registry.npmjs.org/@github/copilot/latest /tmp/npm-manifests/copilot.json
-ADD https://registry.npmjs.org/opencode-ai/latest /tmp/npm-manifests/opencode-ai.json
-ADD https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json
-ADD https://registry.npmjs.org/@twsxtd/hapi/latest /tmp/npm-manifests/hapi.json
+FROM scratch AS npm-manifest-disabled
+COPY cli-packages.txt /manifest.json
+
+FROM scratch AS npm-manifest-claude-code-true
+ADD https://registry.npmjs.org/@anthropic-ai/claude-code/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-claude-code-false
+FROM npm-manifest-claude-code-${INSTALL_CLAUDE_CODE} AS npm-manifest-claude-code
+
+FROM scratch AS npm-manifest-codex-true
+ADD https://registry.npmjs.org/@openai/codex/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-codex-false
+FROM npm-manifest-codex-${INSTALL_CODEX} AS npm-manifest-codex
+
+FROM scratch AS npm-manifest-gemini-true
+ADD https://registry.npmjs.org/@google/gemini-cli/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-gemini-false
+FROM npm-manifest-gemini-${INSTALL_GEMINI} AS npm-manifest-gemini
+
+FROM scratch AS npm-manifest-copilot-true
+ADD https://registry.npmjs.org/@github/copilot/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-copilot-false
+FROM npm-manifest-copilot-${INSTALL_COPILOT} AS npm-manifest-copilot
+
+FROM scratch AS npm-manifest-opencode-true
+ADD https://registry.npmjs.org/opencode-ai/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-opencode-false
+FROM npm-manifest-opencode-${INSTALL_OPENCODE} AS npm-manifest-opencode
+
+FROM scratch AS npm-manifest-droid-true
+ADD https://registry.npmjs.org/droid/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-droid-false
+FROM npm-manifest-droid-${INSTALL_DROID} AS npm-manifest-droid
+
+FROM scratch AS npm-manifest-hapi-true
+ADD https://registry.npmjs.org/@twsxtd/hapi/latest /manifest.json
+FROM npm-manifest-disabled AS npm-manifest-hapi-false
+FROM npm-manifest-hapi-${INSTALL_HAPI} AS npm-manifest-hapi
+
+FROM runtime-base
 
 # Modular install flags (issue #57): set any to "false" at build time to drop
 # that CLI tool from the image, e.g. `docker build --build-arg INSTALL_CODEX=false`.
@@ -82,6 +122,14 @@ ARG INSTALL_OPENCODE=true
 ARG INSTALL_DROID=true
 ARG INSTALL_HAPI=true
 ARG INSTALL_HERMES=true
+
+COPY --from=npm-manifest-claude-code /manifest.json /tmp/npm-manifests/claude-code.json
+COPY --from=npm-manifest-codex /manifest.json /tmp/npm-manifests/codex.json
+COPY --from=npm-manifest-gemini /manifest.json /tmp/npm-manifests/gemini-cli.json
+COPY --from=npm-manifest-copilot /manifest.json /tmp/npm-manifests/copilot.json
+COPY --from=npm-manifest-opencode /manifest.json /tmp/npm-manifests/opencode-ai.json
+COPY --from=npm-manifest-droid /manifest.json /tmp/npm-manifests/droid.json
+COPY --from=npm-manifest-hapi /manifest.json /tmp/npm-manifests/hapi.json
 
 COPY cli-packages.txt /tmp/cli-packages.txt
 COPY bin/install-cli.sh /tmp/install-cli.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,22 +70,49 @@ ADD https://registry.npmjs.org/opencode-ai/latest /tmp/npm-manifests/opencode-ai
 ADD https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json
 ADD https://registry.npmjs.org/@twsxtd/hapi/latest /tmp/npm-manifests/hapi.json
 
-COPY cli-packages.txt /tmp/cli-packages.txt
+# Modular install flags (issue #57): set any to "false" at build time to drop
+# that CLI tool from the image, e.g. `docker build --build-arg INSTALL_CODEX=false`.
+# Defaults are "true", so an unspecified build installs everything (unchanged).
+# Keep the keys in sync with cli-packages.txt and .env.example.
+ARG INSTALL_CLAUDE_CODE=true
+ARG INSTALL_CODEX=true
+ARG INSTALL_GEMINI=true
+ARG INSTALL_COPILOT=true
+ARG INSTALL_OPENCODE=true
+ARG INSTALL_DROID=true
+ARG INSTALL_HAPI=true
+ARG INSTALL_HERMES=true
 
-# Install all CLI tools in one layer, then fix permissions and clean up
-RUN for i in 1 2 3 4 5; do \
-      xargs npm install -g < /tmp/cli-packages.txt && break || sleep 10; \
-    done && \
+COPY cli-packages.txt /tmp/cli-packages.txt
+COPY bin/install-cli.sh /tmp/install-cli.sh
+
+# Install the enabled CLI tools in one layer, then fix permissions and clean up.
+# install-cli.sh reads the INSTALL_<KEY> values from the environment, so promote
+# the build args to env vars for the duration of this RUN.
+RUN chmod +x /tmp/install-cli.sh && \
+    INSTALL_CLAUDE_CODE="${INSTALL_CLAUDE_CODE}" \
+    INSTALL_CODEX="${INSTALL_CODEX}" \
+    INSTALL_GEMINI="${INSTALL_GEMINI}" \
+    INSTALL_COPILOT="${INSTALL_COPILOT}" \
+    INSTALL_OPENCODE="${INSTALL_OPENCODE}" \
+    INSTALL_DROID="${INSTALL_DROID}" \
+    INSTALL_HAPI="${INSTALL_HAPI}" \
+    /tmp/install-cli.sh /tmp/cli-packages.txt && \
     chown -R hapi:hapi /usr/local/lib/node_modules && \
     npm cache clean --force && \
     rm -rf /tmp/*
 
-# Install Hermes Agent (Nous Research) — git clone + pip, no venv/uv
-RUN git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && \
-    cd /tmp/hermes-agent && \
-    pip install --break-system-packages '.[all,messaging]' && \
-    which hermes && \
-    rm -rf /tmp/hermes-agent
+# Install Hermes Agent (Nous Research) — git clone + pip, no venv/uv.
+# Gated by INSTALL_HERMES so it can be dropped from lighter images (issue #57).
+RUN if [ "${INSTALL_HERMES}" = "false" ]; then \
+      echo "Skipping Hermes Agent (INSTALL_HERMES=false)"; \
+    else \
+      git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && \
+      cd /tmp/hermes-agent && \
+      pip install --break-system-packages '.[all,messaging]' && \
+      which hermes && \
+      rm -rf /tmp/hermes-agent; \
+    fi
 
 # Create app directory for TTYD proxy
 RUN mkdir -p /app /bin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clihost
 
-Docker container with web terminal (TTYD) and AI CLI tools (Claude Code, Codex, Gemini CLI, Droid). The web terminal proxy uses a multithreaded HTTP server — concurrent connections do not block each other.
+Docker container with web terminal (TTYD) and AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Droid, Hermes). Each tool can be excluded at build time for a lighter image — see [Модульный состав образа](#модульный-состав-образа). The web terminal proxy uses a multithreaded HTTP server — concurrent connections do not block each other.
 
 ## Quick Start
 
@@ -13,6 +13,31 @@ docker run -p 22:22 -p 8080:8080 clihost
 ```
 
 Open http://localhost:8080 for web terminal access.
+
+## Модульный состав образа
+
+Каждый CLI-инструмент можно исключить из образа на этапе сборки, чтобы получить более лёгкий, заточенный под конкретный деплой образ. Управление — через **build-time** аргументы `INSTALL_<KEY>` (по умолчанию `true`, ставится всё):
+
+| Build arg | Компонент |
+|-----------|-----------|
+| `INSTALL_CLAUDE_CODE` | Claude Code (`@anthropic-ai/claude-code`) |
+| `INSTALL_CODEX` | Codex (`@openai/codex`) |
+| `INSTALL_GEMINI` | Gemini CLI (`@google/gemini-cli`) |
+| `INSTALL_COPILOT` | GitHub Copilot (`@github/copilot`) |
+| `INSTALL_OPENCODE` | OpenCode (`opencode-ai`) |
+| `INSTALL_DROID` | Droid (`droid`) |
+| `INSTALL_HAPI` | Hapi (`@twsxtd/hapi`) — ядро рантайма (туннель/runner/URL на дашборде) |
+| `INSTALL_HERMES` | Hermes Agent (Nous Research, ставится через pip) |
+
+```bash
+# Собрать без Codex и Gemini
+docker build --build-arg INSTALL_CODEX=false --build-arg INSTALL_GEMINI=false -t clihost .
+
+# То же через build.sh (он также авто-определяет версии npm для cache-busting)
+INSTALL_CODEX=false INSTALL_GEMINI=false ./build.sh
+```
+
+> Это **не** runtime-переменные: инструменты устанавливаются во время `docker build`, поэтому задавать их через `docker run -e` бесполезно. На Railway укажите их в разделе **Build-time variables** сервиса — платформа пробросит их в `docker build`.
 
 ## Deploy on Railway
 

--- a/bin/install-cli.sh
+++ b/bin/install-cli.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+# install-cli.sh - Устанавливает npm CLI-инструменты из cli-packages.txt с учётом
+# модульных флагов INSTALL_<KEY> (issue #57). Для каждой строки "<KEY> <spec>"
+# инструмент ставится только если переменная окружения INSTALL_<KEY> != "false"
+# (по умолчанию включено — поведение совпадает с прежней безусловной установкой).
+#
+# Используется в Dockerfile на этапе сборки; флаги приходят из ARG INSTALL_*,
+# которые Dockerfile экспортирует в окружение перед запуском этого скрипта.
+#
+# Тот же парсинг (первый токен = ключ, второй = npm-spec) применяет build.sh при
+# вычислении cache-busting хеша, поэтому формат файла обязан совпадать.
+
+PACKAGE_FILE="${1:-/tmp/cli-packages.txt}"
+
+if [ ! -f "${PACKAGE_FILE}" ]; then
+  echo "ERROR: package list not found: ${PACKAGE_FILE}" >&2
+  exit 1
+fi
+
+# Собираем список включённых npm-спеков, пропуская комментарии/пустые строки и
+# компоненты, отключённые через INSTALL_<KEY>=false.
+packages=()
+skipped=()
+while read -r key spec _rest; do
+  case "${key}" in
+    ''|\#*) continue ;;  # пустая строка или комментарий
+  esac
+  if [ -z "${spec}" ]; then
+    echo "ERROR: malformed line in ${PACKAGE_FILE}: missing npm spec for '${key}'" >&2
+    exit 1
+  fi
+  flag_var="INSTALL_${key}"
+  flag_val="${!flag_var:-true}"
+  if [ "${flag_val}" = "false" ]; then
+    skipped+=("${spec} (${flag_var}=false)")
+    continue
+  fi
+  packages+=("${spec}")
+done < "${PACKAGE_FILE}"
+
+if [ "${#skipped[@]}" -gt 0 ]; then
+  echo "Skipping disabled CLI tools:"
+  for s in "${skipped[@]}"; do
+    echo "  - ${s}"
+  done
+fi
+
+if [ "${#packages[@]}" -eq 0 ]; then
+  echo "No npm CLI tools enabled; nothing to install."
+  exit 0
+fi
+
+echo "Installing npm CLI tools: ${packages[*]}"
+# Retry to ride out transient npm registry hiccups (matches the repo pattern).
+# Track success explicitly: under `set -e` a bare `... && break || sleep 10`
+# loop exits 0 even when every attempt failed (the trailing sleep succeeds), so
+# a registry outage would silently produce an image missing its CLI tools.
+installed=false
+for i in 1 2 3 4 5; do
+  if npm install -g "${packages[@]}"; then
+    installed=true
+    break
+  fi
+  sleep 10
+done
+if [ "${installed}" != "true" ]; then
+  echo "ERROR: failed to install npm CLI tools after 5 attempts" >&2
+  exit 1
+fi

--- a/bin/install-cli.sh
+++ b/bin/install-cli.sh
@@ -32,6 +32,16 @@ while read -r key spec _rest; do
   fi
   flag_var="INSTALL_${key}"
   flag_val="${!flag_var:-true}"
+  # Strict boolean: only "true"/"false" are valid. Fail closed on anything else
+  # (e.g. "False", "0", "no", typos) so a misconfigured build never silently
+  # installs a tool that was meant to be excluded.
+  case "${flag_val}" in
+    true|false) ;;
+    *)
+      echo "ERROR: ${flag_var}='${flag_val}' is invalid; must be 'true' or 'false'" >&2
+      exit 1
+      ;;
+  esac
   if [ "${flag_val}" = "false" ]; then
     skipped+=("${spec} (${flag_var}=false)")
     continue

--- a/bin/npm-manifest-placeholder.json
+++ b/bin/npm-manifest-placeholder.json
@@ -1,0 +1,1 @@
+{"clihost":"disabled-npm-manifest-placeholder","note":"Stable placeholder copied into disabled npm-manifest build stages so a disabled tool's cli-packages.txt row never invalidates the install layer (issue #57). Do not edit — its content is intentionally constant."}

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,19 @@ get_version() {
   echo "unknown"
 }
 
+# Строгая валидация булевого флага: только true/false. Фейлим на любом другом
+# значении, чтобы опечатка ("False"/"0") не привела к тихому включению тула.
+validate_bool() {
+  local name="$1" val="$2"
+  case "${val}" in
+    true|false) ;;
+    *)
+      echo "Error: ${name}='${val}' is invalid; must be 'true' or 'false'"
+      exit 1
+      ;;
+  esac
+}
+
 # cli-packages.txt: "<COMPONENT_KEY> <npm-spec>" (issue #57). Модульные флаги
 # INSTALL_<KEY> читаются из окружения (по умолчанию true) и:
 #   1) передаются в docker build как --build-arg, чтобы install-cli.sh пропустил
@@ -36,6 +49,7 @@ while read -r key spec _rest; do
 
   flag_var="INSTALL_${key}"
   flag_val="${!flag_var:-true}"
+  validate_bool "${flag_var}" "${flag_val}"
   # Всегда пробрасываем флаг в сборку, чтобы образ отражал явный выбор
   BUILD_ARGS+=(--build-arg "${flag_var}=${flag_val}")
 
@@ -58,6 +72,7 @@ done < "${PACKAGE_FILE}"
 # Hermes ставится не из npm (pip из GitHub), но всё равно управляется флагом —
 # пробрасываем его в сборку, если задан.
 if [ -n "${INSTALL_HERMES:-}" ]; then
+  validate_bool "INSTALL_HERMES" "${INSTALL_HERMES}"
   BUILD_ARGS+=(--build-arg "INSTALL_HERMES=${INSTALL_HERMES}")
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -14,15 +14,37 @@ get_version() {
   echo "unknown"
 }
 
-mapfile -t CLI_PACKAGES < "${PACKAGE_FILE}"
-
-# Получаем актуальные версии пакетов из npm registry
+# cli-packages.txt: "<COMPONENT_KEY> <npm-spec>" (issue #57). Модульные флаги
+# INSTALL_<KEY> читаются из окружения (по умолчанию true) и:
+#   1) передаются в docker build как --build-arg, чтобы install-cli.sh пропустил
+#      отключённые компоненты;
+#   2) исключают отключённые пакеты из cache-busting хеша — иначе обновление
+#      версии невыбранного инструмента зря инвалидировало бы кеш.
+BUILD_ARGS=()
 VERSIONS=""
 package_count=0
 unknown_count=0
-for package in "${CLI_PACKAGES[@]}"; do
-  [ -n "${package}" ] || continue
-  version=$(get_version "${package%@latest}")
+
+while read -r key spec _rest; do
+  case "${key}" in
+    ''|\#*) continue ;;  # пустая строка или комментарий
+  esac
+  if [ -z "${spec}" ]; then
+    echo "Error: malformed line in ${PACKAGE_FILE}: missing npm spec for '${key}'"
+    exit 1
+  fi
+
+  flag_var="INSTALL_${key}"
+  flag_val="${!flag_var:-true}"
+  # Всегда пробрасываем флаг в сборку, чтобы образ отражал явный выбор
+  BUILD_ARGS+=(--build-arg "${flag_var}=${flag_val}")
+
+  if [ "${flag_val}" = "false" ]; then
+    echo "Skipping ${spec} from cache hash (${flag_var}=false)"
+    continue
+  fi
+
+  version=$(get_version "${spec%@latest}")
   package_count=$((package_count + 1))
   if [[ "${version}" == "unknown" ]]; then
     unknown_count=$((unknown_count + 1))
@@ -31,19 +53,26 @@ for package in "${CLI_PACKAGES[@]}"; do
     VERSIONS+=" "
   fi
   VERSIONS+="${version}"
-done
+done < "${PACKAGE_FILE}"
+
+# Hermes ставится не из npm (pip из GitHub), но всё равно управляется флагом —
+# пробрасываем его в сборку, если задан.
+if [ -n "${INSTALL_HERMES:-}" ]; then
+  BUILD_ARGS+=(--build-arg "INSTALL_HERMES=${INSTALL_HERMES}")
+fi
 
 # Проверяем что хотя бы часть версий получена
 if (( package_count == 0 )); then
-  echo "Error: package list is empty"
-  exit 1
-fi
-if (( unknown_count == package_count )); then
-  echo "Error: failed to fetch all npm package versions. Check network connectivity."
-  exit 1
-fi
-if [[ "$VERSIONS" == *"unknown"* ]]; then
-  echo "Warning: failed to fetch some npm package versions"
+  echo "Warning: no enabled npm packages (all INSTALL_* flags are false?)"
+  VERSIONS="none"
+else
+  if (( unknown_count == package_count )); then
+    echo "Error: failed to fetch all npm package versions. Check network connectivity."
+    exit 1
+  fi
+  if [[ "$VERSIONS" == *"unknown"* ]]; then
+    echo "Warning: failed to fetch some npm package versions"
+  fi
 fi
 
 # Формируем хеш из версий
@@ -52,4 +81,4 @@ HASH=$(echo "$VERSIONS" | sha256sum | cut -c1-12)
 echo "npm package versions: $VERSIONS"
 echo "Cache hash: $HASH"
 
-docker build --build-arg NPM_VERSIONS_HASH="$HASH" "$@" -t clihost .
+docker build --build-arg NPM_VERSIONS_HASH="$HASH" "${BUILD_ARGS[@]}" "$@" -t clihost .

--- a/cli-packages.txt
+++ b/cli-packages.txt
@@ -1,7 +1,13 @@
-@anthropic-ai/claude-code@latest
-@openai/codex@latest
-@google/gemini-cli@latest
-@github/copilot@latest
-opencode-ai@latest
-droid@latest
-@twsxtd/hapi@latest
+# Bundled npm CLI tools, one per line: "<COMPONENT_KEY> <npm-spec>".
+# The COMPONENT_KEY maps to an INSTALL_<KEY> build arg (see Dockerfile): set
+# INSTALL_CODEX=false (etc.) at build time to drop that tool from the image.
+# Lines starting with '#' and blank lines are ignored.
+# bin/install-cli.sh parses this file; build.sh hashes only the enabled rows.
+# Keep the keys in sync with the ARG block in Dockerfile and .env.example.
+CLAUDE_CODE @anthropic-ai/claude-code@latest
+CODEX @openai/codex@latest
+GEMINI @google/gemini-cli@latest
+COPILOT @github/copilot@latest
+OPENCODE opencode-ai@latest
+DROID droid@latest
+HAPI @twsxtd/hapi@latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -190,59 +190,68 @@ HAPI_HOME="${HAPI_HOME}" \
 TTYD_SANDBOX="${TTYD_SANDBOX}" \
 runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
 
-# Start hapi server with relay in background (logs to file, force TCP relay)
-HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
-# Pre-create the log so the URL-extraction loop's -f check passes immediately
-touch "${HAPI_SERVER_LOG}"
-chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"
-echo "Starting hapi server --relay in background (logs: ${HAPI_SERVER_LOG})..."
-run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay 2>&1 | tee \"${HAPI_SERVER_LOG}\"" &
-HAPI_SERVER_PID=$!
-echo "Hapi server started with PID: ${HAPI_SERVER_PID}"
+if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
+  # Start hapi server with relay in background (logs to file, force TCP relay)
+  HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
+  # Pre-create the log so the URL-extraction loop's -f check passes immediately
+  touch "${HAPI_SERVER_LOG}"
+  chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"
+  echo "Starting hapi server --relay in background (logs: ${HAPI_SERVER_LOG})..."
+  run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay 2>&1 | tee \"${HAPI_SERVER_LOG}\"" &
+  HAPI_SERVER_PID=$!
+  echo "Hapi server started with PID: ${HAPI_SERVER_PID}"
 
-# Extract tunnel URL and token, build full connection URL
-HAPI_URL_FILE="${HAPI_USER_HOME}/url"
-HAPI_SETTINGS_FILE="${HAPI_HOME}/settings.json"
-(
-  for i in $(seq 1 60); do
-    if [ -f "${HAPI_SERVER_LOG}" ] && [ -f "${HAPI_SETTINGS_FILE}" ]; then
-      # Extract relay URL from log: https://xxx.relay.hapi.run
-      RELAY_URL=$(grep -oE 'https://[a-z0-9]+\.relay\.hapi\.run' "${HAPI_SERVER_LOG}" 2>/dev/null | head -1 || true)
-      # Extract token from settings.json
-      TOKEN=$(grep -oE '"cliApiToken":\s*"[^"]+"' "${HAPI_SETTINGS_FILE}" 2>/dev/null | sed 's/.*"cliApiToken":\s*"\([^"]*\)".*/\1/' || true)
-      if [ -n "$RELAY_URL" ] && [ -n "$TOKEN" ]; then
-        # URL-encode the relay URL (replace : with %3A, / with %2F)
-        ENCODED_URL=$(echo "$RELAY_URL" | sed 's/:/%3A/g; s/\//%2F/g')
-        # Build full connection URL
-        FULL_URL="https://app.hapi.run/?hub=${ENCODED_URL}&token=${TOKEN}"
-        echo "$FULL_URL" > "${HAPI_URL_FILE}"
-        chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_URL_FILE}"
-        echo "Hapi connection URL: ${FULL_URL}"
-        break
+  # Extract tunnel URL and token, build full connection URL
+  HAPI_URL_FILE="${HAPI_USER_HOME}/url"
+  HAPI_SETTINGS_FILE="${HAPI_HOME}/settings.json"
+  (
+    for i in $(seq 1 60); do
+      if [ -f "${HAPI_SERVER_LOG}" ] && [ -f "${HAPI_SETTINGS_FILE}" ]; then
+        # Extract relay URL from log: https://xxx.relay.hapi.run
+        RELAY_URL=$(grep -oE 'https://[a-z0-9]+\.relay\.hapi\.run' "${HAPI_SERVER_LOG}" 2>/dev/null | head -1 || true)
+        # Extract token from settings.json
+        TOKEN=$(grep -oE '"cliApiToken":\s*"[^"]+"' "${HAPI_SETTINGS_FILE}" 2>/dev/null | sed 's/.*"cliApiToken":\s*"\([^"]*\)".*/\1/' || true)
+        if [ -n "$RELAY_URL" ] && [ -n "$TOKEN" ]; then
+          # URL-encode the relay URL (replace : with %3A, / with %2F)
+          ENCODED_URL=$(echo "$RELAY_URL" | sed 's/:/%3A/g; s/\//%2F/g')
+          # Build full connection URL
+          FULL_URL="https://app.hapi.run/?hub=${ENCODED_URL}&token=${TOKEN}"
+          echo "$FULL_URL" > "${HAPI_URL_FILE}"
+          chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_URL_FILE}"
+          echo "Hapi connection URL: ${FULL_URL}"
+          break
+        fi
       fi
+      sleep 1
+    done
+  ) &
+
+  # Start hapi runner if enabled (reads config from volume)
+  if [ "${HAPI_RUNNER_ENABLED}" = "true" ]; then
+    echo "Starting hapi runner..."
+    if ! run_as_hapi "hapi runner start 2>&1"; then
+      echo '=== RUNNER START FAILED ===' >&2
     fi
-    sleep 1
-  done
-) &
 
-# Start hapi runner if enabled (reads config from volume)
-if [ "${HAPI_RUNNER_ENABLED}" = "true" ]; then
-  echo "Starting hapi runner..."
-  if ! run_as_hapi "hapi runner start 2>&1"; then
-    echo '=== RUNNER START FAILED ===' >&2
+    # Verify runner is running
+    echo "Checking hapi runner status..."
+    if ! run_as_hapi "hapi runner status 2>&1"; then
+      echo '=== RUNNER NOT RUNNING ===' >&2
+      echo 'Running hapi doctor for diagnostics:' >&2
+      run_as_hapi "hapi doctor 2>&1" || true
+    fi
+    echo "Hapi runner startup complete"
+  else
+    echo "Hapi runner disabled (set HAPI_RUNNER_ENABLED=true to enable)"
+    echo "Config created by 'hapi server --relay' - run 'hapi runner start' manually if needed"
   fi
-
-  # Verify runner is running
-  echo "Checking hapi runner status..."
-  if ! run_as_hapi "hapi runner status 2>&1"; then
-    echo '=== RUNNER NOT RUNNING ===' >&2
-    echo 'Running hapi doctor for diagnostics:' >&2
-    run_as_hapi "hapi doctor 2>&1" || true
-  fi
-  echo "Hapi runner startup complete"
 else
-  echo "Hapi runner disabled (set HAPI_RUNNER_ENABLED=true to enable)"
-  echo "Config created by 'hapi server --relay' - run 'hapi runner start' manually if needed"
+  echo "WARNING: hapi CLI not found; skipping hapi server --relay startup" >&2
+  if [ "${HAPI_RUNNER_ENABLED}" = "true" ]; then
+    echo "WARNING: HAPI_RUNNER_ENABLED=true but hapi CLI is not installed; skipping hapi runner startup" >&2
+  else
+    echo "Hapi runner disabled (set HAPI_RUNNER_ENABLED=true to enable)"
+  fi
 fi
 
 # sshd is now the main process (via CMD in Dockerfile)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -190,6 +190,13 @@ HAPI_HOME="${HAPI_HOME}" \
 TTYD_SANDBOX="${TTYD_SANDBOX}" \
 runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
 
+# Drop any stale dashboard URL up front. On a persistent /home/hapi volume a URL
+# from a previous hapi-enabled image would otherwise make the dashboard render an
+# old relay link/token even when hapi is now absent (INSTALL_HAPI=false). It is
+# recreated below only after a fresh relay URL + token are observed.
+HAPI_URL_FILE="${HAPI_USER_HOME}/url"
+rm -f "${HAPI_URL_FILE}" 2>/dev/null || true
+
 if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
   # Start hapi server with relay in background (logs to file, force TCP relay)
   HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
@@ -202,7 +209,7 @@ if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
   echo "Hapi server started with PID: ${HAPI_SERVER_PID}"
 
   # Extract tunnel URL and token, build full connection URL
-  HAPI_URL_FILE="${HAPI_USER_HOME}/url"
+  # (HAPI_URL_FILE was set + cleared above; recreated here only on a fresh URL.)
   HAPI_SETTINGS_FILE="${HAPI_HOME}/settings.json"
   (
     for i in $(seq 1 60); do

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -19,6 +19,15 @@ NPM_COMPONENT_KEYS = (
     "CLAUDE_CODE", "CODEX", "GEMINI", "COPILOT", "OPENCODE", "DROID", "HAPI",
 )
 ALL_COMPONENT_KEYS = NPM_COMPONENT_KEYS + ("HERMES",)
+NPM_MANIFEST_SLUGS = {
+    "CLAUDE_CODE": "claude-code",
+    "CODEX": "codex",
+    "GEMINI": "gemini",
+    "COPILOT": "copilot",
+    "OPENCODE": "opencode",
+    "DROID": "droid",
+    "HAPI": "hapi",
+}
 
 
 class TestShellSyntax(unittest.TestCase):
@@ -102,6 +111,30 @@ class TestEntrypointRegressions(unittest.TestCase):
         server_start_pos = self.text.find("hapi server --relay 2>&1")
         self.assertGreater(touch_pos, -1, "HAPI_SERVER_LOG is not pre-created")
         self.assertLess(touch_pos, server_start_pos)
+
+    def test_hapi_commands_are_skipped_when_cli_missing(self):
+        guard_pos = self.text.find(
+            'if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then'
+        )
+        warning_pos = self.text.find(
+            "WARNING: hapi CLI not found; skipping hapi server --relay startup"
+        )
+        self.assertGreater(guard_pos, -1, "hapi command guard is missing")
+        self.assertGreater(warning_pos, guard_pos)
+        for marker in (
+            'run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay',
+            'run_as_hapi "hapi runner start 2>&1"',
+            'run_as_hapi "hapi runner status 2>&1"',
+            'run_as_hapi "hapi doctor 2>&1"',
+        ):
+            with self.subTest(marker=marker):
+                pos = self.text.find(marker)
+                self.assertGreater(pos, guard_pos)
+                self.assertLess(pos, warning_pos)
+        self.assertIn(
+            "WARNING: HAPI_RUNNER_ENABLED=true but hapi CLI is not installed",
+            self.text,
+        )
 
     def test_droid_daemon_started_as_hapi_with_log(self):
         self.assertIn(': "${DROID_DAEMON_ENABLED:=false}"', self.text)
@@ -189,7 +222,11 @@ class TestDockerPackageRegressions(unittest.TestCase):
         dockerfile = DOCKERFILE.read_text()
         self.assertIn("droid@latest", packages)
         self.assertIn(
-            "https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json",
+            "https://registry.npmjs.org/droid/latest /manifest.json",
+            dockerfile,
+        )
+        self.assertIn(
+            "FROM npm-manifest-droid-${INSTALL_DROID} AS npm-manifest-droid",
             dockerfile,
         )
 
@@ -243,6 +280,29 @@ class TestModularInstallFlags(unittest.TestCase):
         for key in NPM_COMPONENT_KEYS:
             with self.subTest(key=key):
                 self.assertIn(f'INSTALL_{key}="${{INSTALL_{key}}}"', dockerfile)
+
+    def test_dockerfile_gates_manifest_fetches_by_install_args(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertNotRegex(
+            dockerfile,
+            re.compile(r"^ADD https://registry\.npmjs\.org/.+ /tmp/npm-manifests/", re.MULTILINE),
+        )
+        self.assertIn("FROM scratch AS npm-manifest-disabled", dockerfile)
+        for key, slug in NPM_MANIFEST_SLUGS.items():
+            with self.subTest(key=key):
+                self.assertIn(
+                    f"FROM npm-manifest-disabled AS npm-manifest-{slug}-false",
+                    dockerfile,
+                )
+                self.assertIn(
+                    f"FROM npm-manifest-{slug}-${{INSTALL_{key}}} AS npm-manifest-{slug}",
+                    dockerfile,
+                )
+                self.assertIn(
+                    f"COPY --from=npm-manifest-{slug} /manifest.json "
+                    f"/tmp/npm-manifests/{slug}",
+                    dockerfile,
+                )
 
     def test_hermes_install_is_gated(self):
         dockerfile = DOCKERFILE.read_text()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -306,7 +306,53 @@ class TestModularInstallFlags(unittest.TestCase):
 
     def test_hermes_install_is_gated(self):
         dockerfile = DOCKERFILE.read_text()
-        self.assertIn('if [ "${INSTALL_HERMES}" = "false" ]', dockerfile)
+        # Strict true|false case gate (fails closed on invalid values).
+        self.assertIn('case "${INSTALL_HERMES}" in', dockerfile)
+        self.assertIn("Skipping Hermes Agent (INSTALL_HERMES=false)", dockerfile)
+        self.assertIn(
+            "INSTALL_HERMES='${INSTALL_HERMES}' is invalid", dockerfile
+        )
+
+    def test_disabled_manifest_placeholder_is_independent_of_cli_packages(self):
+        # The disabled-manifest stage must copy a stable placeholder, NOT
+        # cli-packages.txt — otherwise editing a disabled tool's row would change
+        # the stage output and invalidate the shared install layer (issue #57).
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn(
+            "COPY bin/npm-manifest-placeholder.json /manifest.json", dockerfile
+        )
+        self.assertNotIn("COPY cli-packages.txt /manifest.json", dockerfile)
+        self.assertTrue(
+            (REPO_ROOT / "bin/npm-manifest-placeholder.json").is_file(),
+            "placeholder file is missing",
+        )
+
+    def test_install_cli_rejects_invalid_boolean(self):
+        # Strict boolean: a non true/false flag must fail the build, not silently
+        # install (or skip) the tool.
+        result = subprocess.run(
+            ["bash", str(INSTALL_CLI), str(CLI_PACKAGES)],
+            capture_output=True, text=True,
+            env={**os.environ, "INSTALL_CODEX": "False"},
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("INSTALL_CODEX='False' is invalid", result.stderr)
+
+    def test_build_sh_validates_boolean_flags(self):
+        text = BUILD_SH.read_text()
+        self.assertIn("validate_bool", text)
+        self.assertIn("must be 'true' or 'false'", text)
+
+    def test_entrypoint_clears_stale_url_before_hapi_check(self):
+        # On a persistent volume a URL from a previous hapi-enabled image must not
+        # leak into a hapi-disabled run; the entrypoint removes it up front.
+        text = ENTRYPOINT.read_text()
+        rm_pos = text.find('rm -f "${HAPI_URL_FILE}"')
+        guard_pos = text.find(
+            'if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then'
+        )
+        self.assertGreater(rm_pos, -1, "stale URL is not cleared")
+        self.assertLess(rm_pos, guard_pos, "URL must be cleared before the hapi check")
 
     def test_build_sh_forwards_flags_as_build_args(self):
         text = BUILD_SH.read_text()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1,7 +1,9 @@
 """Static checks for shell scripts (syntax + known-bug regressions)."""
+import os
 import pathlib
 import re
 import subprocess
+import tempfile
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -9,12 +11,19 @@ ENTRYPOINT = REPO_ROOT / "entrypoint.sh"
 BUILD_SH = REPO_ROOT / "build.sh"
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 CLI_PACKAGES = REPO_ROOT / "cli-packages.txt"
+INSTALL_CLI = REPO_ROOT / "bin/install-cli.sh"
 TMUX_WRAPPER = REPO_ROOT / "bin/tmux-wrapper.sh"
+
+# Component keys whose INSTALL_<KEY> build args gate the modular image (issue #57).
+NPM_COMPONENT_KEYS = (
+    "CLAUDE_CODE", "CODEX", "GEMINI", "COPILOT", "OPENCODE", "DROID", "HAPI",
+)
+ALL_COMPONENT_KEYS = NPM_COMPONENT_KEYS + ("HERMES",)
 
 
 class TestShellSyntax(unittest.TestCase):
     def test_scripts_parse(self):
-        for script in (ENTRYPOINT, BUILD_SH, TMUX_WRAPPER):
+        for script in (ENTRYPOINT, BUILD_SH, INSTALL_CLI, TMUX_WRAPPER):
             with self.subTest(script=script.name):
                 result = subprocess.run(
                     ["bash", "-n", str(script)], capture_output=True, text=True
@@ -183,6 +192,108 @@ class TestDockerPackageRegressions(unittest.TestCase):
             "https://registry.npmjs.org/droid/latest /tmp/npm-manifests/droid.json",
             dockerfile,
         )
+
+
+def _parse_cli_packages():
+    """Mirror install-cli.sh / build.sh parsing: (KEY, npm-spec) per real line."""
+    rows = []
+    for line in CLI_PACKAGES.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        rows.append((parts[0], parts[1] if len(parts) > 1 else ""))
+    return rows
+
+
+class TestCliPackagesFormat(unittest.TestCase):
+    """cli-packages.txt is now '<COMPONENT_KEY> <npm-spec>' (issue #57)."""
+
+    def test_every_line_has_key_and_spec(self):
+        rows = _parse_cli_packages()
+        self.assertTrue(rows, "cli-packages.txt has no package rows")
+        for key, spec in rows:
+            with self.subTest(key=key):
+                self.assertRegex(key, r"^[A-Z0-9_]+$", "key must be UPPER_SNAKE")
+                self.assertTrue(spec.endswith("@latest"), f"{spec} should pin @latest")
+
+    def test_keys_match_expected_components(self):
+        keys = [key for key, _ in _parse_cli_packages()]
+        self.assertEqual(sorted(keys), sorted(NPM_COMPONENT_KEYS))
+
+
+class TestModularInstallFlags(unittest.TestCase):
+    """Build-time INSTALL_<KEY> flags wired through Dockerfile and build.sh."""
+
+    def test_dockerfile_declares_every_install_arg(self):
+        dockerfile = DOCKERFILE.read_text()
+        for key in ALL_COMPONENT_KEYS:
+            with self.subTest(key=key):
+                self.assertIn(f"ARG INSTALL_{key}=true", dockerfile)
+
+    def test_dockerfile_uses_install_script_not_bare_xargs(self):
+        dockerfile = DOCKERFILE.read_text()
+        # Install is centralized in install-cli.sh; the old unconditional
+        # `xargs npm install -g < cli-packages.txt` must be gone.
+        self.assertIn("install-cli.sh", dockerfile)
+        self.assertNotRegex(dockerfile, r"xargs\s+npm\s+install")
+
+    def test_dockerfile_promotes_npm_flags_into_install_run(self):
+        dockerfile = DOCKERFILE.read_text()
+        for key in NPM_COMPONENT_KEYS:
+            with self.subTest(key=key):
+                self.assertIn(f'INSTALL_{key}="${{INSTALL_{key}}}"', dockerfile)
+
+    def test_hermes_install_is_gated(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn('if [ "${INSTALL_HERMES}" = "false" ]', dockerfile)
+
+    def test_build_sh_forwards_flags_as_build_args(self):
+        text = BUILD_SH.read_text()
+        self.assertIn('--build-arg', text)
+        self.assertIn('flag_var="INSTALL_${key}"', text)
+        # Disabled tools must drop out of the cache-busting hash.
+        self.assertIn('Skipping', text)
+
+
+class TestInstallCliScript(unittest.TestCase):
+    """Behavioural test of bin/install-cli.sh with a fake npm on PATH."""
+
+    def _run(self, env_overrides):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_npm = pathlib.Path(tmp) / "npm"
+            fake_npm.write_text("#!/bin/bash\necho \"NPM $*\"\n")
+            fake_npm.chmod(0o755)
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp}{os.pathsep}{env['PATH']}"
+            env.update(env_overrides)
+            return subprocess.run(
+                ["bash", str(INSTALL_CLI), str(CLI_PACKAGES)],
+                capture_output=True, text=True, env=env,
+            )
+
+    def test_all_enabled_by_default_installs_everything(self):
+        result = self._run({})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for _, spec in _parse_cli_packages():
+            with self.subTest(spec=spec):
+                self.assertIn(spec, result.stdout)
+
+    def test_disabled_tool_is_skipped(self):
+        result = self._run({"INSTALL_CODEX": "false", "INSTALL_GEMINI": "false"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        npm_line = [l for l in result.stdout.splitlines() if l.startswith("NPM ")]
+        self.assertEqual(len(npm_line), 1, result.stdout)
+        self.assertNotIn("@openai/codex", npm_line[0])
+        self.assertNotIn("@google/gemini-cli", npm_line[0])
+        self.assertIn("@anthropic-ai/claude-code", npm_line[0])
+
+    def test_all_disabled_installs_nothing(self):
+        overrides = {f"INSTALL_{k}": "false" for k in NPM_COMPONENT_KEYS}
+        result = self._run(overrides)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("NPM ", result.stdout)
+        self.assertIn("nothing to install", result.stdout)
 
 
 class TestBuildShRegressions(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Каждый CLI-инструмент теперь можно исключить из образа через build-time аргументы `INSTALL_<KEY>` (по умолчанию `true` — поведение прежней безусловной установки не меняется)
- `bin/install-cli.sh` — новый скрипт, централизует `npm install -g` и фильтрует компоненты по флагам; заменяет безусловный `xargs npm install -g < cli-packages.txt`
- `cli-packages.txt` переведён в формат `<COMPONENT_KEY> <npm-spec>` (машиночитаемый, ключ маппится на `INSTALL_<KEY>`)
- `build.sh` пробрасывает все `INSTALL_*` как `--build-arg` и исключает отключённые пакеты из cache-busting хэша
- Hermes-шаг в Dockerfile обёрнут в `if [ "${INSTALL_HERMES}" = "false" ]`

## Новые/изменённые build-time переменные

> Это **build-time** аргументы (`--build-arg`), **не** runtime env vars — на Railway задавать в разделе **Build-time variables** сервиса.

| Переменная | Компонент | По умолчанию |
|---|---|---|
| `INSTALL_CLAUDE_CODE` | `@anthropic-ai/claude-code` | `true` |
| `INSTALL_CODEX` | `@openai/codex` | `true` |
| `INSTALL_GEMINI` | `@google/gemini-cli` | `true` |
| `INSTALL_COPILOT` | `@github/copilot` | `true` |
| `INSTALL_OPENCODE` | `opencode-ai` | `true` |
| `INSTALL_DROID` | `droid` | `true` |
| `INSTALL_HAPI` | `@twsxtd/hapi` (ядро: туннель/runner/URL) | `true` |
| `INSTALL_HERMES` | Hermes Agent (pip из GitHub) | `true` |

Пример — собрать без Codex и Gemini:
```bash
docker build --build-arg INSTALL_CODEX=false --build-arg INSTALL_GEMINI=false -t clihost .
# или с авто-определением версий npm для cache-hash:
INSTALL_CODEX=false INSTALL_GEMINI=false ./build.sh
```

## Test plan

- [x] `python -m pytest tests/` — 226 passed (10 новых тестов для модульной системы)
- [x] `docker build --check` — без предупреждений
- [x] Реальная Docker-сборка с `INSTALL_CODEX=false INSTALL_GEMINI=false INSTALL_HERMES=false`:
  - лог подтвердил `Skipping disabled CLI tools: @openai/codex, @google/gemini-cli`
  - `Skipping Hermes Agent (INSTALL_HERMES=false)`
  - интроспекция образа: `codex`/`gemini`/`hermes` физически отсутствуют, остальные 5 на месте

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)