### PR TITLE
test: pin entrypoint contract for ~/.claude persistence (#69)

### DIFF
--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -132,11 +132,17 @@ class TestClaudeConfigPersistence(unittest.TestCase):
         self.assertIn('ensure_dir_owned "${HAPI_USER_HOME}/.claude"', self.text)
 
     def test_entrypoint_never_removes_claude_config(self):
-        # No rm/rm -rf may target ~/.claude (directly or via HAPI_USER_HOME).
+        # No destructive op may target ~/.claude (directly or via HAPI_USER_HOME).
+        # Covers rm AND the non-rm deletion/truncation mechanisms a future edit
+        # could reach for — find -delete, rmdir, and `:`/`>` truncation — so the
+        # contract is pinned against more than a literal `rm`.
         for pattern in (
             r'rm\s+[^\n]*\.claude\b',
             r'rm\s+[^\n]*\$\{HAPI_USER_HOME\}/\.claude',
             r'rm\s+[^\n]*HOME[^\n]*/\.claude',
+            r'find\s+[^\n]*\.claude[^\n]*-delete',
+            r'rmdir\s+[^\n]*\.claude\b',
+            r'(?:^|[;&|]|\btrue\b)\s*>\s*[^\n]*\.claude',
         ):
             with self.subTest(pattern=pattern):
                 self.assertNotRegex(self.text, re.compile(pattern))

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -115,6 +115,46 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertIn('TTYD_SANDBOX="${TTYD_SANDBOX}"', self.text)
 
 
+class TestClaudeConfigPersistence(unittest.TestCase):
+    """The 'Claude Code login keeps resetting' report (issue #59 tail) blamed
+    lost ~/.claude credentials. Root cause was a missing /home/hapi volume
+    mount, NOT the entrypoint deleting the config. These regressions pin the
+    entrypoint's contract so a future edit can't start wiping ~/.claude and
+    silently reintroduce the symptom on top of a correctly mounted volume.
+    """
+
+    def setUp(self):
+        self.text = ENTRYPOINT.read_text()
+
+    def test_claude_dir_is_ensured_owned_not_recreated(self):
+        # ~/.claude must be created+chowned (so a fresh volume is usable) but
+        # never deleted/recreated, or persisted credentials would vanish.
+        self.assertIn('ensure_dir_owned "${HAPI_USER_HOME}/.claude"', self.text)
+
+    def test_entrypoint_never_removes_claude_config(self):
+        # No rm/rm -rf may target ~/.claude (directly or via HAPI_USER_HOME).
+        for pattern in (
+            r'rm\s+[^\n]*\.claude\b',
+            r'rm\s+[^\n]*\$\{HAPI_USER_HOME\}/\.claude',
+            r'rm\s+[^\n]*HOME[^\n]*/\.claude',
+        ):
+            with self.subTest(pattern=pattern):
+                self.assertNotRegex(self.text, re.compile(pattern))
+
+    def test_cleanup_runner_state_does_not_touch_claude(self):
+        # cleanup_runner_state wipes stale runner state on restart; it must stay
+        # scoped to ~/.hapi / ~/*.json and never list anything under ~/.claude.
+        match = re.search(
+            r"cleanup_runner_state\(\)\s*\{(.*?)\n\}", self.text, re.DOTALL
+        )
+        if match is None:
+            self.fail("cleanup_runner_state() not found")
+        body = match.group(1)
+        self.assertNotIn(".claude", body)
+        # sanity: it does target the runner state files it is meant to clear.
+        self.assertIn("runner.state.json", body)
+
+
 class TestTmuxWrapperSandboxRegressions(unittest.TestCase):
     def setUp(self):
         self.text = TMUX_WRAPPER.read_text()


### PR DESCRIPTION
## Summary

Регресс-тест, фиксирующий контракт entrypoint вокруг `~/.claude`. Закрывает «техдолг трекинга» из хвоста #59: high-priority пункт «авторизация Claude Code в контейнере слетает» вынесен в #69, а этот PR добавляет защиту от регрессии.

**Корень бага** (см. #69) — отсутствие volume-mount для `/home/hapi`: `~/.claude` не переживал перезапуски контейнера. Код entrypoint в этом не виноват, но чтобы будущая правка случайно не начала стирать конфиг и не вернула симптом поверх корректно примонтированного тома, контракт пинятся тестом.

## Что добавлено

`TestClaudeConfigPersistence` в `tests/unit/test_shell_scripts.py`:
- `~/.claude` создаётся+chown-ится (`ensure_dir_owned`), но **не** удаляется/пересоздаётся;
- в entrypoint нет ни одного `rm` по `~/.claude` (прямого или через `$HAPI_USER_HOME`/`$HOME`);
- `cleanup_runner_state` остаётся scoped к `~/.hapi`/runner-state и не трогает `.claude`.

## Тесты

`python -m pytest tests/` → **219 passed** (было 216, +3).

## Env / ports / volumes

Без изменений. Чистый тест-онли PR.

## Что НЕ закрывает

Это не закрывает #69 (поэтому `Refs`, не `Closes`): корневой фикс — переподключение volume на деплое + ручной smoke-тест (залогиниться → `docker restart` → проверить, что сессия жива). Smoke-процедура описана в #69. Закрыть #69 после ручного прогона.

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
