### PR TITLE
fix: устранить 13 подтверждённых багов из issue #59 (TDD)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,9 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
 
-# tini as PID 1 reaps zombies (orphaned subshells) and forwards signals
-ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
+# tini as PID 1 reaps zombies (orphaned subshells) and forwards signals.
+# -g forwards SIGTERM to the whole process group so the ttyd proxy / hapi server
+# / droid daemon (reparented to tini after entrypoint.sh exec's sshd) shut down
+# gracefully on `docker stop` instead of being SIGKILLed after the grace period (B13).
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]
 CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -29,6 +29,7 @@ from ttydproxy.config import (
     MAX_UPLOAD_SIZE,
     UPLOAD_DIR,
     TTYD_ROUTE_PATTERN,
+    MAX_TERMINAL_ID_DIGITS,
 )
 from ttydproxy.manager import TTYDManager
 from ttydproxy.proxy import is_websocket_request, proxy_ttyd_http, proxy_ttyd_websocket
@@ -57,11 +58,12 @@ login_rate_limiter = RateLimiter(max_attempts=5, window_seconds=60)
 account_rate_limiter = RateLimiter(max_attempts=5, window_seconds=300)
 MAX_CLEANUP_DELETE_IDS = 50
 MAX_CLEANUP_TARGET_ID_LENGTH = 128
+# A favicon that failed to load (None) is dropped from the routes so one
+# missing decorative PNG never takes down login/terminal (B18).
 FAVICON_ROUTES = {
-    "/favicon.ico": ("image/x-icon", assets.FAVICON_ICO),
-    "/favicon-16x16.png": ("image/png", assets.FAVICON_16_PNG),
-    "/favicon-32x32.png": ("image/png", assets.FAVICON_32_PNG),
-    "/apple-touch-icon.png": ("image/png", assets.APPLE_TOUCH_ICON_PNG),
+    icon.path: (icon.content_type, icon.body)
+    for icon in assets.FAVICONS
+    if icon.body is not None
 }
 
 
@@ -123,7 +125,15 @@ class TTYDProxyHandler(BaseHandler):
     def do_DELETE(self):
         parsed = urlparse(self.path)
         parts = parsed.path.split("/")
-        if len(parts) == 3 and parts[1] == "terminals" and parts[2].isdigit():
+        # Bound the digit count (same cap as the GET route regex) so int() can
+        # never hit Python's 4300-digit string-conversion limit on this
+        # unauthenticated path (B8); an over-long id falls through to a 404.
+        if (
+            len(parts) == 3
+            and parts[1] == "terminals"
+            and parts[2].isdigit()
+            and len(parts[2]) <= MAX_TERMINAL_ID_DIGITS
+        ):
             self.handle_terminals_delete(int(parts[2]))
             return
         self.send_json(404, {"error": "Not found"})

--- a/app/ttydproxy/assets.py
+++ b/app/ttydproxy/assets.py
@@ -1,4 +1,13 @@
-"""Static asset loading for terminal HTML and injected scripts."""
+"""Static asset loading for terminal HTML and injected scripts.
+
+The contract mirrors views.load_template's robustness, differentiated by how
+critical the asset is (B18):
+  - required assets (injected scripts, virtual keyboard) fail fast at import
+    with a clear error naming the file, instead of a bare deep traceback;
+  - decorative assets (favicons) degrade: a missing file yields None so the
+    caller can drop the route/link rather than abort the whole proxy.
+"""
+from collections import namedtuple
 from functools import lru_cache
 from pathlib import Path
 
@@ -21,11 +30,51 @@ def load_asset_bytes(filename):
     return path.read_bytes()
 
 
-TAB_FIX_SCRIPT = load_asset("tab_fix_script.html")
-TERMINAL_PARENT_TAB_HANDLER = load_asset("terminal_parent_tab_handler.html")
-VIRTUAL_KEYBOARD_STYLE = load_asset("virtual_keyboard_style.css")
-VIRTUAL_KEYBOARD_HTML = load_asset("virtual_keyboard.html")
-FAVICON_ICO = load_asset_bytes("favicon.ico")
-FAVICON_16_PNG = load_asset_bytes("favicon-16x16.png")
-FAVICON_32_PNG = load_asset_bytes("favicon-32x32.png")
-APPLE_TOUCH_ICON_PNG = load_asset_bytes("apple-touch-icon.png")
+def _load_required(filename):
+    """Eager-load a required asset; fail fast with a file-naming error."""
+    try:
+        return load_asset(filename)
+    except (FileNotFoundError, OSError) as exc:
+        raise RuntimeError(f"Required asset missing: {ASSET_DIR / filename}") from exc
+
+
+def _load_optional_bytes(filename):
+    """Eager-load a decorative asset; return None if it can't be read."""
+    try:
+        return load_asset_bytes(filename)
+    except (FileNotFoundError, OSError):
+        return None
+
+
+# Required assets: a missing one is a real outage, surfaced clearly.
+TAB_FIX_SCRIPT = _load_required("tab_fix_script.html")
+TERMINAL_PARENT_TAB_HANDLER = _load_required("terminal_parent_tab_handler.html")
+VIRTUAL_KEYBOARD_STYLE = _load_required("virtual_keyboard_style.css")
+VIRTUAL_KEYBOARD_HTML = _load_required("virtual_keyboard.html")
+
+# Single favicon registry: one row per icon carries everything its consumers
+# need — the HTTP route (path, content_type), the page <link>, and the loaded
+# bytes (None if the decorative file is missing). app.py builds FAVICON_ROUTES
+# and views.py builds FAVICON_LINKS from this, so adding/removing an icon is a
+# one-line change with no risk of the route/link lists drifting apart (B18).
+Favicon = namedtuple("Favicon", "path content_type link body")
+FAVICONS = (
+    Favicon("/favicon.ico", "image/x-icon",
+            '<link rel="icon" href="/favicon.ico" sizes="any">',
+            _load_optional_bytes("favicon.ico")),
+    Favicon("/favicon-16x16.png", "image/png",
+            '<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">',
+            _load_optional_bytes("favicon-16x16.png")),
+    Favicon("/favicon-32x32.png", "image/png",
+            '<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">',
+            _load_optional_bytes("favicon-32x32.png")),
+    Favicon("/apple-touch-icon.png", "image/png",
+            '<link rel="apple-touch-icon" href="/apple-touch-icon.png">',
+            _load_optional_bytes("apple-touch-icon.png")),
+)
+
+# Back-compat aliases for direct byte access (e.g. tests asserting magic bytes).
+FAVICON_ICO = FAVICONS[0].body
+FAVICON_16_PNG = FAVICONS[1].body
+FAVICON_32_PNG = FAVICONS[2].body
+APPLE_TOUCH_ICON_PNG = FAVICONS[3].body

