### PR TITLE
feat: configure native z.ai GLM for Claude Code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,13 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # CLI_API_TOKEN=            # Required if HAPI_RUNNER_ENABLED=true
 # HAPI_API_URL=             # Required if HAPI_RUNNER_ENABLED=true
 
+# Claude Code z.ai GLM Coding Plan (optional runtime secrets)
+# The image ships /home/hapi/.claude/settings.json with non-secret GLM defaults:
+#   base URL https://api.z.ai/api/coding/paas/v4, Sonnet/Opus glm-5.2[1m], Haiku glm-4.7.
+# Put the token in runtime env only; it is not written to the image or settings file.
+# ANTHROPIC_AUTH_TOKEN=     # Token for native `claude` with the preconfigured settings.json
+# ZAI_TOKEN=                # Compatibility token for `bin/glm`; ordinary `claude` does not read this directly
+
 # Droid daemon (optional remote access)
 DROID_DAEMON_ENABLED=false  # Set to 'true' to start `droid daemon --remote-access`
 # DROID_COMPUTER_NAME=clihost  # Required when DROID_DAEMON_ENABLED=true; used for non-interactive registration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,13 +114,27 @@ SSH Client → sshd (22) → shell
 hapi Client → HTTP API (HAPI_PORT) → hapi runner
 ```
 
-**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → optionally start ao daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → drop any stale dashboard URL → if `hapi` is installed, start `hapi server --relay`, write a best-effort legacy connection URL file, and optionally start hapi runner (otherwise warn and skip) → `exec sshd`.
+**Entry point flow** (entrypoint.sh): fix volume permissions → ensure `.tmux.conf` / config dirs → copy the default Claude Code settings from `/etc/skel/.claude/settings.json` to `/home/hapi/.claude/settings.json` only if missing → configure sshd (root access if ROOT_PASSWORD) → clean stale hapi runner state → update Hermes Agent → optionally start Droid daemon → optionally start ao daemon → start ttyd proxy (as `TTYD_USER` via runuser; it auto-creates the first terminal) → drop any stale dashboard URL → if `hapi` is installed, start `hapi server --relay`, write a best-effort legacy connection URL file, and optionally start hapi runner (otherwise warn and skip) → `exec sshd`.
 
 **Volume mount:** `/home/hapi` — persistent runner state, logs, configs. The mount overwrites permissions, hence the permission fixes in entrypoint.sh. **Mount at exactly `/home/hapi`, never the parent `/home`** (issue #69): a Docker volume is seeded from the image only while empty, so a persistent `/home` that survives one deploy stops being re-seeded — the entrypoint then recreates `/home/hapi/.claude` empty on top of it and the saved Claude Code login (`CLAUDE_CONFIG_DIR=/home/hapi/.claude`, set in the Dockerfile) is lost on every redeploy ("auth keeps resetting"). Mounting `/home/hapi` keeps the home dir itself as the persisted unit. Verified in Docker: a non-empty `/home` volume drops the creds on container recreate, a non-empty `/home/hapi` volume keeps them. **Migration caveat:** an existing `/home` volume holds its data under a `hapi/` subdir, so naively retargeting the *same* volume to `/home/hapi` buries it at `/home/hapi/hapi/` (invisible to the app) — move the volume's `hapi/` contents to its root first, or copy them into a fresh `/home/hapi` volume. The entrypoint warning spells this out at startup.
 
 **`bin/` helper scripts:**
 - `tmux-wrapper.sh` — wraps each ttyd's shell in a tmux session `ttyd-{id}` (and, when `TTYD_SANDBOX=true`, inside the bwrap jail). ttyd is launched against this script by `manager.py`.
-- `glm` — convenience wrapper that runs `claude` against the z.ai Anthropic-compatible endpoint (`ANTHROPIC_BASE_URL=https://api.z.ai/...`) with GLM models (`glm-4.6` for Sonnet/Opus, `glm-4.5-air` for Haiku). Requires `ZAI_TOKEN`.
+- `glm` — compatibility wrapper that runs `claude` against the z.ai GLM Coding Plan endpoint (`https://api.z.ai/api/coding/paas/v4`) with Sonnet/Opus mapped to `glm-5.2[1m]` and Haiku mapped to `glm-4.7`. Requires `ZAI_TOKEN`. Native `claude` no longer needs this wrapper when `ANTHROPIC_AUTH_TOKEN` is present.
+
+### Native Claude Code z.ai GLM configuration (issue #60)
+
+Claude Code is preconfigured for z.ai GLM Coding Plan through a template at `config/claude-settings.json`, copied into the image at `/etc/skel/.claude/settings.json`. At container startup, `entrypoint.sh` copies that file to `/home/hapi/.claude/settings.json` only when the user's file is missing. Existing `settings.json` is not overwritten, and `settings.local.json` is a separate Claude Code file and must not be touched by this bootstrap.
+
+The settings template contains only non-secret values:
+- `ANTHROPIC_BASE_URL=https://api.z.ai/api/coding/paas/v4`
+- `ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.2[1m]`
+- `ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1m]`
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.7`
+- `API_TIMEOUT_MS=3000000`
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`
+
+Tokens are runtime-only. Use `ANTHROPIC_AUTH_TOKEN` for ordinary `claude`; keep `ZAI_TOKEN` only for the compatibility `bin/glm` wrapper. Do not put `ANTHROPIC_*` or `ZAI_TOKEN` literals in `Dockerfile` or `entrypoint.sh`: `TestClaudeAuthRootCause69` deliberately guards against shell-level GLM env leakage that could affect normal Claude Code auth.
 
 ### ttyd proxy package (app/)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -279,6 +279,8 @@ COPY bin/tmux-wrapper.sh /bin/tmux-wrapper.sh
 COPY bin/glm /bin/glm
 COPY config/.tmux.conf /home/hapi/.tmux.conf
 COPY config/.tmux.conf /etc/skel/.tmux.conf
