### PR TITLE
feat(entrypoint): optional ao daemon service (AO_DAEMON_ENABLED) (#72 #61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 DROID_DAEMON_ENABLED=false  # Set to 'true' to start `droid daemon --remote-access`
 # DROID_COMPUTER_NAME=clihost  # Required when DROID_DAEMON_ENABLED=true; used for non-interactive registration
 
+# agent-orchestrator daemon (optional, issue #72 / #61)
+# Loopback-only 127.0.0.1:AO_PORT (нет auth/TLS by design). Доступ снаружи — через
+# SSH-туннель (#79): ssh -L 127.0.0.1:3001:127.0.0.1:3001 ... затем localhost:3001.
+AO_DAEMON_ENABLED=false      # Set to 'true' to start `ao daemon` (agent-orchestrator)
+AO_PORT=3001                 # Порт daemon (loopback-only; читается самим daemon)
+
 # ============================================================================
 # Внешний SSH-туннель (issue #79) — RUNTIME-переменные
 # ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Docker container running hapi CLI runner alongside OpenSSH server, bundling AI C
 - `ttyd_proxy.py` (PORT, default 8080) — HTTP/WebSocket reverse proxy with auth; **spawns and manages ttyd processes itself**; runs unprivileged as `TTYD_USER` (entrypoint drops root via `runuser`)
 - `ttyd` (127.0.0.1:7681, 7682, …) — one process per terminal, localhost-only, each attached to its own tmux session `ttyd-{id}` via `bin/tmux-wrapper.sh`
 - `droid daemon --remote-access` — optional remote-access gateway; starts as `hapi` only when `DROID_DAEMON_ENABLED=true`; requires `DROID_COMPUTER_NAME` for non-interactive `droid computer register <name> -y`; logs to `/home/hapi/.hapi/droid-daemon.log`
+- `ao daemon` — optional agent-orchestrator gateway (issues #72/#61); starts as `hapi` only when `AO_DAEMON_ENABLED=true`; binds **loopback-only** `127.0.0.1:AO_PORT` (default 3001) by design — no `AO_HOST`/auth/TLS, so external access is via the SSH tunnel (#79) + `ssh -L 127.0.0.1:3001:127.0.0.1:3001`. Independent of hapi (the `ao` binary is built into the image in #83); logs to `/home/hapi/.hapi/ao-daemon.log`. **No `EXPOSE 3001`** (loopback by design).
 - `hapi server --relay` — always starts; tunnel URL + token are extracted from its log into `/home/hapi/url` (shown on the dashboard)
 - SSH tunnel (`cloudflared` or `chisel`) — optional external SSH access (issue #79); starts as `hapi` only when `SSH_TUNNEL_ENABLED=true`, next to (not inside) the hapi block so it is **independent of hapi** (works with `INSTALL_HAPI=false`); provider chosen by `SSH_TUNNEL_PROVIDER` (default `cloudflared`); logs to `/home/hapi/.hapi/ssh-tunnel.log`; the dashboard connection string is built from env (the public hostname is not logged) into `/home/hapi/ssh-url` (consumed by #80)
 - `hapi runner` (HAPI_PORT, default 80) — optional, requires HAPI_RUNNER_ENABLED=true
@@ -113,7 +114,7 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → drop any stale dashboard URL → if `hapi` is installed, start `hapi server --relay`, extract connection URL, and optionally start hapi runner (otherwise warn and skip) → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → optionally start ao daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → drop any stale dashboard URL → if `hapi` is installed, start `hapi server --relay`, extract connection URL, and optionally start hapi runner (otherwise warn and skip) → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh.
 
@@ -193,6 +194,8 @@ Terminal list and controls are built **dynamically in JavaScript**, not static H
 **Other:**
 - `DROID_DAEMON_ENABLED` — set `true` to start `droid daemon --remote-access` at container start (default: false)
 - `DROID_COMPUTER_NAME` — required when `DROID_DAEMON_ENABLED=true`; limited to letters, numbers, dots, underscores, and dashes; used for non-interactive registration before daemon startup
+- `AO_DAEMON_ENABLED` — set `true` to start `ao daemon` (agent-orchestrator) at container start (default: false). Loopback-only; reach it from the host through the SSH tunnel (#79) + `ssh -L 127.0.0.1:3001:127.0.0.1:3001`. Independent of hapi.
+- `AO_PORT` — `ao daemon` bind port (default: 3001; loopback-only by design, read by the daemon itself; validated numeric in the entrypoint since it is interpolated into the launch string)
 - `HERMES_AUTO_UPDATE` — set `false` to skip Hermes Agent update at container start.
 
 **External SSH tunnel (optional, issue #79):**

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ hapi Client               → hapi runner (80)     → CLI tools
 | `ttyd_proxy.py` | 8080 | Multithreaded HTTP/WS прокси с аутентификацией |
 | `ttyd` | 127.0.0.1:768x | Web-терминал (по одному на сессию, только localhost) |
 | `droid daemon --remote-access` | — | Optional Droid gateway, logs to `/home/hapi/.hapi/droid-daemon.log` |
+| `ao daemon` | 127.0.0.1:3001 | Optional agent-orchestrator gateway (loopback-only), logs to `/home/hapi/.hapi/ao-daemon.log` |
 | `hapi runner` | `HAPI_PORT` (default 80) | Запуск CLI-инструментов по API (опционально) |
 | `hapi server --relay` | — | Туннель для внешнего доступа |
 
@@ -117,6 +118,8 @@ Terminal iframe page и связанные JS/CSS-ассеты лежат в `ap
 | `ROOT_PASSWORD` | - | Enable root SSH access with this password |
 | `DROID_DAEMON_ENABLED` | false | Start `droid daemon --remote-access` for Droid remote access |
 | `DROID_COMPUTER_NAME` | - | Required when `DROID_DAEMON_ENABLED=true`; used for non-interactive `droid computer register <name> -y` |
+| `AO_DAEMON_ENABLED` | false | Start `ao daemon` (agent-orchestrator); loopback-only, reach it through the SSH tunnel |
+| `AO_PORT` | 3001 | `ao daemon` bind port (loopback-only by design; understood by the daemon itself) |
 | `TTYD_SANDBOX` | false | Wrap each tmux session in a bubblewrap jail (see Multi-tenant sandbox below) |
 
 ### Multi-tenant sandbox (optional)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -227,6 +227,14 @@ fi
 # 127.0.0.1:${AO_PORT} by design (no AO_HOST / auth / TLS) — external access is via
 # the existing SSH tunnel (#79) + `ssh -L 127.0.0.1:3001:127.0.0.1:3001`.
 # Independent of hapi (binary built into the image in #83), like the droid daemon.
+#
+# The loopback bind is enforced by the `ao` binary itself, NOT by this script:
+# verified against the binary, the listen address is hardcoded to 127.0.0.1
+# (`ao daemon` exposes no --host/--listen flag and honors no AO_HOST env), and it
+# range-validates AO_PORT on its own. So there is nothing here to pass to keep it
+# on loopback. If a future `ao` upgrade ever adds a bind-host knob or changes the
+# default, this no-auth/no-TLS daemon could be exposed on a published port — re-check
+# that the hardcoded-loopback invariant still holds before bumping the pinned ao ref.
 if [ "${AO_DAEMON_ENABLED}" = "true" ]; then
   # Validate AO_PORT numeric: it is interpolated into the `ao daemon` launch
   # string, so a non-numeric value must fail loudly (mirrors PORT / CHISEL_REMOTE_PORT).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ fi
 : "${HAPI_RUNNER_ENABLED:=false}"
 : "${DROID_DAEMON_ENABLED:=false}"
 : "${DROID_COMPUTER_NAME:=}"
+: "${AO_DAEMON_ENABLED:=false}"
+: "${AO_PORT:=3001}"
 : "${ROOT_PASSWORD:=}"
 : "${TTYD_SANDBOX:=false}"
 
@@ -219,6 +221,34 @@ if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
   fi
 else
   echo "Droid daemon disabled (set DROID_DAEMON_ENABLED=true to enable remote access)"
+fi
+
+# Start agent-orchestrator daemon (issue #72, closes #61). Loopback-only
+# 127.0.0.1:${AO_PORT} by design (no AO_HOST / auth / TLS) — external access is via
+# the existing SSH tunnel (#79) + `ssh -L 127.0.0.1:3001:127.0.0.1:3001`.
+# Independent of hapi (binary built into the image in #83), like the droid daemon.
+if [ "${AO_DAEMON_ENABLED}" = "true" ]; then
+  # Validate AO_PORT numeric: it is interpolated into the `ao daemon` launch
+  # string, so a non-numeric value must fail loudly (mirrors PORT / CHISEL_REMOTE_PORT).
+  case "${AO_PORT}" in
+    ''|*[!0-9]*)
+      echo "ERROR: AO_PORT='${AO_PORT}' must be a positive integer" >&2
+      exit 1
+      ;;
+  esac
+  if PATH="${HAPI_RUN_PATH}" command -v ao >/dev/null 2>&1; then
+    AO_DAEMON_LOG="${HAPI_HOME}/ao-daemon.log"
+    touch "${AO_DAEMON_LOG}"
+    chown "${HAPI_USER}:${HAPI_USER}" "${AO_DAEMON_LOG}"
+    echo "Starting ao daemon on 127.0.0.1:${AO_PORT} in background (logs: ${AO_DAEMON_LOG})..."
+    run_as_hapi "AO_PORT=\"${AO_PORT}\" stdbuf -oL ao daemon 2>&1 | tee \"${AO_DAEMON_LOG}\"" &
+    AO_DAEMON_PID=$!
+    echo "ao daemon started with PID: ${AO_DAEMON_PID}"
+  else
+    echo "ao CLI not found; skipping ao daemon startup" >&2
+  fi
+else
+  echo "ao daemon disabled (set AO_DAEMON_ENABLED=true to enable agent-orchestrator remote access)"
 fi
 
 # Start external SSH tunnel (issue #79). Pluggable provider, gated by

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -149,6 +149,36 @@ class TestEntrypointRegressions(unittest.TestCase):
             self.text,
         )
 
+    def test_ao_daemon_started_as_hapi_with_log(self):
+        # agent-orchestrator daemon (issue #72, closes #61): off by default, gated
+        # by AO_DAEMON_ENABLED, started as hapi with its log under HAPI_HOME, the
+        # `ao` binary guarded by `command -v` so a missing binary skips (not fails).
+        self.assertIn(': "${AO_DAEMON_ENABLED:=false}"', self.text)
+        self.assertIn(': "${AO_PORT:=3001}"', self.text)
+        self.assertIn('[ "${AO_DAEMON_ENABLED}" = "true" ]', self.text)
+        self.assertIn('PATH="${HAPI_RUN_PATH}" command -v ao', self.text)
+        self.assertIn("ao CLI not found; skipping ao daemon startup", self.text)
+        self.assertIn('AO_DAEMON_LOG="${HAPI_HOME}/ao-daemon.log"', self.text)
+        self.assertIn(
+            'run_as_hapi "AO_PORT=\\"${AO_PORT}\\" stdbuf -oL ao daemon 2>&1 | tee \\"${AO_DAEMON_LOG}\\"" &',
+            self.text,
+        )
+        self.assertIn(
+            "ao daemon disabled (set AO_DAEMON_ENABLED=true", self.text
+        )
+
+    def test_ao_port_validated_numeric_in_daemon_gate(self):
+        # AO_PORT is interpolated into the `ao daemon` launch string, so a
+        # non-numeric value must fail loudly (mirrors PORT / CHISEL_REMOTE_PORT).
+        # The guard lives inside the AO_DAEMON_ENABLED gate so the default path
+        # (flag off) never validates a value it doesn't use.
+        gate_pos = self.text.find('if [ "${AO_DAEMON_ENABLED}" = "true" ]; then')
+        self.assertGreater(gate_pos, -1, "AO_DAEMON_ENABLED gate is missing")
+        check_pos = self.text.find(
+            "AO_PORT='${AO_PORT}' must be a positive integer", gate_pos
+        )
+        self.assertGreater(check_pos, gate_pos, "AO_PORT numeric check missing in gate")
+
     def test_ssh_tunnel_env_defaults(self):
         # Pluggable SSH tunnel (issue #79): env defaults must be set so the gate
         # and provider switch never run against an unset variable (set -u).


### PR DESCRIPTION
## Summary

Adds an optional background service — the agent-orchestrator `ao daemon` — to the container, mirroring the existing `DROID_DAEMON_ENABLED` pattern in `entrypoint.sh`. **Off by default.** Closes #72, closes #61.

The daemon listens **loopback-only** on `127.0.0.1:${AO_PORT}` (default 3001). A desktop AO app reaches it from the host through the container's existing sshd via an SSH tunnel.

## Why loopback-only (no public bind)

By design the daemon has **no `AO_HOST`** env var and **no auth/CORS/TLS** — binding `0.0.0.0` would expose a public, no-auth service that executes code (RCE). So it stays on loopback and is reached through the SSH tunnel (#79):

```bash
ssh -L 127.0.0.1:3001:127.0.0.1:3001 -N <user>@<container-host>
# then talk to localhost:3001 from the host
```

## Implementation notes

- **Dockerfile untouched / no `EXPOSE 3001`.** The `ao` binary is already built into the image from Go source (#83), so unlike the original issue sketch there is no curl-prebuilt step to add. `EXPOSE` is omitted because the port is loopback-only.
- **Independent of hapi**, like the droid daemon (works with `INSTALL_HAPI=false`).
- Gated by `AO_DAEMON_ENABLED`; a `command -v ao` guard **skips (not fails)** when the binary is absent.
- `AO_PORT` is **validated numeric inside the gate** (mirrors `PORT` / `CHISEL_REMOTE_PORT`) because it is interpolated into the `ao daemon` launch string.
- Logs to `~/.hapi/ao-daemon.log` (pre-created + chowned like the droid log).

## New / changed environment variables

| Variable | Default | Description |
|----------|---------|-------------|
| `AO_DAEMON_ENABLED` | `false` | Start `ao daemon` (agent-orchestrator) for remote access |
| `AO_PORT` | `3001` | Daemon bind port (loopback-only; read by the daemon itself) |

`.env.example` updated accordingly.

## Ports & volumes

- **No** `EXPOSE 3001` — loopback-only by design.
- No new volume mappings.

## Testing

- `bash -n entrypoint.sh` — OK
- `python -m pytest tests/unit/` — **310 passed, 166 subtests** (incl. 2 new tests: `test_ao_daemon_started_as_hapi_with_log`, `test_ao_port_validated_numeric_in_daemon_gate`)
- `docker build` not run (per request; Docker Hub timeouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2Lw7VgMHBKmzDCoMAx4yZ