--- a/app/ttydproxy/cleanup.py
+++ b/app/ttydproxy/cleanup.py
@@ -103,7 +103,10 @@ def _resolve_within_root(path, root):
     try:
         resolved_root = root.resolve()
         resolved_path = path.resolve()
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError covers a path with an embedded NUL/illegal byte
+        # (pathlib raises 'embedded null byte'); treat it as an unknown
+        # target rather than letting it crash the handler (B9).
         return None
     try:
         resolved_path.relative_to(resolved_root)

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -13,12 +13,19 @@ TTYD_BASE_PORT = 7681
 CLEANUP_ROOT = os.environ.get("CLEANUP_ROOT", "/home/hapi")
 HAPI_HOME = os.environ.get("HAPI_HOME", f"{CLEANUP_ROOT}/.hapi")
 MAX_TERMINALS = env_int(os.environ.get("MAX_TERMINALS"), 100, name="MAX_TERMINALS")
-SESSION_TIMEOUT = env_int(os.environ.get("SESSION_TIMEOUT"), 604800, name="SESSION_TIMEOUT")
+# minimum=1: a non-positive TTL would issue already-expired tokens and lock out
+# every login / reject every CSRF check (B1).
+SESSION_TIMEOUT = env_int(os.environ.get("SESSION_TIMEOUT"), 604800, name="SESSION_TIMEOUT", minimum=1)
 VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
-CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL")
+CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL", minimum=1)
 SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
 MAX_UPLOAD_SIZE = env_int(os.environ.get("MAX_UPLOAD_SIZE"), 10485760, name="MAX_UPLOAD_SIZE")
 UPLOAD_DIR = os.environ.get("UPLOAD_DIR", f"{CLEANUP_ROOT}/.uploads")
 
-TTYD_ROUTE_PATTERN = re.compile(r"^/ttyd(\d+)(/.*)?$")
+# Single source of truth for the terminal-id digit cap. Bounding the length
+# keeps int() from ever hitting Python's 4300-digit string-conversion limit on
+# an unauthenticated path; an over-long id fails to match / fails the guard and
+# falls through to a 404. Used by both the GET route regex and do_DELETE (B7/B8).
+MAX_TERMINAL_ID_DIGITS = 9
+TTYD_ROUTE_PATTERN = re.compile(rf"^/ttyd(\d{{1,{MAX_TERMINAL_ID_DIGITS}}})(/.*)?$")

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -14,7 +14,8 @@ CLEANUP_ROOT = os.environ.get("CLEANUP_ROOT", "/home/hapi")
 HAPI_HOME = os.environ.get("HAPI_HOME", f"{CLEANUP_ROOT}/.hapi")
 MAX_TERMINALS = env_int(os.environ.get("MAX_TERMINALS"), 100, name="MAX_TERMINALS")
 # minimum=1: a non-positive TTL would issue already-expired tokens and lock out
-# every login / reject every CSRF check (B1).
+# every login / reject every CSRF check. A bad value clamps to 1s (fail-closed),
+# never expands to the week-long default (B1).
 SESSION_TIMEOUT = env_int(os.environ.get("SESSION_TIMEOUT"), 604800, name="SESSION_TIMEOUT", minimum=1)
 VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
 CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL", minimum=1)

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -27,6 +27,10 @@ TUNNEL_RECV_SIZE = 8192
 TUNNEL_MAX_PENDING = 1048576  # 1 MiB per direction before backpressure kicks in
 TUNNEL_SELECT_TIMEOUT = 60
 
+# Largest request body forwarded to ttyd. A client body above this is rejected
+# with 413 rather than silently dropped (B4).
+TTYD_MAX_BODY = 10485760  # 10 MiB
+
 
 def is_websocket_request(handler):
     """Check if the current request is a WebSocket upgrade request."""
@@ -46,7 +50,13 @@ def build_ttyd_headers(handler, port):
 
 
 def inject_tab_fix_script(data):
-    """Inject the Tab fix script into ttyd HTML responses."""
+    """Inject the Tab fix script into ttyd HTML responses.
+
+    On any failure the ORIGINAL input bytes are returned unchanged, so a caller
+    forwarding Content-Encoding: gzip stays consistent even when the
+    decompressed payload can't be decoded (B3).
+    """
+    original = data
     try:
         is_gzipped = False
         if len(data) >= 2 and data[0:2] == b"\x1f\x8b":
@@ -54,7 +64,7 @@ def inject_tab_fix_script(data):
                 data = gzip.decompress(data)
                 is_gzipped = True
             except Exception:
-                return data
+                return original
 
         html = data.decode("utf-8")
         script = TAB_FIX_SCRIPT
@@ -76,7 +86,7 @@ def inject_tab_fix_script(data):
             result = gzip.compress(result)
         return result
     except Exception:
-        return data
+        return original
 
 
 def tunnel_sockets(handler, upstream):
@@ -203,13 +213,24 @@ def proxy_ttyd_http(handler, upstream_path, port):
     """Proxy an HTTP request to ttyd."""
     body = None
     content_length = handler.headers.get("Content-Length")
-    if content_length:
+    if content_length is not None:
+        # A malformed/oversized body must be rejected with an explicit 4xx, not
+        # silently dropped while the request is forwarded body-less (B4).
         try:
             length = int(content_length)
         except ValueError:
-            length = 0
-        if 0 < length <= 10485760:
+            handler.send_json(400, {"error": "Invalid Content-Length"})
+            return
+        if length < 0 or length > TTYD_MAX_BODY:
+            handler.send_json(413, {"error": "Request too large"})
+            return
+        if length > 0:
             body = handler.rfile.read(length)
+    elif handler.headers.get("Transfer-Encoding"):
+        # No Content-Length but the client framed a body (e.g. chunked). We do
+        # not de-chunk; forwarding an empty body would silently lose it (B4).
+        handler.send_json(411, {"error": "Length required"})
+        return
 
     conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
     try:
@@ -223,6 +244,9 @@ def proxy_ttyd_http(handler, upstream_path, port):
             if key.lower() == "content-type":
                 content_type = value
                 break
+        # Normalize the value so injection + CSP hardening fire regardless of
+        # upstream header casing (e.g. 'Text/HTML') (B6).
+        content_type = content_type.lower()
 
         if "text/html" in content_type and data:
             data = inject_tab_fix_script(data)

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -26,20 +26,33 @@ def env_bool(value, default=False):
     return default
 
 
-def env_int(value, default, name=None):
-    """Parse an integer env var value, falling back to default on garbage."""
+def env_int(value, default, name=None, minimum=None):
+    """Parse an integer env var value, falling back to default on garbage.
+
+    When `minimum` is given, a parsed value below it is rejected (warning +
+    default). This guards time-to-live settings against a non-positive value
+    that would otherwise issue already-expired tokens and lock out logins (B1).
+    """
     if value is None or str(value).strip() == "":
         return default
+    label = name or "env var"
     try:
-        return int(str(value).strip())
+        result = int(str(value).strip())
     except ValueError:
-        label = name or "env var"
         print(
             f"Invalid integer for {label}: {value!r}, using default {default}",
             file=sys.stderr,
             flush=True,
         )
         return default