+RUN mkdir -p /etc/skel/.claude
+COPY config/claude-settings.json /etc/skel/.claude/settings.json
 RUN chmod +x /bin/tmux-wrapper.sh /bin/glm && \
     chown hapi:hapi /home/hapi/.tmux.conf
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,30 @@ Add persistent volume at `/home/hapi` via Railway dashboard → Service → Volu
 - `PORT` is injected automatically by Railway, `ttyd_proxy.py` reads it via `os.environ`
 - When `hapi` is installed, the dashboard builds the **HAPI Server** link on demand from `/home/hapi/.hapi/server.log` (latest `https://*.relay.hapi.run`) and `/home/hapi/.hapi/settings.json` (`cliApiToken`). `/home/hapi/url` remains a legacy fallback, but the dashboard no longer depends on the entrypoint's one-shot URL writer. If hapi is absent or the URL/token is not available yet, the menu item is omitted.
 
+### Claude Code with z.ai GLM Coding Plan
+
+The image preconfigures native Claude Code for z.ai GLM Coding Plan through
+`/home/hapi/.claude/settings.json`. On startup, `entrypoint.sh` copies
+`config/claude-settings.json` from `/etc/skel/.claude/settings.json` only when
+the user's `settings.json` is missing, so persisted volumes and custom Claude
+settings are not overwritten. `settings.local.json` is a separate Claude Code
+file and is never touched by this bootstrap.
+
+The template contains only non-secret Claude Code env settings:
+`ANTHROPIC_BASE_URL=https://api.z.ai/api/coding/paas/v4`,
+Sonnet/Opus `glm-5.2[1m]`, Haiku `glm-4.7`, and the long timeout/context
+window settings. It does **not** contain a token.
+
+For native `claude`, pass the z.ai Coding Plan token at runtime:
+
+```bash
+docker run --env-file .env -e ANTHROPIC_AUTH_TOKEN=your_zai_token clihost
+```
+
+`bin/glm` is still shipped for compatibility and still reads `ZAI_TOKEN`, but it
+is no longer required for GLM: ordinary `claude` uses the native settings file
+when `ANTHROPIC_AUTH_TOKEN` is present in the environment.
+
 ## Архитектура
 
 ```
@@ -140,6 +164,8 @@ Terminal iframe page и связанные JS/CSS-ассеты лежат в `ap
 | `AO_DAEMON_ENABLED` | false | Start `ao daemon` (agent-orchestrator); loopback-only, reach it through the SSH tunnel |
 | `AO_PORT` | 3001 | `ao daemon` bind port (loopback-only by design; understood by the daemon itself) |
 | `TTYD_SANDBOX` | false | Wrap each tmux session in a bubblewrap jail (see Multi-tenant sandbox below) |
