### PR TITLE
feat(dashboard): полноценный режим без hapi — нейтральный заголовок clihost (#63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,10 @@
 # INSTALL_COPILOT=true       # @github/copilot
 # INSTALL_OPENCODE=true      # opencode-ai
 # INSTALL_DROID=true         # droid
-# INSTALL_HAPI=true          # @twsxtd/hapi (ядро рантайма: туннель/runner/URL на дашборде)
+# INSTALL_HAPI=true          # @twsxtd/hapi (ядро рантайма: туннель/runner/URL на дашборде).
+#                            # При INSTALL_HAPI=false образ работает в режиме «только терминал»:
+#                            # дашборд показывает нейтральный заголовок «clihost», а пункт меню
+#                            # «HAPI Server» не отображается (ttyd веб-терминал + SSH остаются).
 # INSTALL_HERMES=true        # Hermes Agent (Nous Research, ставится через pip из GitHub)
 
 # Hapi Runner Configuration (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Each bundled CLI tool can be dropped from the image to build a lighter, deploy-s
 - `bin/install-cli.sh` reads `cli-packages.txt` and installs only the npm tools whose `INSTALL_<KEY>` env var is not `false`. The `Dockerfile` declares one `ARG INSTALL_<KEY>=true` per component and promotes them into the env for that `RUN`. Hermes has its own `INSTALL_HERMES`-gated `RUN`.
 - `build.sh` forwards every `INSTALL_<KEY>` (read from the shell environment, default `true`) to `docker build` as `--build-arg`, and excludes disabled tools from the cache-busting hash (so bumping a disabled tool's version no longer invalidates the cache).
 - Keys: `INSTALL_CLAUDE_CODE`, `INSTALL_CODEX`, `INSTALL_GEMINI`, `INSTALL_COPILOT`, `INSTALL_OPENCODE`, `INSTALL_DROID`, `INSTALL_HAPI`, `INSTALL_HERMES`. Disabling `INSTALL_HAPI` removes the runtime core (tunnel/runner/dashboard URL); the entrypoint skips hapi startup when the binary is absent and warns if `HAPI_RUNNER_ENABLED=true`.
+
+#### Headless mode — running without hapi (issue #63)
+
+Building with `INSTALL_HAPI=false` yields a "terminal-only" image: the relay tunnel, hapi runner, and the dashboard relay-URL are all gone, but the **ttyd web terminal + SSH** keep working as the container's reason to exist. With no relay URL, `render_menu_page` (`views.py`) drops the **"HAPI Server" menu item entirely** (no disabled "(not available)" stub), and the dashboard renders the neutral title `clihost` (via the `{{TITLE}}` placeholder) instead of "HAPI Dashboard". This is purely build-time — there is no `HAPI_ENABLED` runtime flag and `entrypoint.sh` is unchanged; the same neutral-title path also runs whenever hapi is installed but no relay URL was extracted.
 - Every `INSTALL_<KEY>` must be exactly `true` or `false` — `install-cli.sh`, `build.sh`, and the Hermes `RUN` all fail closed on anything else (`False`, `0`, typos) so a misconfigured build never silently ships a tool. Caveat: an invalid value passed straight to `docker build` (bypassing `build.sh`) still fails the build, but for an npm tool the manifest stage `FROM npm-manifest-<tool>-${INSTALL_<KEY>}` errors first with an opaque "base name not found" instead of the friendly message — the strict check in `install-cli.sh` is the readable one.
 
 Examples — drop Codex and Gemini:
@@ -125,7 +129,7 @@ hapi Client → HTTP API (HAPI_PORT) → hapi runner
 
 `app/server.py` — shared `BaseHTTPHandler` (JSON/HTML/binary responses, silent logging, security headers). Server is `ThreadingHTTPServer` (one thread per request) — never switch to plain `HTTPServer`, slow WebSocket connections would block everything.
 
-**Templates & assets:** `app/index.html` (dashboard), `app/login.html`, `app/terminal.html` — variable substitution like `{{USERNAME}}`, `{{CSRF_TOKEN}}`, values escaped via `html.escape()`. Front-end JS/CSS injected into pages lives in `app/assets/` (tab_fix_script.html, virtual_keyboard.html/.css, terminal_parent_tab_handler.html, favicons).
+**Templates & assets:** `app/index.html` (dashboard), `app/login.html`, `app/terminal.html` — variable substitution like `{{TITLE}}`, `{{USERNAME}}`, `{{CSRF_TOKEN}}`, values escaped via `html.escape()`. `{{TITLE}}` defaults to the neutral `DEFAULT_TITLE` (`clihost`) via `BASE_REPLACEMENTS` (applied to every page); `render_terminal_page` overrides it per terminal. On the dashboard, `{{HAPI_LINK}}` is the "HAPI Server" link only when a relay URL is present, otherwise an empty string (no menu item at all). Front-end JS/CSS injected into pages lives in `app/assets/` (tab_fix_script.html, virtual_keyboard.html/.css, terminal_parent_tab_handler.html, favicons).
 
 ### HTTP routes
 
@@ -146,6 +150,8 @@ hapi Client → HTTP API (HAPI_PORT) → hapi runner
 State-changing requests use a CSRF double-submit token (`X-CSRF-Token` header must match the `csrf_token` cookie and verify against PASSWORD_SECRET). Login is rate-limited: 5 attempts per 60s per IP and 5 per 300s per IP+account.
 
 ### Dashboard UI (app/index.html)
+
+The page title/heading is the templated `{{TITLE}}` (rendered as `clihost`), and the "HAPI Server" link (`{{HAPI_LINK}}`) only appears when a relay URL is available — without hapi the menu shows just the terminal list and "+ New terminal".
 
 Terminal list and controls are built **dynamically in JavaScript**, not static HTML — searching for button text in the HTML will not find them:
 - **Close terminal button** (`delete-btn` class, red ×): calls `deleteTerminal(id)` → `DELETE /terminals/{id}`. This is what users mean by "кнопка закрытия сессии". It is **not** a logout button.

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{FAVICON}}
-  <title>HAPI Dashboard</title>
+  <title>{{TITLE}}</title>
   <style>
     * { box-sizing: border-box; }
     body {
@@ -56,12 +56,6 @@
     }
     .menu-link.secondary:hover {
       background: #4d5460;
-    }
-    .menu-link.disabled {
-      background: #2d3240;
-      color: #6b7280;
-      cursor: not-allowed;
-      pointer-events: none;
     }
     .menu-link.new-terminal {
       background: #2d6a4f;
@@ -262,7 +256,7 @@
 </head>
 <body>
   <div class="menu-container">
-    <h1>HAPI Dashboard</h1>
+    <h1>{{TITLE}}</h1>
     <div class="username">{{USERNAME}}</div>
     <div class="menu-links" id="menu-links">
       {{HAPI_LINK}}

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -17,8 +17,12 @@ FAVICON_LINKS = "\n  ".join(
     icon.link for icon in assets.FAVICONS if icon.body is not None
 )
 
-# Placeholders substituted into every rendered page.
-BASE_REPLACEMENTS = {"{{FAVICON}}": FAVICON_LINKS}
+# Neutral dashboard title (issue #63) — shown whether or not hapi is present.
+DEFAULT_TITLE = "clihost"
+
+# Placeholders substituted into every rendered page. {{TITLE}} defaults to the
+# neutral title here; pages that need a dynamic title (e.g. terminals) override it.
+BASE_REPLACEMENTS = {"{{FAVICON}}": FAVICON_LINKS, "{{TITLE}}": DEFAULT_TITLE}
 
 
 @lru_cache(maxsize=None)
@@ -63,7 +67,7 @@ def render_menu_page(username, hapi_url):
         escaped_url = html_module.escape(hapi_url, quote=True)
         hapi_link = f'<a href="{escaped_url}" target="_blank" class="menu-link">HAPI Server</a>'
     else:
-        hapi_link = '<span class="menu-link disabled">HAPI Server (not available)</span>'
+        hapi_link = ""  # without hapi the menu item disappears entirely (issue #63)
     return render_template(
         "index.html",
         {

--- a/tests/unit/test_load_hapi_url.py
+++ b/tests/unit/test_load_hapi_url.py
@@ -1,0 +1,43 @@
+"""Tests for load_hapi_url — the relay-URL contract behind hapi menu gating (issue #63)."""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from ttydproxy.views import load_hapi_url
+
+
+class TestLoadHapiUrl(unittest.TestCase):
+    def _write(self, content):
+        with tempfile.NamedTemporaryFile("w", suffix=".url", delete=False) as f:
+            f.write(content)
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_missing_file_returns_none(self):
+        path = Path(tempfile.gettempdir()) / "clihost-nonexistent-url-file"
+        if path.exists():
+            path.unlink()
+        self.assertIsNone(load_hapi_url(str(path)))
+
+    def test_empty_file_returns_none(self):
+        self.assertIsNone(load_hapi_url(self._write("")))
+
+    def test_whitespace_only_returns_none(self):
+        self.assertIsNone(load_hapi_url(self._write("   \n\t  \n")))
+
+    def test_non_http_url_returns_none(self):
+        self.assertIsNone(load_hapi_url(self._write("ftp://example.com/x")))
+
+    def test_valid_https_url_returned(self):
+        url = "https://app.hapi.run/?token=abc"
+        self.assertEqual(load_hapi_url(self._write(url + "\n")), url)
+
+    def test_valid_http_url_returned(self):
+        url = "http://localhost:8080/x"
+        self.assertEqual(load_hapi_url(self._write(url)), url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_menu_views.py
+++ b/tests/unit/test_menu_views.py
@@ -1,0 +1,39 @@
+"""Tests for render_menu_page — dashboard title and hapi menu item gating (issue #63)."""
+import unittest
+
+from ttydproxy.views import DEFAULT_TITLE, render_menu_page
+
+
+HAPI_URL = "https://app.hapi.run/?token=abc123"
+
+
+class TestMenuViews(unittest.TestCase):
+    def test_hapi_item_rendered_when_url_present(self):
+        page = render_menu_page("hapi", HAPI_URL)
+        self.assertIn("HAPI Server", page)
+        self.assertIn("href=", page)
+        self.assertIn(HAPI_URL, page)
+
+    def test_hapi_item_absent_when_url_missing(self):
+        # Without a relay URL the whole menu item must disappear — no link AND no
+        # disabled "(not available)" placeholder (regression on the removed stub).
+        page = render_menu_page("hapi", None)
+        self.assertNotIn("HAPI Server", page)
+        self.assertNotIn("not available", page)
+
+    def test_neutral_title_both_branches(self):
+        for hapi_url in (HAPI_URL, None):
+            with self.subTest(hapi_url=hapi_url):
+                page = render_menu_page("hapi", hapi_url)
+                self.assertIn(f"<title>{DEFAULT_TITLE}", page)
+                self.assertIn(f"<h1>{DEFAULT_TITLE}", page)
+                self.assertNotIn("HAPI Dashboard", page)
+
+    def test_username_is_escaped(self):
+        page = render_menu_page("<script>alert(1)</script>", None)
+        self.assertNotIn("<script>alert(1)</script>", page)
+        self.assertIn("&lt;script&gt;", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Доводит режим «без hapi» (минимальный образ `INSTALL_HAPI=false`, issue #57/#62) до полноценного: дашборд больше не выглядит «hapi-центричным».

- **Нейтральный заголовок**: жёсткий `HAPI Dashboard` в `<title>` и `<h1>` заменён на шаблонный `{{TITLE}}`, который по умолчанию рендерится как `clihost` (`DEFAULT_TITLE` в `BASE_REPLACEMENTS`). Динамический заголовок терминалов (`render_terminal_page`) по-прежнему переопределяет базовый.
- **Чистое меню**: при отсутствии relay-URL пункт «HAPI Server» исчезает полностью (`hapi_link = ""`), а не показывается disabled-заглушкой `HAPI Server (not available)`.
- **Cleanup**: удалён ставший мёртвым CSS `.menu-link.disabled` (его использовала только удалённая заглушка).

Покрывает пункты issue #63: 1 (копирайт), 2 (убрать пункт), 4 (доки), 5 (тесты). Пункт 3 (`HAPI_ENABLED`) — out of scope по решению: `entrypoint.sh` не трогается, runtime-флаг не вводится, отключение hapi остаётся build-time через `INSTALL_HAPI`.

## Tests (TDD)

- `tests/unit/test_menu_views.py` — заголовок `clihost` в обеих ветках, гейтинг пункта «HAPI Server», экранирование username.
- `tests/unit/test_load_hapi_url.py` — контракт `load_hapi_url` (нет файла/пусто/пробелы/не-http → None; http/https → строка).
- Вся сюита: **287 passed, 157 subtests** (включая `test_favicon.py`).

## Docker-проверка (end-to-end)

- **Без hapi** (`clihost:nohapi`): контейнер не падает (`hapi CLI not found; skipping`), health `ok`, дашборд — title/h1 `clihost`, нет «HAPI Server»/«not available»/«HAPI Dashboard».
- **С hapi** (контроль): relay-туннель поднимается, пункт «HAPI Server» со ссылкой на живой relay-URL, заголовок `clihost`.

## Env / порты / volume

Новых runtime-переменных, портов и volume нет. `.env.example` дополнен комментарием к `INSTALL_HAPI` про режим «только терминал».

🤖 Generated with [Claude Code](https://claude.com/claude-code)