+    if minimum is not None and result < minimum:
+        print(
+            f"{label}: {result} below minimum {minimum}, using default {default}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return default
+    return result
 
 
 def env_secret(name, default):

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -29,9 +29,11 @@ def env_bool(value, default=False):
 def env_int(value, default, name=None, minimum=None):
     """Parse an integer env var value, falling back to default on garbage.
 
-    When `minimum` is given, a parsed value below it is rejected (warning +
-    default). This guards time-to-live settings against a non-positive value
-    that would otherwise issue already-expired tokens and lock out logins (B1).
+    When `minimum` is given, a parsed value below it is clamped UP to the
+    minimum (warning + minimum). This guards time-to-live settings against a
+    non-positive value that would otherwise issue already-expired tokens and
+    lock out logins (B1) — clamping fails CLOSED (the access window shrinks to
+    the minimum) rather than expanding to a possibly-large default.
     """
     if value is None or str(value).strip() == "":
         return default
@@ -47,11 +49,11 @@ def env_int(value, default, name=None, minimum=None):
         return default
     if minimum is not None and result < minimum:
         print(
-            f"{label}: {result} below minimum {minimum}, using default {default}",
+            f"{label}: {result} below minimum {minimum}, clamping to {minimum}",
             file=sys.stderr,
             flush=True,
         )
-        return default
+        return minimum
     return result
 
 

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -29,14 +29,20 @@ def env_bool(value, default=False):
 def env_int(value, default, name=None, minimum=None):
     """Parse an integer env var value, falling back to default on garbage.
 
-    When `minimum` is given, a parsed value below it is clamped UP to the
-    minimum (warning + minimum). This guards time-to-live settings against a
+    When `minimum` is given, the result is never returned below it: a parsed
+    value below the minimum (or a fallback `default` below it) is clamped UP to
+    the minimum (warning + minimum). This guards time-to-live settings against a
     non-positive value that would otherwise issue already-expired tokens and
     lock out logins (B1) — clamping fails CLOSED (the access window shrinks to
     the minimum) rather than expanding to a possibly-large default.
     """
+    def _floor(n):
+        # The minimum binds every return path, so even a sub-minimum default
+        # (no real caller passes one today) can't silently undercut the floor.
+        return n if minimum is None or n >= minimum else minimum
+
     if value is None or str(value).strip() == "":
-        return default
+        return _floor(default)
     label = name or "env var"
     try:
         result = int(str(value).strip())
@@ -46,7 +52,7 @@ def env_int(value, default, name=None, minimum=None):
             file=sys.stderr,
             flush=True,
         )