+| `ANTHROPIC_AUTH_TOKEN` | - | z.ai Coding Plan token for native Claude Code GLM access; do not bake it into the image or settings file |
+| `ZAI_TOKEN` | - | Compatibility token for the legacy `bin/glm` wrapper only |
 
 ### Multi-tenant sandbox (optional)
 

--- a/bin/glm
+++ b/bin/glm
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-export ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+export ANTHROPIC_BASE_URL=https://api.z.ai/api/coding/paas/v4
 export ANTHROPIC_AUTH_TOKEN="${ZAI_TOKEN:?ZAI_TOKEN environment variable is required}"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.5-air
-export ANTHROPIC_DEFAULT_SONNET_MODEL=glm-4.6
-export ANTHROPIC_DEFAULT_OPUS_MODEL=glm-4.6
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.7
+export ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.2[1m]
+export ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1m]
+export API_TIMEOUT_MS=3000000
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000
 
 exec claude "$@"

--- a/config/claude-settings.json
+++ b/config/claude-settings.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/coding/paas/v4",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2[1m]",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000"
+  }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,11 +121,25 @@ EOF
 }
 
 ensure_claude_settings() {
-  local settings_file="${HAPI_USER_HOME}/.claude/settings.json"
-  if [ ! -f "${settings_file}" ] && [ -f "${CLAUDE_SETTINGS_TEMPLATE}" ]; then
-    cp "${CLAUDE_SETTINGS_TEMPLATE}" "${settings_file}"
-    chown "${HAPI_USER}:${HAPI_USER}" "${settings_file}"
-  fi
+  local claude_dir="${HAPI_USER_HOME}/.claude"
+  local settings_file="${claude_dir}/settings.json"
+  # This runs as root before the privilege drop, and /home/hapi is writable by
+  # the (untrusted in multi-tenant forks) hapi user via the persistent volume.
+  # So treat ANY pre-existing destination as hands-off and never follow symlinks:
+  # gating only on `! -f` would let a hapi-planted settings.json *symlink* (e.g.
+  # -> a directory or /etc) pass the check, and the root `cp`/`chown` would then
+  # follow it — writing the template through the link and chowning its target
+  # (arbitrary-path write + ownership change). Mirrors the symlink hardening in
+  # uploads.py. Bail unless .claude is a real (non-symlink) dir and settings.json
+  # is genuinely absent (also rejecting a dangling/symlink settings.json via -L).
+  if [ ! -d "${claude_dir}" ] || [ -L "${claude_dir}" ]; then return 0; fi
+  if [ -e "${settings_file}" ] || [ -L "${settings_file}" ]; then return 0; fi
+  if [ ! -f "${CLAUDE_SETTINGS_TEMPLATE}" ]; then return 0; fi
+  # cp over a guaranteed-absent, non-symlink path; restrictive mode up front so a
+  # future credential-bearing template never lands world-readable (default umask).
+  cp "${CLAUDE_SETTINGS_TEMPLATE}" "${settings_file}"
+  chmod 600 "${settings_file}"
+  chown "${HAPI_USER}:${HAPI_USER}" "${settings_file}"
 }
 
 run_as_hapi() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,7 @@ HAPI_USER_HOME="/home/${HAPI_USER}"
 : "${HAPI_HOME:=${HAPI_USER_HOME}/.hapi}"
 : "${UPLOAD_DIR:=${CLEANUP_ROOT}/.uploads}"
 HAPI_RUN_PATH="/usr/local/bin:/usr/bin:/bin"
+CLAUDE_SETTINGS_TEMPLATE="${CLAUDE_SETTINGS_TEMPLATE:-/etc/skel/.claude/settings.json}"
 
 echo "Starting clihost container..."
 
@@ -119,6 +120,14 @@ EOF
   fi
 }
 