-        return default
+        return _floor(default)
     if minimum is not None and result < minimum:
         print(
             f"{label}: {result} below minimum {minimum}, clamping to {minimum}",

--- a/app/ttydproxy/uploads.py
+++ b/app/ttydproxy/uploads.py
@@ -15,7 +15,8 @@ _SIGNATURES = (
 )
 
 # How many times to regenerate the random filename on an O_EXCL collision before
-# giving up. 32 bits of randomness makes one collision astronomically unlikely;
+# giving up. The name is a per-second timestamp plus 32 bits of randomness, so a
+# collision needs the same second AND the same nonce — astronomically unlikely;
 # a handful of attempts is plenty (B5).
 _MAX_NAME_ATTEMPTS = 5
 

--- a/app/ttydproxy/uploads.py
+++ b/app/ttydproxy/uploads.py
@@ -14,6 +14,11 @@ _SIGNATURES = (
     (b"GIF89a", "gif"),
 )
 
+# How many times to regenerate the random filename on an O_EXCL collision before
+# giving up. 32 bits of randomness makes one collision astronomically unlikely;
+# a handful of attempts is plenty (B5).
+_MAX_NAME_ATTEMPTS = 5
+
 
 def detect_image_extension(data):
     """Return the file extension for known image magic bytes, else None."""
@@ -140,16 +145,29 @@ def save_upload(data, upload_dir, owner):
     # recreate it (and any missing parents) on every save.
     dir_fd = _open_upload_dir_nofollow(upload_dir, ids)
     try:
-        name = f"img-{time.strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(4)}.{extension}"
-        # Resolve `name` relative to the open directory inode (dir_fd), not by
-        # walking upload_dir again; O_EXCL keeps the "xb" semantics and
-        # O_NOFOLLOW rejects a symlink someone planted under that name.
-        file_fd = os.open(
-            name,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-            0o600,
-            dir_fd=dir_fd,
-        )
+        # Bounded retry: a generated-name collision (O_EXCL FileExistsError —
+        # a token_hex collision in the same second, or a pre-created
+        # predictable-prefix name) regenerates a fresh suffix rather than
+        # failing the upload (B5). The O_EXCL/O_NOFOLLOW atomicity is preserved.
+        for _ in range(_MAX_NAME_ATTEMPTS):
+            name = f"img-{time.strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(4)}.{extension}"
+            # Resolve `name` relative to the open directory inode (dir_fd), not
+            # by walking upload_dir again; O_EXCL keeps the "xb" semantics and
+            # O_NOFOLLOW rejects a symlink someone planted under that name.
+            try:
+                file_fd = os.open(
+                    name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                    0o600,
+                    dir_fd=dir_fd,
+                )
+                break
+            except FileExistsError:
+                continue
+        else:
+            raise FileExistsError(
+                f"could not allocate a unique upload filename after {_MAX_NAME_ATTEMPTS} attempts"
+            )
         try:
             _fchown_best_effort(file_fd, ids)
             with open(file_fd, "wb", closefd=False) as upload_file:

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -11,12 +11,11 @@ from ttydproxy.security import env_bool
 APP_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = APP_ROOT
 
-FAVICON_LINKS = "\n  ".join((
-    '<link rel="icon" href="/favicon.ico" sizes="any">',
-    '<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">',
-    '<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">',
-    '<link rel="apple-touch-icon" href="/apple-touch-icon.png">',
-))
+# Only advertise a <link> for a favicon that actually loaded, so a missing
+# decorative PNG is not referenced by a dead route (B18).
+FAVICON_LINKS = "\n  ".join(
+    icon.link for icon in assets.FAVICONS if icon.body is not None
+)
 
 # Placeholders substituted into every rendered page.
 BASE_REPLACEMENTS = {"{{FAVICON}}": FAVICON_LINKS}

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,10 @@ PACKAGE_FILE="cli-packages.txt"
 # Получаем версию пакета с retry (соответствует паттерну из CLAUDE.md)
 get_version() {
   for i in 1 2 3 4 5; do
-    ver=$(npm view "$1" version 2>/dev/null) && echo "$ver" && return || sleep 10
+    # Require non-empty output: an empty `npm view` (exit 0 but blank — transient
+    # registry response or a missing version field) must fall through to a retry
+    # and ultimately "unknown", so the unknown-count guard/warning engage (B14).
+    ver=$(npm view "$1" version 2>/dev/null) && [ -n "$ver" ] && echo "$ver" && return || sleep 10
   done
   echo "unknown"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -237,7 +237,9 @@ if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
     for i in $(seq 1 60); do
       if [ -f "${HAPI_SERVER_LOG}" ] && [ -f "${HAPI_SETTINGS_FILE}" ]; then
         # Extract relay URL from log: https://xxx.relay.hapi.run
-        RELAY_URL=$(grep -oE 'https://[a-z0-9]+\.relay\.hapi\.run' "${HAPI_SERVER_LOG}" 2>/dev/null | head -1 || true)
+        # Allow valid DNS-label chars (hyphen + mixed case): a subdomain like
+        # my-sub-01.relay.hapi.run must match or the URL is never built (B12).
+        RELAY_URL=$(grep -oE 'https://[A-Za-z0-9-]+\.relay\.hapi\.run' "${HAPI_SERVER_LOG}" 2>/dev/null | head -1 || true)
         # Extract token from settings.json
         TOKEN=$(grep -oE '"cliApiToken":\s*"[^"]+"' "${HAPI_SETTINGS_FILE}" 2>/dev/null | sed 's/.*"cliApiToken":\s*"\([^"]*\)".*/\1/' || true)
         if [ -n "$RELAY_URL" ] && [ -n "$TOKEN" ]; then
@@ -253,6 +255,11 @@ if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
       fi
       sleep 1
     done
+    # Visible failure path: if the loop ran out without writing the URL file,
+    # the relay log never produced a matching URL (B12) — don't fail silently.
+    if [ ! -f "${HAPI_URL_FILE}" ]; then
+      echo "WARNING: could not build hapi connection URL after 60s; relay log did not contain a matching URL" >&2
+    fi
   ) &
 
   # Start hapi runner if enabled (reads config from volume)

--- a/tests/unit/test_assets.py
+++ b/tests/unit/test_assets.py
@@ -1,0 +1,95 @@
+"""A single missing static asset must not take down the whole proxy (B18).
+
+assets.py eagerly loads the injected scripts and the favicons at import time.
+load_template (views.py) degrades gracefully on a missing file; the asset
+loaders must follow a consistent contract:
+  - a missing *decorative* favicon degrades (the route/link is dropped), the
+    proxy still imports and serves login/terminal/health;
+  - a missing *required* asset (tab_fix_script, vkbd) fails fast with a clear
+    error naming the file, not a bare deep traceback.
+
+The import is exercised in a fresh subprocess against a COPY of app/ so we never
+touch the repo tree and never collide with already-imported modules.
+"""
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SRC_APP = REPO_ROOT / "app"
+
+
+class AssetDegradationTest(unittest.TestCase):
+    def _run_import(self, app_dir, probe):
+        """Import ttydproxy.app from app_dir in a subprocess, then run probe.
+
+        probe is python source that may print markers / sys.exit(nonzero).
+        Returns the CompletedProcess.
+        """
+        lines = [
+            "import sys",
+            f"sys.path.insert(0, {str(app_dir)!r})",
+            "try:",
+            "    from ttydproxy import app",
+            "except Exception as exc:",
+            '    print("IMPORT_FAILED:" + type(exc).__name__ + ":" + str(exc))',
+            "    sys.exit(3)",
+        ]
+        lines.extend(probe.splitlines())
+        script = "\n".join(lines)
+        return subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+
+    def _fresh_copy(self):
+        tmp = tempfile.mkdtemp(prefix="b18_")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        dst = os.path.join(tmp, "app")
+        shutil.copytree(SRC_APP, dst)
+        return dst
+
+    def test_all_assets_present_imports_cleanly(self):
+        app_dir = self._fresh_copy()
+        probe = (
+            "print('ROUTES:' + ','.join(sorted(app.FAVICON_ROUTES.keys())))"
+        )
+        result = self._run_import(app_dir, probe)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("/favicon.ico", result.stdout)
+        self.assertIn("/favicon-16x16.png", result.stdout)
+
+    def test_missing_favicon_degrades_not_crash(self):
+        app_dir = self._fresh_copy()
+        os.remove(os.path.join(app_dir, "assets", "favicon-16x16.png"))
+        probe = (
+            "print('ROUTES:' + ','.join(sorted(app.FAVICON_ROUTES.keys())))\n"
+            "from ttydproxy import views\n"
+            "print('LINKS:' + views.FAVICON_LINKS)"
+        )
+        result = self._run_import(app_dir, probe)
+        # Import must SUCCEED despite the missing decorative file.
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        # The missing favicon's route must be dropped, others kept.
+        self.assertNotIn("/favicon-16x16.png", result.stdout)
+        self.assertIn("/favicon.ico", result.stdout)
+        # And its <link> must not be advertised.
+        self.assertNotIn("favicon-16x16.png", result.stdout.split("LINKS:")[1])
+
+    def test_missing_required_asset_raises_clear_error(self):
+        app_dir = self._fresh_copy()
+        os.remove(os.path.join(app_dir, "assets", "tab_fix_script.html"))
+        result = self._run_import(app_dir, "pass")
+        # A required asset is fatal, but with a clear message naming the file.
+        self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
+        self.assertIn("IMPORT_FAILED:", result.stdout)
+        self.assertIn("tab_fix_script.html", result.stdout)
+        # Not a bare FileNotFoundError traceback — a deliberate RuntimeError.
+        self.assertIn("RuntimeError", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -6,7 +6,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from ttydproxy.cleanup import _format_size, delete_cleanup_targets, list_cleanup_targets, summarize_cleanup_targets
+from ttydproxy.cleanup import (
+    _format_size,
+    _resolve_within_root,
+    delete_cleanup_targets,
+    list_cleanup_targets,
+    summarize_cleanup_targets,
+)
 
 
 def write_file(path, size):
@@ -250,6 +256,34 @@ class TestCleanupDeletion(unittest.TestCase):
         self.assertEqual(len(result["errors"]), 1)
         self.assertFalse(good_dir.exists())
         self.assertTrue(bad_dir.exists())
+
+
+class TestCleanupIllegalPathBytes(unittest.TestCase):
+    """A target id with a NUL (or other path-illegal) byte must not crash the
+    handler: pathlib.resolve() raises ValueError('embedded null byte'), which
+    must be treated as an unknown target, not propagated (B9).
+    """
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.hapi_home = self.root / ".hapi"
+        self.hapi_home.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_resolve_within_root_rejects_nul_byte(self):
+        # The unit-level cause: ValueError must yield None, not propagate.
+        self.assertIsNone(_resolve_within_root(Path("foo\x00bar"), self.root))
+
+    def test_nul_byte_id_treated_as_unknown(self):
+        result = delete_cleanup_targets(
+            ["project:foo\x00bar"], str(self.root), str(self.hapi_home)
+        )
+        self.assertEqual(result["deleted"], [])
+        skipped_ids = [entry["id"] for entry in result["skipped"]]
+        self.assertIn("project:foo\x00bar", skipped_ids)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_config_timeouts.py
+++ b/tests/unit/test_config_timeouts.py
@@ -1,0 +1,56 @@
+"""TTL config settings must be floored to a sane minimum (B1).
+
+A negative SESSION_TIMEOUT (operator typo) otherwise produces session tokens
+that are already expired at issue time, locking out every successful login. The
+fix applies minimum=1 to the TTL settings in config.py, so a non-positive value
+falls back to the default instead.
+"""
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+from ttydproxy import security
+
+
+class TestConfigTimeoutFloor(unittest.TestCase):
+    def _reload_config_with(self, **env):
+        with patch.dict(os.environ, env, clear=False):
+            config = importlib.import_module("ttydproxy.config")
+            return importlib.reload(config)
+
+    def tearDown(self):
+        # Restore module to a pristine (env-free) state for other tests.
+        config = importlib.import_module("ttydproxy.config")
+        with patch.dict(os.environ, {}, clear=False):
+            for key in ("SESSION_TIMEOUT", "CSRF_TOKEN_TTL"):
+                os.environ.pop(key, None)
+            importlib.reload(config)
+
+    def test_negative_session_timeout_falls_back_to_default(self):
+        config = self._reload_config_with(SESSION_TIMEOUT="-1")
+        self.assertEqual(config.SESSION_TIMEOUT, 604800)
+
+    def test_zero_csrf_ttl_falls_back_to_default(self):
+        config = self._reload_config_with(CSRF_TOKEN_TTL="0")
+        self.assertEqual(config.CSRF_TOKEN_TTL, 604800)
+
+    def test_positive_values_are_kept(self):
+        config = self._reload_config_with(
+            SESSION_TIMEOUT="3600", CSRF_TOKEN_TTL="7200"
+        )
+        self.assertEqual(config.SESSION_TIMEOUT, 3600)
+        self.assertEqual(config.CSRF_TOKEN_TTL, 7200)
+
+
+class TestSessionTokenSurvivesFlooredTimeout(unittest.TestCase):
+    """End-to-end contract: a token built with the floored default round-trips."""
+
+    def test_roundtrip_with_default_timeout(self):
+        secret = "secret"
+        token = security.build_session_token("alice", secret, 604800)
+        self.assertEqual(security.parse_session_token(token, secret), "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_config_timeouts.py
+++ b/tests/unit/test_config_timeouts.py
@@ -3,7 +3,8 @@
 A negative SESSION_TIMEOUT (operator typo) otherwise produces session tokens
 that are already expired at issue time, locking out every successful login. The
 fix applies minimum=1 to the TTL settings in config.py, so a non-positive value
-falls back to the default instead.
+is clamped UP to the minimum (1s) — fail-closed: the access window shrinks to
+almost nothing rather than silently expanding to the week-long default.
 """
 import importlib
 import os
@@ -27,13 +28,15 @@ class TestConfigTimeoutFloor(unittest.TestCase):
                 os.environ.pop(key, None)
             importlib.reload(config)
 
-    def test_negative_session_timeout_falls_back_to_default(self):
+    def test_negative_session_timeout_clamps_to_minimum(self):
+        # Fail-closed: a non-positive auth TTL shrinks to 1s, NOT the week-long
+        # default — a typo must not silently widen the access window.
         config = self._reload_config_with(SESSION_TIMEOUT="-1")
-        self.assertEqual(config.SESSION_TIMEOUT, 604800)
+        self.assertEqual(config.SESSION_TIMEOUT, 1)
 
-    def test_zero_csrf_ttl_falls_back_to_default(self):
+    def test_zero_csrf_ttl_clamps_to_minimum(self):
         config = self._reload_config_with(CSRF_TOKEN_TTL="0")
-        self.assertEqual(config.CSRF_TOKEN_TTL, 604800)
+        self.assertEqual(config.CSRF_TOKEN_TTL, 1)
 
     def test_positive_values_are_kept(self):
         config = self._reload_config_with(

--- a/tests/unit/test_env_int.py
+++ b/tests/unit/test_env_int.py
@@ -78,6 +78,13 @@ class TestEnvIntMinimum(unittest.TestCase):
         # verbatim (e.g. settings where negative is meaningful).
         self.assertEqual(env_int("-5", 1), -5)
 
+    def test_sub_minimum_default_is_also_floored(self):
+        # The minimum binds the fallback paths too: a default below the minimum
+        # is clamped up, so the floor can never be silently undercut.
+        self.assertEqual(env_int(None, 0, minimum=1), 1)
+        self.assertEqual(env_int("", 0, minimum=1), 1)
+        self.assertEqual(env_int("abc", 0, minimum=1), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_env_int.py
+++ b/tests/unit/test_env_int.py
@@ -48,13 +48,15 @@ class TestEnvIntDefault(unittest.TestCase):
 class TestEnvIntMinimum(unittest.TestCase):
     """A lower bound for time-to-live settings: a non-positive value must not be
     accepted verbatim (it would issue already-expired tokens / lock out logins).
+    Below-minimum values clamp UP to the minimum (fail-closed) rather than
+    expanding to a possibly-large default.
     """
 
-    def test_below_minimum_returns_default(self):
-        self.assertEqual(env_int("-1", 604800, minimum=1), 604800)
+    def test_below_minimum_clamps_to_minimum(self):
+        self.assertEqual(env_int("-1", 604800, minimum=1), 1)
 
-    def test_zero_below_minimum_returns_default(self):
-        self.assertEqual(env_int("0", 100, minimum=1), 100)
+    def test_zero_below_minimum_clamps_to_minimum(self):
+        self.assertEqual(env_int("0", 100, minimum=1), 1)
 
     def test_at_minimum_is_kept(self):
         self.assertEqual(env_int("1", 100, minimum=1), 1)
@@ -68,7 +70,8 @@ class TestEnvIntMinimum(unittest.TestCase):
             env_int("-1", 604800, name="SESSION_TIMEOUT", minimum=1)
         message = buf.getvalue()
         self.assertIn("SESSION_TIMEOUT", message)
-        self.assertIn("604800", message)
+        # The warning must surface the clamp target (the minimum), not silence.
+        self.assertIn("1", message)
 
     def test_no_minimum_keeps_negative(self):
         # Backwards compatible: without a minimum, a negative value is returned

--- a/tests/unit/test_env_int.py
+++ b/tests/unit/test_env_int.py
@@ -45,5 +45,36 @@ class TestEnvIntDefault(unittest.TestCase):
         self.assertEqual(buf.getvalue(), "")
 
 
+class TestEnvIntMinimum(unittest.TestCase):
+    """A lower bound for time-to-live settings: a non-positive value must not be
+    accepted verbatim (it would issue already-expired tokens / lock out logins).
+    """
+
+    def test_below_minimum_returns_default(self):
+        self.assertEqual(env_int("-1", 604800, minimum=1), 604800)
+
+    def test_zero_below_minimum_returns_default(self):
+        self.assertEqual(env_int("0", 100, minimum=1), 100)
+
+    def test_at_minimum_is_kept(self):
+        self.assertEqual(env_int("1", 100, minimum=1), 1)
+
+    def test_above_minimum_is_kept(self):
+        self.assertEqual(env_int("5000", 100, minimum=1), 5000)
+
+    def test_below_minimum_warns_to_stderr(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            env_int("-1", 604800, name="SESSION_TIMEOUT", minimum=1)
+        message = buf.getvalue()
+        self.assertIn("SESSION_TIMEOUT", message)
+        self.assertIn("604800", message)
+
+    def test_no_minimum_keeps_negative(self):
+        # Backwards compatible: without a minimum, a negative value is returned
+        # verbatim (e.g. settings where negative is meaningful).
+        self.assertEqual(env_int("-5", 1), -5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_favicon.py
+++ b/tests/unit/test_favicon.py
@@ -16,6 +16,11 @@ FAVICON_LINKS = (
 
 class TestFavicon(unittest.TestCase):
     def test_favicon_assets_are_loaded(self):
+        # The aliases degrade to None when a file is missing (B18); assert they
+        # actually loaded first, so a missing asset reads as a clear failure
+        # rather than an AttributeError on the .startswith below.
+        for name in ("FAVICON_ICO", "FAVICON_16_PNG", "FAVICON_32_PNG", "APPLE_TOUCH_ICON_PNG"):
+            self.assertIsNotNone(getattr(assets, name), f"{name} failed to load")
         self.assertTrue(assets.FAVICON_ICO.startswith(b"\x00\x00\x01\x00"))
         self.assertTrue(assets.FAVICON_16_PNG.startswith(b"\x89PNG\r\n\x1a\n"))
         self.assertTrue(assets.FAVICON_32_PNG.startswith(b"\x89PNG\r\n\x1a\n"))

--- a/tests/unit/test_inject_tab_fix.py
+++ b/tests/unit/test_inject_tab_fix.py
@@ -81,6 +81,20 @@ class TestInjectSilentFailure(unittest.TestCase):
         data = b"\x1f\x8b" + b"\x00" * 10
         self.assertEqual(inject_tab_fix_script(data), data)
 
+    def test_gzip_valid_but_non_utf8_returns_original(self):
+        # Valid gzip whose DECOMPRESSED payload is not UTF-8: the function must
+        # return the ORIGINAL gzip bytes, not the decompressed buffer. Returning
+        # the latter breaks the forwarded Content-Encoding: gzip header (B3).
+        inner = b"<html><head></head><body>caf\xe9</body></html>"
+        with self.assertRaises(UnicodeDecodeError):
+            inner.decode("utf-8")  # premise: not valid UTF-8
+        original = gzip.compress(inner)
+        out = inject_tab_fix_script(original)
+        self.assertEqual(out, original)
+        self.assertEqual(out[0:2], b"\x1f\x8b")
+        # Still a valid gzip stream the browser can gunzip.
+        self.assertEqual(gzip.decompress(out), inner)
+
 
 class TestInjectTTYDRealistic(unittest.TestCase):
     def test_script_before_ttyd_scripts(self):

--- a/tests/unit/test_proxy_http.py
+++ b/tests/unit/test_proxy_http.py
@@ -1,0 +1,170 @@
+"""Tests for proxy_ttyd_http: request-body framing (B4) and case-insensitive
+Content-Type handling (B6).
+
+These exercise the real proxy_ttyd_http against a fake upstream HTTPConnection
+so we can observe (a) whether a client body is dropped/forwarded and which 4xx
+is returned, and (b) which response headers (CSP) the proxy sends.
+"""
+import io
+import unittest
+from unittest.mock import patch
+
+from ttydproxy import proxy
+from ttydproxy.proxy import TTYD_PROXY_HTML_CSP
+
+
+class FakeResponse:
+    def __init__(self, status=200, reason="OK", headers=None, body=b""):
+        self.status = status
+        self.reason = reason
+        self._headers = headers or []
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def getheaders(self):
+        return self._headers
+
+
+class FakeConn:
+    """Captures the body/method/path passed to conn.request(...)."""
+
+    last_body = "UNSET"
+    last_method = None
+    last_path = None
+    response = None
+
+    def __init__(self, host, port, timeout=None):
+        self.host = host
+        self.port = port
+
+    def request(self, method, path, body=None, headers=None):
+        FakeConn.last_body = body
+        FakeConn.last_method = method
+        FakeConn.last_path = path
+
+    def getresponse(self):
+        return FakeConn.response
+
+    def close(self):
+        pass
+
+
+class StubHandler:
+    """Minimal BaseHTTPRequestHandler surface used by proxy_ttyd_http."""
+
+    def __init__(self, headers=None, body=b"", command="POST"):
+        self.headers = headers or {}
+        self.rfile = io.BytesIO(body)
+        self.command = command
+        self.client_address = ("127.0.0.1", 12345)
+        self.request_version = "HTTP/1.1"
+        self.json_response = None
+        self.status_line = None
+        self.sent_headers = []
+        self.ended = False
+        self.wfile = io.BytesIO()
+
+    def send_json(self, status, data):
+        self.json_response = (status, data)
+
+    def send_response(self, status, reason=None):
+        self.status_line = (status, reason)
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        self.ended = True
+
+    def headers_named(self, name):
+        return [v for k, v in self.sent_headers if k.lower() == name.lower()]
+
+
+def _reset_conn(response):
+    FakeConn.last_body = "UNSET"
+    FakeConn.last_method = None
+    FakeConn.last_path = None
+    FakeConn.response = response
+
+
+class TestRequestBodyFraming(unittest.TestCase):
+    """B4: a client-supplied body must never be silently dropped."""
+
+    def setUp(self):
+        _reset_conn(FakeResponse(headers=[("Content-Type", "text/plain")], body=b"ok"))
+
+    def _run(self, handler):
+        with patch.object(proxy.http.client, "HTTPConnection", FakeConn):
+            proxy.proxy_ttyd_http(handler, "/", 7681)
+
+    def test_non_numeric_content_length_returns_400(self):
+        handler = StubHandler(headers={"Content-Length": "abc"}, body=b"BODYDATA")
+        self._run(handler)
+        self.assertEqual(handler.json_response, (400, {"error": "Invalid Content-Length"}))
+        # The body must NOT have been forwarded to ttyd.
+        self.assertEqual(FakeConn.last_body, "UNSET")
+
+    def test_oversize_content_length_returns_413(self):
+        handler = StubHandler(headers={"Content-Length": "20000000"}, body=b"x")
+        self._run(handler)
+        self.assertEqual(handler.json_response, (413, {"error": "Request too large"}))
+        self.assertEqual(FakeConn.last_body, "UNSET")
+
+    def test_chunked_without_content_length_returns_411(self):
+        handler = StubHandler(
+            headers={"Transfer-Encoding": "chunked"}, body=b"BODYDATA"
+        )
+        self._run(handler)
+        self.assertEqual(handler.json_response, (411, {"error": "Length required"}))
+        self.assertEqual(FakeConn.last_body, "UNSET")
+
+    def test_valid_body_is_forwarded(self):
+        handler = StubHandler(headers={"Content-Length": "8"}, body=b"BODYDATA")
+        self._run(handler)
+        self.assertIsNone(handler.json_response)
+        self.assertEqual(FakeConn.last_body, b"BODYDATA")
+
+    def test_no_body_no_content_length_is_forwarded(self):
+        # A plain GET-like request with no body must still proxy (body=None).
+        handler = StubHandler(headers={}, body=b"", command="GET")
+        self._run(handler)
+        self.assertIsNone(handler.json_response)
+        self.assertIsNone(FakeConn.last_body)
+
+
+class TestContentTypeCaseInsensitivity(unittest.TestCase):
+    """B6: Content-Type matching must be case-insensitive for CSP + injection."""
+
+    def _run_with_content_type(self, ctype):
+        html = b"<html><head></head><body>x</body></html>"
+        _reset_conn(
+            FakeResponse(
+                headers=[
+                    ("Content-Type", ctype),
+                    ("Content-Security-Policy", "default-src *"),
+                ],
+                body=html,
+            )
+        )
+        handler = StubHandler(headers={}, command="GET")
+        with patch.object(proxy.http.client, "HTTPConnection", FakeConn):
+            proxy.proxy_ttyd_http(handler, "/", 7681)
+        return handler
+
+    def test_lowercase_content_type_applies_hardened_csp(self):
+        handler = self._run_with_content_type("text/html; charset=utf-8")
+        csps = handler.headers_named("Content-Security-Policy")
+        self.assertIn(TTYD_PROXY_HTML_CSP, csps)
+        self.assertNotIn("default-src *", csps)
+
+    def test_uppercase_content_type_applies_hardened_csp(self):
+        handler = self._run_with_content_type("Text/HTML; charset=utf-8")
+        csps = handler.headers_named("Content-Security-Policy")
+        self.assertIn(TTYD_PROXY_HTML_CSP, csps)
+        self.assertNotIn("default-src *", csps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_routing_overlong_id.py
+++ b/tests/unit/test_routing_overlong_id.py
@@ -1,0 +1,71 @@
+"""Routing must not crash on an over-long numeric terminal id (B7/B8).
+
+GET /ttyd<N> and DELETE /terminals/<N> reach int() on the id BEFORE any auth.
+Python 3.11+ caps int(str) at sys.get_int_max_str_digits() (default 4300), so a
+>4300-digit id raises ValueError. An unauthenticated request must yield a clean
+404, never an unhandled exception. The fix bounds the digit count at the routing
+layer (regex \\d{1,9} for GET; len cap for DELETE) so the id simply fails to
+match and falls through to the existing 404.
+"""
+import unittest
+from unittest.mock import patch
+
+from ttydproxy.config import TTYD_ROUTE_PATTERN
+
+from tests.unit.handler_stubs import RecordingHandler
+
+
+OVERLONG = "9" * 4301  # passes str.isdigit() but exceeds int()'s 4300-digit cap
+
+
+class TestRoutePattern(unittest.TestCase):
+    def test_overlong_id_does_not_match_pattern(self):
+        self.assertIsNone(TTYD_ROUTE_PATTERN.match("/ttyd" + OVERLONG))
+
+    def test_normal_id_matches_pattern(self):
+        match = TTYD_ROUTE_PATTERN.match("/ttyd7")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "7")
+
+
+class TestGetRouting(unittest.TestCase):
+    def test_overlong_ttyd_id_returns_404(self):
+        handler = RecordingHandler()
+        handler.path = "/ttyd" + OVERLONG
+        # Must not raise (the bug raised ValueError pre-auth).
+        handler.do_GET()
+        self.assertEqual(handler.response, (404, {"error": "Not found"}))
+
+    def test_normal_ttyd_id_routes_to_handle_ttyd(self):
+        handler = RecordingHandler()
+        handler.path = "/ttyd3"
+        with patch.object(RecordingHandler, "handle_ttyd") as mock_ttyd:
+            handler.do_GET()
+        mock_ttyd.assert_called_once_with(3)
+
+    def test_normal_ttyd_subpath_routes_to_proxy(self):
+        handler = RecordingHandler()
+        handler.path = "/ttyd3/ws"
+        with patch.object(RecordingHandler, "handle_ttyd_proxy") as mock_proxy:
+            handler.do_GET()
+        mock_proxy.assert_called_once_with(3)
+
+
+class TestDeleteRouting(unittest.TestCase):
+    def test_overlong_delete_id_returns_404(self):
+        handler = RecordingHandler()
+        handler.path = "/terminals/" + OVERLONG
+        # Must not raise (the bug raised ValueError pre-auth).
+        handler.do_DELETE()
+        self.assertEqual(handler.response, (404, {"error": "Not found"}))
+
+    def test_normal_delete_id_routes(self):
+        handler = RecordingHandler()
+        handler.path = "/terminals/5"
+        with patch.object(RecordingHandler, "handle_terminals_delete") as mock_del:
+            handler.do_DELETE()
+        mock_del.assert_called_once_with(5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -498,5 +498,114 @@ class TestBuildShRegressions(unittest.TestCase):
         self.assertLess(cd_match.start(), build_match.start())
 
 
+class TestEntrypointRelayUrlRegex(unittest.TestCase):
+    """B12: the relay-URL subdomain class must accept valid DNS-label chars.
+
+    A subdomain like my-sub-01.relay.hapi.run (hyphens, digits) must match so
+    the connection URL is built; the original [a-z0-9]+ silently dropped it.
+    """
+
+    def setUp(self):
+        self.text = ENTRYPOINT.read_text()
+
+    def _extract_grep_regex(self):
+        # Pull the actual grep -oE pattern out of the real script so the test
+        # cannot drift from the source.
+        match = re.search(
+            r"grep -oE '(https://[^']*relay\\.hapi\\.run)'", self.text
+        )
+        self.assertIsNotNone(match, "relay-URL grep pattern not found in entrypoint.sh")
+        return match.group(1)
+
+    def _grep_relay_url(self, log):
+        """Run the real entrypoint grep pattern over `log`, return the match."""
+        result = subprocess.run(
+            ["grep", "-oE", self._extract_grep_regex()],
+            input=log, capture_output=True, text=True,
+        )
+        return result.stdout.strip()
+
+    def test_regex_matches_hyphenated_subdomain(self):
+        self.assertEqual(
+            self._grep_relay_url("noise\nready at https://my-sub-01.relay.hapi.run now\n"),
+            "https://my-sub-01.relay.hapi.run",
+            "hyphenated relay subdomain was not matched (B12)",
+        )
+
+    def test_regex_matches_plain_lowercase_subdomain(self):
+        self.assertEqual(
+            self._grep_relay_url("x https://abc123.relay.hapi.run y\n"),
+            "https://abc123.relay.hapi.run",
+        )
+
+    def test_source_uses_dns_label_class(self):
+        self.assertIn("[A-Za-z0-9-]+\\.relay\\.hapi\\.run", self.text)
+        self.assertNotIn("[a-z0-9]+\\.relay\\.hapi\\.run", self.text)
+
+
+class TestDockerEntrypointSignals(unittest.TestCase):
+    """B13: tini must forward signals to the whole process group (-g).
+
+    entrypoint.sh `exec`s sshd after backgrounding the ttyd proxy / hapi server
+    / droid daemon, which are reparented to tini (PID 1). Without -g, tini only
+    SIGTERMs its direct child (sshd); the reparented children are SIGKILLed
+    after the grace period. -g makes `docker stop` reach them gracefully.
+
+    A full repro needs tini as PID 1 inside a container (out of unit scope), so
+    this pins the fix statically.
+    """
+
+    def test_tini_entrypoint_uses_group_signal_flag(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn(
+            '["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]',
+            dockerfile,
+            "tini must run with -g so SIGTERM reaches reparented children (B13)",
+        )
+
+
+class TestBuildShGetVersion(unittest.TestCase):
+    """B14: an empty `npm view` result must be treated as a fetch failure, not
+    accepted as a valid (empty) version that bypasses the unknown-count guard.
+    """
+
+    def _extract_get_version(self):
+        text = BUILD_SH.read_text()
+        match = re.search(r"^get_version\(\) \{\n.*?^\}", text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(match, "get_version() not found in build.sh")
+        return match.group(0)
+
+    def _run_get_version(self, npm_body):
+        get_version = self._extract_get_version()
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_npm = pathlib.Path(tmp) / "npm"
+            fake_npm.write_text("#!/bin/bash\n" + npm_body)
+            fake_npm.chmod(0o755)
+            # sleep 0 so the retry loop doesn't actually wait.
+            script = (
+                "set -uo pipefail\n"
+                "sleep() { :; }\n"
+                f"{get_version}\n"
+                'get_version "somepkg"\n'
+            )
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp}{os.pathsep}{env['PATH']}"
+            return subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, env=env
+            )
+
+    def test_empty_npm_view_becomes_unknown(self):
+        # npm view exits 0 but prints nothing (transient registry / missing field).
+        result = self._run_get_version('printf ""\nexit 0\n')
+        self.assertEqual(result.stdout.strip(), "unknown", result.stderr)
+
+    def test_nonempty_npm_view_passes_through(self):
+        result = self._run_get_version('echo "1.2.3"\nexit 0\n')
+        self.assertEqual(result.stdout.strip(), "1.2.3", result.stderr)
+
+    def test_source_requires_nonempty_version(self):
+        self.assertIn('[ -n "$ver" ]', BUILD_SH.read_text())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_uploads.py
+++ b/tests/unit/test_uploads.py
@@ -183,6 +183,31 @@ class TestSaveUpload(unittest.TestCase):
         second = save_upload(PNG_BYTES, self.dir, "hapi")
         self.assertNotEqual(first, second)
 
+    def test_collision_retries_and_succeeds(self):
+        # A generated-name collision (O_EXCL FileExistsError) must regenerate a
+        # fresh name and retry, not surface as a failed upload (B5). The first
+        # token collides with an existing file; the second succeeds.
+        with patch("ttydproxy.uploads.time.strftime", return_value="20260101-000000"):
+            with patch("ttydproxy.uploads.secrets.token_hex", return_value="deadbeef"):
+                first = save_upload(PNG_BYTES, self.dir, "hapi")
+            with patch(
+                "ttydproxy.uploads.secrets.token_hex",
+                side_effect=["deadbeef", "cafe1234"],
+            ):
+                second = save_upload(PNG_BYTES, self.dir, "hapi")
+        self.assertNotEqual(first, second)
+        self.assertTrue(second.endswith("img-20260101-000000-cafe1234.png"))
+        self.assertEqual(len(os.listdir(self.dir)), 2)
+
+    def test_exhausted_retries_raises(self):
+        # If every generated name collides, the bounded retry eventually gives
+        # up and raises FileExistsError (rather than looping forever).
+        with patch("ttydproxy.uploads.time.strftime", return_value="20260101-000000"):
+            with patch("ttydproxy.uploads.secrets.token_hex", return_value="deadbeef"):
+                save_upload(PNG_BYTES, self.dir, "hapi")
+                with self.assertRaises(FileExistsError):
+                    save_upload(PNG_BYTES, self.dir, "hapi")
+
     def test_concurrent_uploads_into_missing_dir_all_succeed(self):
         # ThreadingHTTPServer runs one thread per request and the client sends
         # up to 5 images per gesture; when uploads/ does not exist yet (fresh


### PR DESCRIPTION
Refs #59 (closes the 13 confirmed bugs; the separate high-priority auth-reset item stays open for a follow-up)

## Summary

Исправлены **причины** (не симптомы) всех 13 test-verified багов из #59, строго по TDD: для каждого бага сначала написан падающий тест против реального кода, затем минимальный фикс причины, затем зелёный прогон. Закрывает #59.

**Тесты:** `python -m pytest tests/` → **276 passed**, `npm test` (JS asset suite) → **15 passed**.

### Medium
- **B1** — `env_int` получил параметр `minimum`; `SESSION_TIMEOUT`/`CSRF_TOKEN_TTL` флорятся к 1. Негативный TTL больше не выдаёт уже-истёкшие токены и не ломает cookie `Max-Age`.
- **B3** — `inject_tab_fix_script` возвращает **оригинальные** байты на любой ошибке (раньше при не-UTF8 содержимом отдавал декомпрессированные байты под `Content-Encoding: gzip`).
- **B4** — `proxy_ttyd_http` отвечает явными `400`/`413`/`411` вместо тихой потери тела при кривом/большом/chunked `Content-Length`.
- **B7/B8** — длина terminal id ограничена единым `MAX_TERMINAL_ID_DIGITS` (regex маршрута + guard в `do_DELETE`); pre-auth `ValueError` на >4300-значном id устранён.
- **B12** — regex извлечения relay-URL принимает дефис/uppercase в субдомене (`[A-Za-z0-9-]+`) + видимый warning, если URL не построен.
- **B13** — `tini -g` форвардит SIGTERM всей process-group, чтобы reparented ttyd-proxy/hapi-server/droid гасились gracefully на `docker stop`.
- **B18** — единый реестр `FAVICONS`; критичные ассеты fail-fast (`RuntimeError` с именем файла), декоративные деградируют (`None`) — отсутствие одной фавиконки больше не рушит весь прокси на импорте.

### Low
- **B5** — `save_upload` ретраит при коллизии сгенерированного имени (`_MAX_NAME_ATTEMPTS`), сохраняя атомарность `O_EXCL`/`O_NOFOLLOW`.
- **B6** — `Content-Type` сравнивается регистронезависимо (инъекция скрипта + hardened CSP).
- **B9** — `_resolve_within_root` ловит `ValueError`; id с NUL-байтом → `skipped`, без краша хендлера.
- **B14** — пустой `npm view` трактуется как fetch-failure → `unknown` (срабатывает существующий unknown-count guard).

## Тесты
**Новые:** `test_routing_overlong_id.py` (B7/B8), `test_proxy_http.py` (B4/B6), `test_assets.py` (B18), `test_config_timeouts.py` (B1).
**Дополнены:** `test_env_int.py`, `test_inject_tab_fix.py`, `test_uploads.py`, `test_cleanup.py`, `test_shell_scripts.py`.

После реализации прогнан `/simplify`: единый реестр фавиконок, единый источник `MAX_TERMINAL_ID_DIGITS`, именованные константы — без изменения поведения.

## Env / ports / volumes
Новых переменных окружения, портов и volume-маппингов нет. `B13` меняет только `ENTRYPOINT` в Dockerfile (`tini -g`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAe7eWFeTRikwYPdB1ZDjK