+ensure_claude_settings() {
+  local settings_file="${HAPI_USER_HOME}/.claude/settings.json"
+  if [ ! -f "${settings_file}" ] && [ -f "${CLAUDE_SETTINGS_TEMPLATE}" ]; then
+    cp "${CLAUDE_SETTINGS_TEMPLATE}" "${settings_file}"
+    chown "${HAPI_USER}:${HAPI_USER}" "${settings_file}"
+  fi
+}
+
 run_as_hapi() {
   local command="$1"
   runuser -u "${HAPI_USER}" -- sh -c "cd \"${HAPI_USER_HOME}\" && env HOME=\"${HAPI_USER_HOME}\" PATH=\"${HAPI_RUN_PATH}\" HAPI_HOME=\"${HAPI_HOME}\" ${command}"
@@ -173,6 +182,7 @@ ensure_home_owned
 ensure_dir_owned "${HAPI_USER_HOME}/.config/gh"
 ensure_dir_owned "${HAPI_USER_HOME}/.claude"
 ensure_local_bin_env
+ensure_claude_settings
 
 # Ensure tmux config exists (volume mount may overwrite it)
 if [ ! -f "${HAPI_USER_HOME}/.tmux.conf" ]; then

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -568,20 +568,36 @@ class TestClaudeNativeZaiConfig(unittest.TestCase):
         assert match is not None
         return match.group(0)
 
-    def _run_helper(self, settings_content=None, local_content="local hooks"):
+    def _run_helper(self, settings_content=None, local_content="local hooks",
+                    settings_symlink_to=None, claude_symlink_to=None):
         helper = self._extract_helper()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)
             home = tmp_path / "home" / "hapi"
             claude_dir = home / ".claude"
-            claude_dir.mkdir(parents=True)
+            if claude_symlink_to is not None:
+                # Attack: .claude itself is a symlink to an attacker-chosen dir.
+                home.mkdir(parents=True)
+                target = tmp_path / claude_symlink_to
+                target.mkdir(parents=True, exist_ok=True)
+                claude_dir.symlink_to(target)
+            else:
+                claude_dir.mkdir(parents=True)
             template = tmp_path / "claude-settings.json"
             template.write_text('{"env":{"from":"template"}}\n')
             settings = claude_dir / "settings.json"
-            if settings_content is not None:
+            if settings_symlink_to is not None:
+                # Attack: settings.json is a symlink to an attacker-chosen path.
+                target = tmp_path / settings_symlink_to
+                target.mkdir(parents=True, exist_ok=True)
+                settings.symlink_to(target)
+            elif settings_content is not None:
                 settings.write_text(settings_content)
             settings_local = claude_dir / "settings.local.json"
-            settings_local.write_text(local_content)
+            # When .claude is itself the attacker symlink, do NOT write through it
+            # (that would be the test corrupting the victim, not the helper).
+            if claude_symlink_to is None:
+                settings_local.write_text(local_content)
             chown_log = tmp_path / "chown.log"
             fake_chown = tmp_path / "chown"
             fake_chown.write_text(
@@ -607,12 +623,27 @@ class TestClaudeNativeZaiConfig(unittest.TestCase):
             chown_targets = (
                 chown_log.read_text().splitlines() if chown_log.exists() else []
             )
+            # For symlink-attack cases, report whether the template leaked into
+            # the attacker-controlled target directory (it must not). "Leaked" =
+            # the template content was written somewhere under the victim dir.
+            template_text = template.read_text()
+            leaked = False
+            for attack_target in (settings_symlink_to, claude_symlink_to):
+                if attack_target is not None:
+                    tgt = tmp_path / attack_target
+                    if tgt.is_dir():
+                        for child in tgt.rglob("*"):
+                            if child.is_file() and child.read_text() == template_text:
+                                leaked = True
             return {
-                "template": template.read_text(),
-                "settings": settings.read_text() if settings.exists() else None,
-                "settings_local": settings_local.read_text(),
+                "template": template_text,
+                "settings": settings.read_text()
+                if settings.is_file() and not settings.is_symlink() else None,
+                "settings_local": settings_local.read_text()
+                if settings_local.is_file() else None,
                 "chown_targets": chown_targets,
                 "settings_path": str(settings),
+                "leaked": leaked,
             }
 
     def test_template_uses_zai_coding_plan_without_token(self):
@@ -668,6 +699,24 @@ class TestClaudeNativeZaiConfig(unittest.TestCase):
         result = self._run_helper(settings_content=existing)
         self.assertEqual(result["settings"], existing)
         self.assertEqual(result["settings_local"], "local hooks")
+        self.assertNotIn(result["settings_path"], result["chown_targets"])
+
+    def test_entrypoint_rejects_settings_symlink_attack(self):
+        # The helper runs as root before the privilege drop, and /home/hapi is
+        # writable by the hapi user via the persistent volume. A planted
+        # settings.json *symlink* must NOT cause the root cp/chown to follow it
+        # (arbitrary-path write + ownership change). Gating on `! -f` alone would
+        # treat a symlink-to-dir as "missing"; the helper must bail on any
+        # pre-existing path including a symlink. (Codex finding, PR #88 review.)
+        result = self._run_helper(settings_symlink_to="victim")
+        self.assertFalse(result["leaked"], "template leaked through settings symlink")
+        self.assertNotIn(result["settings_path"], result["chown_targets"])
+
+    def test_entrypoint_rejects_claude_dir_symlink_attack(self):
+        # Same class of attack one level up: ~/.claude itself is a symlink. The
+        # helper must refuse to operate unless .claude is a real, non-symlink dir.
+        result = self._run_helper(claude_symlink_to="victim2")
+        self.assertFalse(result["leaked"], "template leaked through .claude symlink")
         self.assertNotIn(result["settings_path"], result["chown_targets"])
 
 

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1,4 +1,5 @@
 """Static checks for shell scripts (syntax + known-bug regressions)."""
+import json
 import os
 import pathlib
 import re
@@ -16,6 +17,7 @@ TMUX_WRAPPER = REPO_ROOT / "bin/tmux-wrapper.sh"
 GLM = REPO_ROOT / "bin/glm"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+CLAUDE_SETTINGS_TEMPLATE = REPO_ROOT / "config/claude-settings.json"
 
 # Component keys whose INSTALL_<KEY> build args gate the modular image (issue #57).
 NPM_COMPONENT_KEYS = (
@@ -550,6 +552,123 @@ class TestClaudeConfigPersistence(unittest.TestCase):
         self.assertNotIn(".claude", body)
         # sanity: it does target the runner state files it is meant to clear.
         self.assertIn("runner.state.json", body)
+
+
+class TestClaudeNativeZaiConfig(unittest.TestCase):
+    """Native Claude Code configuration for z.ai Coding Plan (issue #60)."""
+
+    def _extract_helper(self):
+        text = ENTRYPOINT.read_text()
+        match = re.search(
+            r"^ensure_claude_settings\(\) \{\n.*?^\}",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "ensure_claude_settings not found in entrypoint.sh")
+        assert match is not None
+        return match.group(0)
+
+    def _run_helper(self, settings_content=None, local_content="local hooks"):
+        helper = self._extract_helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            home = tmp_path / "home" / "hapi"
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            template = tmp_path / "claude-settings.json"
+            template.write_text('{"env":{"from":"template"}}\n')
+            settings = claude_dir / "settings.json"
+            if settings_content is not None:
+                settings.write_text(settings_content)
+            settings_local = claude_dir / "settings.local.json"
+            settings_local.write_text(local_content)
+            chown_log = tmp_path / "chown.log"
+            fake_chown = tmp_path / "chown"
+            fake_chown.write_text(
+                "#!/bin/bash\n"
+                'for a in "$@"; do case "$a" in -*) ;; *:*) ;; '
+                f'*) echo "$a" >> "{chown_log}" ;; esac; done\n'
+            )
+            fake_chown.chmod(0o755)
+            script = (
+                "set -euo pipefail\n"
+                'HAPI_USER="hapi"\n'
+                f'HAPI_USER_HOME="{home}"\n'
+                f'CLAUDE_SETTINGS_TEMPLATE="{template}"\n'
+                f"{helper}\n"
+                "ensure_claude_settings\n"
+            )
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, env=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            chown_targets = (
+                chown_log.read_text().splitlines() if chown_log.exists() else []
+            )
+            return {
+                "template": template.read_text(),
+                "settings": settings.read_text() if settings.exists() else None,
+                "settings_local": settings_local.read_text(),
+                "chown_targets": chown_targets,
+                "settings_path": str(settings),
+            }
+
+    def test_template_uses_zai_coding_plan_without_token(self):
+        data = json.loads(CLAUDE_SETTINGS_TEMPLATE.read_text())
+        self.assertEqual(
+            data,
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/coding/paas/v4",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1m]",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2[1m]",
+                    "API_TIMEOUT_MS": "3000000",
+                    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+                }
+            },
+        )
+        text = CLAUDE_SETTINGS_TEMPLATE.read_text()
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", text)
+        self.assertNotIn("ZAI_TOKEN", text)
+
+    def test_dockerfile_copies_claude_settings_template_only(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn(
+            "COPY config/claude-settings.json /etc/skel/.claude/settings.json",
+            dockerfile,
+        )
+        self.assertNotRegex(
+            dockerfile,
+            re.compile(r"(ANTHROPIC_(BASE_URL|AUTH_TOKEN)|ZAI_TOKEN)"),
+        )
+
+    def test_glm_wrapper_stays_compatible_with_zai_token(self):
+        glm = GLM.read_text()
+        self.assertIn("ANTHROPIC_BASE_URL=https://api.z.ai/api/coding/paas/v4", glm)
+        self.assertIn(
+            'ANTHROPIC_AUTH_TOKEN="${ZAI_TOKEN:?ZAI_TOKEN environment variable is required}"',
+            glm,
+        )
+        self.assertIn("ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.7", glm)
+        self.assertIn("ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.2[1m]", glm)
+        self.assertIn("ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1m]", glm)
+        self.assertIn("CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000", glm)
+
+    def test_entrypoint_copies_template_when_settings_missing(self):
+        result = self._run_helper()
+        self.assertEqual(result["settings"], result["template"])
+        self.assertEqual(result["settings_local"], "local hooks")
+        self.assertIn(result["settings_path"], result["chown_targets"])
+
+    def test_entrypoint_does_not_overwrite_existing_settings(self):
+        existing = '{"env":{"custom":"user"}}\n'
+        result = self._run_helper(settings_content=existing)
+        self.assertEqual(result["settings"], existing)
+        self.assertEqual(result["settings_local"], "local hooks")
+        self.assertNotIn(result["settings_path"], result["chown_targets"])
 
 
 class TestClaudeAuthRootCause69(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `config/claude-settings.json` with native Claude Code z.ai GLM Coding Plan defaults
- copy that template into `/home/hapi/.claude/settings.json` at startup only when the user file is missing
- update `bin/glm` as a compatibility wrapper for the Coding Plan endpoint and current GLM models
- document the runtime token contract in `CLAUDE.md`, `README.md`, and `.env.example`

## Approach
The image stores the non-secret Claude Code settings template under `/etc/skel/.claude/settings.json`, then `entrypoint.sh` copies the file into the persisted `/home/hapi` volume only if `settings.json` is absent. This keeps native `claude` configured for GLM without putting `ANTHROPIC_*` literals in Dockerfile/entrypoint shell code and without overwriting user Claude settings or `settings.local.json`.

## Environment
- `ANTHROPIC_AUTH_TOKEN`: runtime-only z.ai Coding Plan token for ordinary `claude`
- `ZAI_TOKEN`: still supported by `bin/glm` for backward compatibility

No token is written to the Docker image or `settings.json`.

## Validation
- `python -m pytest tests/unit/test_shell_scripts.py -q`
- `python -m pytest tests/`
- `npm ci && npm test`
- `docker build -t clihost:native-zai-glm-config-60 .`
- Docker smoke with bind-mounted `/home/hapi`: verified entrypoint copies the settings template, owner is `hapi:hapi`, endpoint/models are present, and token keys are absent
- Docker smoke with existing `settings.json` and `settings.local.json`: verified both files are preserved

Closes #60
