### PR TITLE
feat: add claude auth snapshot diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # Put the token in runtime env only; it is not written to the image or settings file.
 # ANTHROPIC_AUTH_TOKEN=     # Token for native `claude` with the preconfigured settings.json
 # ZAI_TOKEN=                # Compatibility token for `bin/glm`; ordinary `claude` does not read this directly
+# CLAUDE_AUTH_SNAPSHOT_DIR=/home/hapi/.hapi/auth-snapshots  # Optional override for diagnostic auth snapshots
 
 # Droid daemon (optional remote access)
 DROID_DAEMON_ENABLED=false  # Set to 'true' to start `droid daemon --remote-access`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,57 @@ The settings template contains only non-secret values:
 
 Tokens are runtime-only. Use `ANTHROPIC_AUTH_TOKEN` for ordinary `claude`; keep `ZAI_TOKEN` only for the compatibility `bin/glm` wrapper. Do not put `ANTHROPIC_*` or `ZAI_TOKEN` literals in `Dockerfile` or `entrypoint.sh`: `TestClaudeAuthRootCause69` deliberately guards against shell-level GLM env leakage that could affect normal Claude Code auth.
 
+### Диагностика слёта Claude Code auth
+
+`bin/claude-auth-snapshot.sh` is copied into the image as
+`/bin/claude-auth-snapshot.sh` for diagnosing ordinary Claude Code OAuth
+logout/refresh failures. It reads
+`$CLAUDE_CONFIG_DIR/.credentials.json` (default
+`/home/hapi/.claude/.credentials.json`) and writes JSON snapshots under
+`${CLAUDE_AUTH_SNAPSHOT_DIR:-/home/hapi/.hapi/auth-snapshots}`. Secret hygiene is
+the main contract: токенов в снэпшоте нет. The snapshot must never contain
+`accessToken` or `refreshToken`; it stores only metadata such as `expiresAt`,
+`scopes`, `subscriptionType`, sha256/mtime, permissions, process uid, UTC time,
+uptime, and a no-token reachability check for `api.anthropic.com`.
+
+Operational flow:
+
+```bash
+# immediately after a successful claude login
+docker exec <container> bash /bin/claude-auth-snapshot.sh snapshot baseline
+
+# after Claude Code logs out
+docker exec <container> bash /bin/claude-auth-snapshot.sh snapshot failed
+docker exec <container> bash /bin/claude-auth-snapshot.sh diff
+docker exec <container> bash /bin/claude-auth-snapshot.sh list
+```
+
+The built-in `diff` compares two explicit files or, without args, the two latest
+container snapshots. Verdicts separate the expected root-cause buckets:
+refresh works when sha256/mtime/`expiresAt` changed; refresh is not happening
+when the file is unchanged and `expiresAt` is expired; permissions block refresh
+when `.credentials.json` becomes non-`hapi` or loses write access; Anthropic
+network loss is called out separately; missing credentials points back to
+mount/persistence.
+
+`bin/claude-auth-snapshot-host.sh` is a host-only wrapper and must not be copied
+into the image. It runs `docker inspect` for only `RestartCount`,
+`State.StartedAt`, `State.Status`, and `Mounts`, then executes the inner
+`claude-auth-snapshot.sh snapshot` and writes a host JSON snapshot under
+`./claude-auth-host-snapshots` (override with `CLAUDE_AUTH_HOST_SNAPSHOT_DIR`).
+Use it when you need to prove whether the container restarted or the `/home/hapi`
+mount changed:
+
+```bash
+bin/claude-auth-snapshot-host.sh <container> baseline
+bin/claude-auth-snapshot-host.sh <container> failed
+bin/claude-auth-snapshot-host.sh diff ./claude-auth-host-snapshots/<A>.json ./claude-auth-host-snapshots/<B>.json
+```
+
+This is diagnostic only. It distinguishes (a) mount/persistence, (b)
+permissions/refresh write failure, and (c) network/token refresh failure; it does
+not change OAuth state.
+
 ### ttyd proxy package (app/)
 
 `app/ttyd_proxy.py` is only a **thin process entry point** (imports `main` from `ttydproxy.app`; referenced by entrypoint.sh as `python3 /app/ttyd_proxy.py`); all logic lives in the `app/ttydproxy/` package:

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,11 +277,12 @@ RUN mkdir -p /app /bin
 COPY app/ /app/
 COPY bin/tmux-wrapper.sh /bin/tmux-wrapper.sh
 COPY bin/glm /bin/glm
+COPY bin/claude-auth-snapshot.sh /bin/claude-auth-snapshot.sh
 COPY config/.tmux.conf /home/hapi/.tmux.conf
 COPY config/.tmux.conf /etc/skel/.tmux.conf
 RUN mkdir -p /etc/skel/.claude
 COPY config/claude-settings.json /etc/skel/.claude/settings.json
-RUN chmod +x /bin/tmux-wrapper.sh /bin/glm && \
+RUN chmod +x /bin/tmux-wrapper.sh /bin/glm /bin/claude-auth-snapshot.sh && \
     chown hapi:hapi /home/hapi/.tmux.conf
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -104,6 +104,48 @@ docker run --env-file .env -e ANTHROPIC_AUTH_TOKEN=your_zai_token clihost
 is no longer required for GLM: ordinary `claude` uses the native settings file
 when `ANTHROPIC_AUTH_TOKEN` is present in the environment.
 
+### Диагностика слёта Claude Code auth
+
+Для обычного Claude Code OAuth (`claude login`, файл
+`/home/hapi/.claude/.credentials.json`) в образе есть диагностический snapshot
+без секретов: токенов в снэпшоте нет, сохраняются только `expiresAt`, scopes,
+тип подписки, sha256/mtime файла, права, время и быстрый сетевой чек Anthropic.
+
+Снимите baseline сразу после успешного `claude login` внутри живого контейнера:
+
+```bash
+docker exec <container> bash /bin/claude-auth-snapshot.sh snapshot baseline
+```
+
+Когда Claude Code разлогинился, снимите второй snapshot и сравните:
+
+```bash
+docker exec <container> bash /bin/claude-auth-snapshot.sh snapshot failed
+docker exec <container> bash /bin/claude-auth-snapshot.sh diff
+docker exec <container> bash /bin/claude-auth-snapshot.sh list
+```
+
+По умолчанию файлы пишутся в
+`/home/hapi/.hapi/auth-snapshots`; при необходимости путь меняется через
+`CLAUDE_AUTH_SNAPSHOT_DIR`. `diff` выдаёт подсказку причины: refresh работает,
+refresh не происходит при истёкшем `expiresAt`, права мешают записи
+`.credentials.json`, пропал доступ к `api.anthropic.com`, либо credentials-файл
+исчез.
+
+С хоста используйте wrapper, чтобы добавить `docker inspect`-мету
+(`RestartCount`, `State.StartedAt`, `State.Status`, mounts) и отделить
+mount/persistence-рестарт от token/refresh-проблемы:
+
+```bash
+bin/claude-auth-snapshot-host.sh <container> baseline
+bin/claude-auth-snapshot-host.sh <container> failed
+bin/claude-auth-snapshot-host.sh diff ./claude-auth-host-snapshots/<A>.json ./claude-auth-host-snapshots/<B>.json
+```
+
+Этот инструмент диагностический: он разделяет (а) mount/persistence, (б)
+права/refresh-запись, (в) сетевой или token-refresh провал, но сам OAuth не
+чинит.
+
 ## Архитектура
 
 ```

--- a/bin/claude-auth-snapshot-host.sh
+++ b/bin/claude-auth-snapshot-host.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_HOST_SNAPSHOT_DIR="./claude-auth-host-snapshots"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  claude-auth-snapshot-host.sh <container-name-or-id> [label]
+  claude-auth-snapshot-host.sh snapshot <container-name-or-id> [label]
+  claude-auth-snapshot-host.sh diff A.json B.json
+  claude-auth-snapshot-host.sh list
+  claude-auth-snapshot-host.sh latest
+EOF
+}
+
+host_snapshot_dir() {
+  printf '%s\n' "${CLAUDE_AUTH_HOST_SNAPSHOT_DIR:-${DEFAULT_HOST_SNAPSHOT_DIR}}"
+}
+
+sanitize_label() {
+  local label="${1:-}"
+  if [ -z "${label}" ]; then
+    return 0
+  fi
+  printf '%s' "${label}" \
+    | tr -c 'A-Za-z0-9._-' '-' \
+    | sed -e 's/^-*//' -e 's/-*$//' -e 's/--*/-/g' \
+    | cut -c 1-80
+}
+
+unique_host_snapshot_path() {
+  local dir="$1"
+  local label="$2"
+  local stamp
+  local safe_label
+  local base
+  local path
+  local n
+
+  stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  safe_label="$(sanitize_label "${label}")"
+  base="${dir}/${stamp}-host"
+  if [ -n "${safe_label}" ]; then
+    base="${base}-${safe_label}"
+  fi
+  path="${base}.json"
+  n=1
+  while [ -e "${path}" ]; do
+    path="${base}-${n}.json"
+    n=$((n + 1))
+  done
+  printf '%s\n' "${path}"
+}
+
+docker_inspect_field() {
+  local container="$1"
+  local template="$2"
+  docker inspect --format "${template}" "${container}"
+}
+
+create_host_snapshot() {
+  local container="${1:-}"
+  local label="${2:-}"
+  local dir
+  local out
+  local restart_count
+  local started_at
+  local status
+  local mounts_json
+  local container_snapshot_path
+  local container_snapshot_json
+
+  [ -n "${container}" ] || die "container name or id is required"
+  command -v docker >/dev/null 2>&1 || die "docker CLI not found"
+
+  dir="$(host_snapshot_dir)"
+  mkdir -p "${dir}"
+  out="$(unique_host_snapshot_path "${dir}" "${label}")"
+
+  restart_count="$(docker_inspect_field "${container}" '{{.RestartCount}}')"
+  started_at="$(docker_inspect_field "${container}" '{{.State.StartedAt}}')"
+  status="$(docker_inspect_field "${container}" '{{.State.Status}}')"
+  mounts_json="$(docker_inspect_field "${container}" '{{json .Mounts}}')"
+
+  if [ -n "${label}" ]; then
+    container_snapshot_path="$(docker exec "${container}" bash /bin/claude-auth-snapshot.sh snapshot "${label}")"
+  else
+    container_snapshot_path="$(docker exec "${container}" bash /bin/claude-auth-snapshot.sh snapshot)"
+  fi
+  container_snapshot_json="$(docker exec "${container}" cat "${container_snapshot_path}")"
+
+  HOST_SNAPSHOT_OUTPUT="${out}" \
+  HOST_SNAPSHOT_LABEL="${label}" \
+  HOST_CONTAINER="${container}" \
+  HOST_RESTART_COUNT="${restart_count}" \
+  HOST_STARTED_AT="${started_at}" \
+  HOST_STATUS="${status}" \
+  HOST_MOUNTS_JSON="${mounts_json}" \
+  CONTAINER_SNAPSHOT_PATH="${container_snapshot_path}" \
+  CONTAINER_SNAPSHOT_JSON="${container_snapshot_json}" \
+  python3 <<'PY'
+import datetime
+import json
+import os
+from pathlib import Path
+
+
+def iso_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+mounts = json.loads(os.environ["HOST_MOUNTS_JSON"])
+safe_mounts = [
+    {
+        "destination": mount.get("Destination"),
+        "source": mount.get("Source"),
+        "type": mount.get("Type"),
+        "rw": mount.get("RW"),
+    }
+    for mount in mounts
+]
+
+snapshot = {
+    "schema_version": 1,
+    "kind": "claude-auth-host-snapshot",
+    "label": os.environ.get("HOST_SNAPSHOT_LABEL") or None,
+    "created_at": iso_now(),
+    "host": {
+        "container": os.environ["HOST_CONTAINER"],
+        "inspect": {
+            "restart_count": int(os.environ["HOST_RESTART_COUNT"]),
+            "state": {
+                "started_at": os.environ["HOST_STARTED_AT"],
+                "status": os.environ["HOST_STATUS"],
+            },
+            "mounts": safe_mounts,
+        },
+    },
+    "container_snapshot_path": os.environ["CONTAINER_SNAPSHOT_PATH"],
+    "container_snapshot": json.loads(os.environ["CONTAINER_SNAPSHOT_JSON"]),
+}
+
+Path(os.environ["HOST_SNAPSHOT_OUTPUT"]).write_text(
+    json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
+)
+PY
+
+  echo "${out}"
+}
+
+run_host_diff() {
+  local a="${1:-}"
+  local b="${2:-}"
+  [ -n "${a}" ] && [ -n "${b}" ] || die "diff requires A.json B.json"
+  [ -f "${a}" ] || die "snapshot not found: ${a}"
+  [ -f "${b}" ] || die "snapshot not found: ${b}"
+
+  python3 - "${a}" "${b}" <<'PY'
+import json
+import sys
+
+
+def load(path):
+    with open(path) as handle:
+        return json.load(handle)
+
+
+def mounts_fp(data):
+    mounts = data.get("host", {}).get("inspect", {}).get("mounts", [])
+    return sorted(
+        (
+            mount.get("destination"),
+            mount.get("source"),
+            mount.get("type"),
+            mount.get("rw"),
+        )
+        for mount in mounts
+    )
+
+
+old = load(sys.argv[1])
+new = load(sys.argv[2])
+old_inspect = old.get("host", {}).get("inspect", {})
+new_inspect = new.get("host", {}).get("inspect", {})
+old_state = old_inspect.get("state", {})
+new_state = new_inspect.get("state", {})
+
+print("Host docker diff")
+print(f"A: {sys.argv[1]}")
+print(f"B: {sys.argv[2]}")
+print("")
+print("Delta:")
+print(f"- RestartCount: {old_inspect.get('restart_count')} -> {new_inspect.get('restart_count')}")
+print(f"- State.Status: {old_state.get('status')} -> {new_state.get('status')}")
+print(f"- State.StartedAt: {old_state.get('started_at')} -> {new_state.get('started_at')}")
+print(f"- Mounts changed: {mounts_fp(old) != mounts_fp(new)}")
+print("")
+if old_inspect.get("restart_count") != new_inspect.get("restart_count") or old_state.get("started_at") != new_state.get("started_at"):
+    print("Host verdict:")
+    print("- ⚠️ container restart detected; compare with inner credentials state to separate restart/mount causes from token refresh causes.")
+    print("")
+if mounts_fp(old) != mounts_fp(new):
+    print("Mount verdict:")
+    print("- ⚠️ Docker mounts changed; verify /home/hapi persistence before blaming OAuth refresh.")
+    print("")
+PY
+
+  bash "${SCRIPT_DIR}/claude-auth-snapshot.sh" diff "${a}" "${b}"
+}
+
+list_host_snapshots() {
+  local dir
+  dir="$(host_snapshot_dir)"
+  [ -d "${dir}" ] || return 0
+  find "${dir}" -maxdepth 1 -type f -name '*.json' | sort
+}
+
+latest_host_snapshot() {
+  list_host_snapshots | tail -n 1
+}
+
+main() {
+  local command="${1:-}"
+  case "${command}" in
+    snapshot)
+      shift
+      [ "$#" -ge 1 ] && [ "$#" -le 2 ] || die "snapshot requires <container> [label]"
+      create_host_snapshot "$@"
+      ;;
+    diff)
+      shift
+      [ "$#" -eq 2 ] || die "diff requires A.json B.json"
+      run_host_diff "$@"
+      ;;
+    list)
+      shift
+      [ "$#" -eq 0 ] || die "list accepts no arguments"
+      list_host_snapshots
+      ;;
+    latest)
+      shift
+      [ "$#" -eq 0 ] || die "latest accepts no arguments"
+      latest_host_snapshot
+      ;;
+    -h|--help|help|"")
+      usage
+      [ -n "${command}" ] || exit 2
+      ;;
+    *)
+      [ "$#" -le 2 ] || die "expected <container> [label]"
+      create_host_snapshot "$@"
+      ;;
+  esac
+}
+
+main "$@"

--- a/bin/claude-auth-snapshot.sh
+++ b/bin/claude-auth-snapshot.sh
@@ -1,0 +1,552 @@
+#!/bin/bash
+set -euo pipefail
+
+DEFAULT_SNAPSHOT_DIR="/home/hapi/.hapi/auth-snapshots"
+DEFAULT_CLAUDE_CONFIG_DIR="/home/hapi/.claude"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  claude-auth-snapshot.sh snapshot [label]
+  claude-auth-snapshot.sh diff [A.json B.json]
+  claude-auth-snapshot.sh list
+  claude-auth-snapshot.sh latest
+EOF
+}
+
+snapshot_dir() {
+  printf '%s\n' "${CLAUDE_AUTH_SNAPSHOT_DIR:-${DEFAULT_SNAPSHOT_DIR}}"
+}
+
+sanitize_label() {
+  local label="${1:-}"
+  if [ -z "${label}" ]; then
+    return 0
+  fi
+  printf '%s' "${label}" \
+    | tr -c 'A-Za-z0-9._-' '-' \
+    | sed -e 's/^-*//' -e 's/-*$//' -e 's/--*/-/g' \
+    | cut -c 1-80
+}
+
+unique_snapshot_path() {
+  local dir="$1"
+  local label="$2"
+  local stamp
+  local safe_label
+  local base
+  local path
+  local n
+
+  stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  safe_label="$(sanitize_label "${label}")"
+  base="${dir}/${stamp}"
+  if [ -n "${safe_label}" ]; then
+    base="${base}-${safe_label}"
+  fi
+  path="${base}.json"
+  n=1
+  while [ -e "${path}" ]; do
+    path="${base}-${n}.json"
+    n=$((n + 1))
+  done
+  printf '%s\n' "${path}"
+}
+
+create_snapshot() {
+  local label="${1:-}"
+  local dir
+  local out
+
+  dir="$(snapshot_dir)"
+  mkdir -p "${dir}"
+  out="$(unique_snapshot_path "${dir}" "${label}")"
+
+  CLAUDE_AUTH_SNAPSHOT_LABEL="${label}" \
+  CLAUDE_AUTH_SNAPSHOT_OUTPUT="${out}" \
+  CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${DEFAULT_CLAUDE_CONFIG_DIR}}" \
+  python3 <<'PY'
+import datetime
+import grp
+import hashlib
+import json
+import os
+import pwd
+import shutil
+import socket
+import ssl
+import stat
+import subprocess
+from pathlib import Path
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def iso_z(dt):
+    return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def name_for_uid(uid):
+    try:
+        return pwd.getpwuid(uid).pw_name
+    except KeyError:
+        return str(uid)
+
+
+def name_for_gid(gid):
+    try:
+        return grp.getgrgid(gid).gr_name
+    except KeyError:
+        return str(gid)
+
+
+def hapi_identity():
+    try:
+        user = pwd.getpwnam("hapi")
+    except KeyError:
+        return None
+    gids = {user.pw_gid}
+    for group in grp.getgrall():
+        if "hapi" in group.gr_mem:
+            gids.add(group.gr_gid)
+    return {"uid": user.pw_uid, "gids": gids}
+
+
+def writable_by_hapi(path, mode, st):
+    ident = hapi_identity()
+    if ident is None:
+        return None
+    if st.st_uid == ident["uid"]:
+        return bool(mode & stat.S_IWUSR)
+    if st.st_gid in ident["gids"]:
+        return bool(mode & stat.S_IWGRP)
+    return bool(mode & stat.S_IWOTH)
+
+
+def path_meta(path):
+    path = Path(path)
+    exists = path.exists()
+    lexists = os.path.lexists(path)
+    if not lexists:
+        return {
+            "path": str(path),
+            "exists": False,
+            "owner": None,
+            "mode": None,
+            "mtime": None,
+            "is_symlink": False,
+            "writable_by_hapi": None,
+        }
+    try:
+        st = path.stat()
+    except OSError as exc:
+        return {
+            "path": str(path),
+            "exists": exists,
+            "owner": None,
+            "mode": None,
+            "mtime": None,
+            "is_symlink": path.is_symlink(),
+            "writable_by_hapi": None,
+            "error": exc.__class__.__name__,
+        }
+    mode = stat.S_IMODE(st.st_mode)
+    return {
+        "path": str(path),
+        "exists": True,
+        "owner": f"{name_for_uid(st.st_uid)}:{name_for_gid(st.st_gid)}",
+        "mode": f"{mode:o}",
+        "mtime": int(st.st_mtime),
+        "is_symlink": path.is_symlink(),
+        "writable_by_hapi": writable_by_hapi(path, mode, st),
+    }
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_credentials(credentials_path, now_ms):
+    meta = {
+        "path": str(credentials_path),
+        "has_credentials": credentials_path.is_file(),
+        "sha256": None,
+        "mtime": None,
+        "oauth": {
+            "expiresAt": None,
+            "expires_in_minutes": None,
+            "is_expired": None,
+            "scopes": [],
+            "subscriptionType": None,
+        },
+    }
+    if not credentials_path.is_file():
+        return meta
+
+    try:
+        st = credentials_path.stat()
+        meta["sha256"] = file_sha256(credentials_path)
+        meta["mtime"] = int(st.st_mtime)
+    except OSError as exc:
+        meta["read_error"] = exc.__class__.__name__
+        return meta
+
+    try:
+        raw = json.loads(credentials_path.read_text())
+    except Exception as exc:  # noqa: BLE001 - diagnostic should not fail hard
+        meta["parse_error"] = exc.__class__.__name__
+        return meta
+
+    oauth = raw.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        meta["oauth_error"] = "claudeAiOauth missing or not an object"
+        return meta
+
+    expires_at = oauth.get("expiresAt")
+    scopes = oauth.get("scopes")
+    if not isinstance(scopes, list):
+        scopes = []
+    meta["oauth"] = {
+        "expiresAt": expires_at if isinstance(expires_at, int) else None,
+        "expires_in_minutes": (
+            int((expires_at - now_ms) / 60000)
+            if isinstance(expires_at, int)
+            else None
+        ),
+        "is_expired": (
+            expires_at <= now_ms
+            if isinstance(expires_at, int)
+            else None
+        ),
+        "scopes": scopes,
+        "subscriptionType": oauth.get("subscriptionType"),
+    }
+    return meta
+
+
+def uptime_seconds():
+    try:
+        return float(Path("/proc/uptime").read_text().split()[0])
+    except Exception:  # noqa: BLE001
+        try:
+            result = subprocess.run(
+                ["uptime"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            return result.stdout.strip() or None
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def anthropic_check():
+    result = {
+        "url": "https://api.anthropic.com/",
+        "ok": False,
+        "http_code": None,
+        "method": None,
+        "error": None,
+    }
+    curl = shutil.which("curl")
+    if curl:
+        try:
+            proc = subprocess.run(
+                [
+                    curl,
+                    "-sS",
+                    "-m",
+                    "5",
+                    "-o",
+                    "/dev/null",
+                    "-w",
+                    "%{http_code}",
+                    "https://api.anthropic.com/",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=7,
+            )
+            code = proc.stdout.strip()
+            result.update({
+                "method": "curl",
+                "http_code": code or None,
+                "ok": proc.returncode == 0 and bool(code) and code != "000",
+            })
+            if proc.returncode != 0:
+                result["error"] = (proc.stderr or "").strip()[:200] or "curl failed"
+            return result
+        except Exception as exc:  # noqa: BLE001
+            result.update({"method": "curl", "error": exc.__class__.__name__})
+            return result
+
+    try:
+        context = ssl.create_default_context()
+        with socket.create_connection(("api.anthropic.com", 443), timeout=5) as sock:
+            with context.wrap_socket(sock, server_hostname="api.anthropic.com"):
+                pass
+        result.update({"method": "tcp_tls", "ok": True})
+    except Exception as exc:  # noqa: BLE001
+        result.update({"method": "tcp_tls", "error": exc.__class__.__name__})
+    return result
+
+
+def main():
+    now = utc_now()
+    now_ms = int(now.timestamp() * 1000)
+    claude_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", "/home/hapi/.claude"))
+    credentials_path = claude_dir / ".credentials.json"
+    if claude_dir.name == ".claude":
+        hapi_home = claude_dir.parent
+    else:
+        hapi_home = Path(os.environ.get("HOME", "/home/hapi"))
+
+    settings = claude_dir / "settings.json"
+    settings_local = claude_dir / "settings.local.json"
+    projects = claude_dir / "projects"
+    statsig = claude_dir / "statsig"
+    claude_json = hapi_home / ".claude.json"
+
+    snapshot = {
+        "schema_version": 1,
+        "kind": "claude-auth-snapshot",
+        "label": os.environ.get("CLAUDE_AUTH_SNAPSHOT_LABEL") or None,
+        "created_at": iso_z(now),
+        "now_ms": now_ms,
+        "process": {
+            "user": name_for_uid(os.getuid()),
+            "uid": os.getuid(),
+            "claude_config_dir": str(claude_dir),
+            "snapshot_dir": os.environ.get("CLAUDE_AUTH_SNAPSHOT_DIR", "/home/hapi/.hapi/auth-snapshots"),
+        },
+        "credentials": read_credentials(credentials_path, now_ms),
+        "permissions": {
+            "claude_dir": path_meta(claude_dir),
+            "credentials": path_meta(credentials_path),
+            "settings_json": path_meta(settings),
+            "settings_local_json": path_meta(settings_local),
+        },
+        "artifacts": {
+            "settings_json": settings.exists(),
+            "settings_local_json": settings_local.exists(),
+            "projects": projects.exists(),
+            "claude_json": claude_json.exists(),
+            "statsig": statsig.exists(),
+            "paths": {
+                "settings_json": str(settings),
+                "settings_local_json": str(settings_local),
+                "projects": str(projects),
+                "claude_json": str(claude_json),
+                "statsig": str(statsig),
+            },
+        },
+        "time": {
+            "date_utc": iso_z(now),
+            "uptime_seconds": uptime_seconds(),
+        },
+        "network": {
+            "anthropic": anthropic_check(),
+        },
+    }
+
+    out = Path(os.environ["CLAUDE_AUTH_SNAPSHOT_OUTPUT"])
+    out.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+  echo "${out}"
+}
+
+collect_latest_two() {
+  local dir
+  dir="$(snapshot_dir)"
+  [ -d "${dir}" ] || die "snapshot dir not found: ${dir}"
+  find "${dir}" -maxdepth 1 -type f -name '*.json' | sort | tail -n 2
+}
+
+run_diff() {
+  local a=""
+  local b=""
+  local snapshots=()
+
+  if [ "$#" -eq 0 ]; then
+    while IFS= read -r path; do
+      snapshots+=("${path}")
+    done < <(collect_latest_two)
+    [ "${#snapshots[@]}" -eq 2 ] || die "need at least two snapshots in $(snapshot_dir)"
+    a="${snapshots[0]}"
+    b="${snapshots[1]}"
+  elif [ "$#" -eq 2 ]; then
+    a="$1"
+    b="$2"
+  else
+    usage
+    exit 2
+  fi
+
+  [ -f "${a}" ] || die "snapshot not found: ${a}"
+  [ -f "${b}" ] || die "snapshot not found: ${b}"
+
+  python3 - "${a}" "${b}" <<'PY'
+import json
+import sys
+
+
+def load(path):
+    with open(path) as handle:
+        data = json.load(handle)
+    return data.get("container_snapshot", data)
+
+
+def get(data, keys, default=None):
+    cur = data
+    for key in keys:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def changed(old, new, keys):
+    return get(old, keys) != get(new, keys)
+
+
+def bool_word(value):
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    return "unknown"
+
+
+def permission_verdict(old, new):
+    owner_changed = changed(old, new, ["permissions", "credentials", "owner"])
+    mode_changed = changed(old, new, ["permissions", "credentials", "mode"])
+    owner = get(new, ["permissions", "credentials", "owner"])
+    writable = get(new, ["permissions", "credentials", "writable_by_hapi"])
+    non_hapi_owner = isinstance(owner, str) and not owner.startswith("hapi:")
+    lost_write = writable is False
+    return (owner_changed or mode_changed) and (non_hapi_owner or lost_write)
+
+
+def main():
+    path_a, path_b = sys.argv[1], sys.argv[2]
+    old = load(path_a)
+    new = load(path_b)
+
+    old_has = get(old, ["credentials", "has_credentials"])
+    new_has = get(new, ["credentials", "has_credentials"])
+    file_changed = (
+        changed(old, new, ["credentials", "sha256"])
+        or changed(old, new, ["credentials", "mtime"])
+        or changed(old, new, ["credentials", "oauth", "expiresAt"])
+    )
+    new_expired = get(new, ["credentials", "oauth", "is_expired"])
+    old_net_ok = get(old, ["network", "anthropic", "ok"])
+    new_net_ok = get(new, ["network", "anthropic", "ok"])
+
+    print(f"Claude auth snapshot diff")
+    print(f"A: {path_a}")
+    print(f"B: {path_b}")
+    print("")
+    print("Delta:")
+    print(f"- credentials present: {bool_word(old_has)} -> {bool_word(new_has)}")
+    print(f"- expiresAt: {get(old, ['credentials', 'oauth', 'expiresAt'])} -> {get(new, ['credentials', 'oauth', 'expiresAt'])}")
+    print(f"- is_expired: {bool_word(get(old, ['credentials', 'oauth', 'is_expired']))} -> {bool_word(new_expired)}")
+    print(f"- sha256 changed: {bool_word(changed(old, new, ['credentials', 'sha256']))}")
+    print(f"- mtime changed: {bool_word(changed(old, new, ['credentials', 'mtime']))}")
+    print(
+        "- credentials owner/mode: "
+        f"{get(old, ['permissions', 'credentials', 'owner'])} "
+        f"{get(old, ['permissions', 'credentials', 'mode'])} -> "
+        f"{get(new, ['permissions', 'credentials', 'owner'])} "
+        f"{get(new, ['permissions', 'credentials', 'mode'])}"
+    )
+    print(f"- writable_by_hapi: {bool_word(get(old, ['permissions', 'credentials', 'writable_by_hapi']))} -> {bool_word(get(new, ['permissions', 'credentials', 'writable_by_hapi']))}")
+    print(f"- network api.anthropic.com ok: {bool_word(old_net_ok)} -> {bool_word(new_net_ok)}")
+    print("")
+    print("Verdict:")
+
+    verdicts = []
+    if old_has is True and new_has is False:
+        verdicts.append("🔴 credentials-файл исчез (mount/persistence? проверь host-снэпшот RestartCount/Mounts).")
+    if permission_verdict(old, new):
+        verdicts.append("🔴 права мешают записи: refresh не может сохранить обновлённый токен.")
+    if old_has is True and new_has is True and file_changed:
+        verdicts.append("✅ refresh работает: токен обновляется.")
+    if old_has is True and new_has is True and not file_changed and new_expired is True:
+        verdicts.append("🔴 refresh НЕ происходит: expiresAt в прошлом, файл не переписан — Claude Code не обновляет токен (сеть? падает молча?).")
+    if old_net_ok is True and new_net_ok is False:
+        verdicts.append("⚠️ сетевой доступ к Anthropic пропал.")
+    if not verdicts:
+        verdicts.append("⚪ причина не определена по этим двум снэпшотам.")
+
+    for verdict in verdicts:
+        print(f"- {verdict}")
+
+
+if __name__ == "__main__":
+    main()
+PY
+}
+
+list_snapshots() {
+  local dir
+  dir="$(snapshot_dir)"
+  [ -d "${dir}" ] || return 0
+  find "${dir}" -maxdepth 1 -type f -name '*.json' | sort
+}
+
+latest_snapshot() {
+  list_snapshots | tail -n 1
+}
+
+main() {
+  local command="${1:-snapshot}"
+  if [ "$#" -gt 0 ]; then
+    shift
+  fi
+
+  case "${command}" in
+    snapshot)
+      [ "$#" -le 1 ] || die "snapshot accepts at most one label"
+      create_snapshot "${1:-}"
+      ;;
+    diff)
+      run_diff "$@"
+      ;;
+    list)
+      [ "$#" -eq 0 ] || die "list accepts no arguments"
+      list_snapshots
+      ;;
+    latest)
+      [ "$#" -eq 0 ] || die "latest accepts no arguments"
+      latest_snapshot
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/bin/claude-auth-snapshot.sh
+++ b/bin/claude-auth-snapshot.sh
@@ -64,7 +64,20 @@ create_snapshot() {
   local out
 
   dir="$(snapshot_dir)"
+  # The documented host flow runs this via `docker exec` as ROOT (the image sets
+  # no USER), while /home/hapi is writable by the hapi user — so a hapi process
+  # could pre-place the snapshot dir as a symlink and steer a root write outside
+  # it (arbitrary-path write). Refuse to operate on a symlinked dir, create it
+  # 0700, and let the Python writer create the file with O_NOFOLLOW|O_EXCL 0600.
+  # Mirrors the symlink hardening in uploads.py / ensure_claude_settings.
+  if [ -L "${dir}" ]; then
+    die "snapshot dir '${dir}' is a symlink; refusing (potential arbitrary-path write)"
+  fi
   mkdir -p "${dir}"
+  if [ -L "${dir}" ] || [ ! -d "${dir}" ]; then
+    die "snapshot dir '${dir}' is not a real directory"
+  fi
+  chmod 0700 "${dir}" 2>/dev/null || true
   out="$(unique_snapshot_path "${dir}" "${label}")"
 
   CLAUDE_AUTH_SNAPSHOT_LABEL="${label}" \
@@ -214,9 +227,19 @@ def read_credentials(credentials_path, now_ms):
         return meta
 
     expires_at = oauth.get("expiresAt")
-    scopes = oauth.get("scopes")
-    if not isinstance(scopes, list):
-        scopes = []
+    # Strict scalar allowlist: never serialize a value we did not shape ourselves.
+    # A malformed / schema-drifted credentials file could hide a token inside an
+    # unexpected nested object under scopes/subscriptionType; copying those through
+    # would leak it. So scopes is kept ONLY as a list of plain strings, and
+    # subscriptionType ONLY when it is a str/None — anything else is dropped.
+    raw_scopes = oauth.get("scopes")
+    scopes = (
+        [s for s in raw_scopes if isinstance(s, str)]
+        if isinstance(raw_scopes, list)
+        else []
+    )
+    raw_sub = oauth.get("subscriptionType")
+    subscription_type = raw_sub if isinstance(raw_sub, (str, type(None))) else None
     meta["oauth"] = {
         "expiresAt": expires_at if isinstance(expires_at, int) else None,
         "expires_in_minutes": (
@@ -230,7 +253,7 @@ def read_credentials(credentials_path, now_ms):
             else None
         ),
         "scopes": scopes,
-        "subscriptionType": oauth.get("subscriptionType"),
+        "subscriptionType": subscription_type,
     }
     return meta
 
@@ -362,8 +385,17 @@ def main():
         },
     }
 
-    out = Path(os.environ["CLAUDE_AUTH_SNAPSHOT_OUTPUT"])
-    out.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+    out = os.environ["CLAUDE_AUTH_SNAPSHOT_OUTPUT"]
+    payload = (json.dumps(snapshot, indent=2, sort_keys=True) + "\n").encode()
+    # Symlink-safe, exclusive create at 0600: this may run as root (docker exec)
+    # over hapi-writable storage, so never follow a symlink and never clobber an
+    # existing path. O_NOFOLLOW rejects a final-component symlink; O_EXCL rejects
+    # a pre-created file; 0600 keeps the snapshot non-world-readable.
+    fd = os.open(out, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        os.write(fd, payload)
+    finally:
+        os.close(fd)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -15,6 +15,8 @@ CLI_PACKAGES = REPO_ROOT / "cli-packages.txt"
 INSTALL_CLI = REPO_ROOT / "bin/install-cli.sh"
 TMUX_WRAPPER = REPO_ROOT / "bin/tmux-wrapper.sh"
 GLM = REPO_ROOT / "bin/glm"
+CLAUDE_AUTH_SNAPSHOT = REPO_ROOT / "bin/claude-auth-snapshot.sh"
+CLAUDE_AUTH_SNAPSHOT_HOST = REPO_ROOT / "bin/claude-auth-snapshot-host.sh"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 CLAUDE_SETTINGS_TEMPLATE = REPO_ROOT / "config/claude-settings.json"
@@ -37,7 +39,14 @@ NPM_MANIFEST_SLUGS = {
 
 class TestShellSyntax(unittest.TestCase):
     def test_scripts_parse(self):
-        for script in (ENTRYPOINT, BUILD_SH, INSTALL_CLI, TMUX_WRAPPER):
+        for script in (
+            ENTRYPOINT,
+            BUILD_SH,
+            INSTALL_CLI,
+            TMUX_WRAPPER,
+            CLAUDE_AUTH_SNAPSHOT,
+            CLAUDE_AUTH_SNAPSHOT_HOST,
+        ):
             with self.subTest(script=script.name):
                 result = subprocess.run(
                     ["bash", "-n", str(script)], capture_output=True, text=True
@@ -552,6 +561,205 @@ class TestClaudeConfigPersistence(unittest.TestCase):
         self.assertNotIn(".claude", body)
         # sanity: it does target the runner state files it is meant to clear.
         self.assertIn("runner.state.json", body)
+
+
+class TestClaudeAuthSnapshotScript(unittest.TestCase):
+    """Diagnostic snapshots for Claude Code OAuth must expose metadata only."""
+
+    def _write_fake_curl(self, tmp_path, http_code="200"):
+        fake_curl = tmp_path / "curl"
+        fake_curl.write_text(
+            "#!/bin/bash\n"
+            f"printf '{http_code}'\n"
+        )
+        fake_curl.chmod(0o755)
+
+    def _env(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        snapshot_dir = tmp_path / "snapshots"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        self._write_fake_curl(tmp_path)
+        env = dict(os.environ)
+        env["CLAUDE_CONFIG_DIR"] = str(claude_dir)
+        env["CLAUDE_AUTH_SNAPSHOT_DIR"] = str(snapshot_dir)
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+        return env, claude_dir, snapshot_dir
+
+    def _write_credentials(self, claude_dir, expires_at):
+        credentials = claude_dir / ".credentials.json"
+        credentials.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-SECRET",
+                "refreshToken": "sk-ant-REFRESH",
+                "expiresAt": expires_at,
+                "scopes": ["user:inference", "org:read"],
+                "subscriptionType": "pro",
+            }
+        }))
+        credentials.chmod(0o600)
+        return credentials
+
+    def _snapshot(self, env, label="baseline"):
+        result = subprocess.run(
+            ["bash", str(CLAUDE_AUTH_SNAPSHOT), "snapshot", label],
+            capture_output=True, text=True, env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        path = pathlib.Path(result.stdout.strip())
+        self.assertTrue(path.is_file(), result.stdout)
+        return path, json.loads(path.read_text())
+
+    def _diff(self, a, b):
+        result = subprocess.run(
+            ["bash", str(CLAUDE_AUTH_SNAPSHOT), "diff", str(a), str(b)],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def test_snapshot_redacts_oauth_tokens_and_extracts_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, claude_dir, _ = self._env(tmp_path)
+            self._write_credentials(claude_dir, 4102444800000)
+
+            snapshot_path, snapshot = self._snapshot(env)
+            raw = snapshot_path.read_text()
+
+            for forbidden in (
+                "sk-ant-SECRET",
+                "sk-ant-REFRESH",
+                "accessToken",
+                "refreshToken",
+            ):
+                self.assertNotIn(forbidden, raw)
+
+            credentials = snapshot["credentials"]
+            self.assertTrue(credentials["has_credentials"])
+            self.assertRegex(credentials["sha256"], r"^[0-9a-f]{64}$")
+            oauth = credentials["oauth"]
+            self.assertEqual(oauth["expiresAt"], 4102444800000)
+            self.assertEqual(oauth["scopes"], ["user:inference", "org:read"])
+            self.assertEqual(oauth["subscriptionType"], "pro")
+            self.assertFalse(oauth["is_expired"])
+            self.assertGreater(oauth["expires_in_minutes"], 0)
+
+    def test_snapshot_marks_expired_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, claude_dir, _ = self._env(tmp_path)
+            self._write_credentials(claude_dir, 946684800000)
+
+            _, snapshot = self._snapshot(env, "expired")
+
+            oauth = snapshot["credentials"]["oauth"]
+            self.assertTrue(oauth["is_expired"])
+            self.assertLess(oauth["expires_in_minutes"], 0)
+
+    def test_snapshot_without_credentials_does_not_fail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, _, _ = self._env(tmp_path)
+
+            _, snapshot = self._snapshot(env, "missing")
+
+            self.assertFalse(snapshot["credentials"]["has_credentials"])
+            self.assertIsNone(snapshot["credentials"]["sha256"])
+
+    def test_diff_verdict_refresh_works_when_file_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, claude_dir, _ = self._env(tmp_path)
+            self._write_credentials(claude_dir, 4102444800000)
+            before, _ = self._snapshot(env, "before")
+            self._write_credentials(claude_dir, 4102448400000)
+            after, _ = self._snapshot(env, "after")
+
+            output = self._diff(before, after)
+
+            self.assertIn("refresh работает", output)
+
+    def test_diff_verdict_no_refresh_when_expired_and_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            first = tmp_path / "a.json"
+            second = tmp_path / "b.json"
+            snapshot = {
+                "credentials": {
+                    "has_credentials": True,
+                    "sha256": "a" * 64,
+                    "mtime": 1000,
+                    "oauth": {"expiresAt": 946684800000, "is_expired": True},
+                },
+                "permissions": {
+                    "credentials": {
+                        "owner": "hapi:hapi",
+                        "mode": "600",
+                        "writable_by_hapi": True,
+                    }
+                },
+                "network": {"anthropic": {"ok": True}},
+            }
+            first.write_text(json.dumps(snapshot))
+            second.write_text(json.dumps(snapshot))
+
+            output = self._diff(first, second)
+
+            self.assertIn("refresh НЕ происходит", output)
+
+    def test_diff_verdict_permissions_block_refresh_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            first = tmp_path / "a.json"
+            second = tmp_path / "b.json"
+            before = {
+                "credentials": {
+                    "has_credentials": True,
+                    "sha256": "a" * 64,
+                    "mtime": 1000,
+                    "oauth": {"expiresAt": 4102444800000, "is_expired": False},
+                },
+                "permissions": {
+                    "credentials": {
+                        "owner": "hapi:hapi",
+                        "mode": "600",
+                        "writable_by_hapi": True,
+                    }
+                },
+                "network": {"anthropic": {"ok": True}},
+            }
+            after = json.loads(json.dumps(before))
+            after["permissions"]["credentials"] = {
+                "owner": "root:root",
+                "mode": "400",
+                "writable_by_hapi": False,
+            }
+            first.write_text(json.dumps(before))
+            second.write_text(json.dumps(after))
+
+            output = self._diff(first, second)
+
+            self.assertIn("права мешают", output)
+
+    def test_dockerfile_installs_only_container_snapshot_script(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn(
+            "COPY bin/claude-auth-snapshot.sh /bin/claude-auth-snapshot.sh",
+            dockerfile,
+        )
+        self.assertIn("/bin/claude-auth-snapshot.sh", dockerfile)
+        self.assertNotIn("claude-auth-snapshot-host.sh /bin/", dockerfile)
+
+    def test_docs_and_env_document_snapshot_diagnostics(self):
+        self.assertIn("CLAUDE_AUTH_SNAPSHOT_DIR", (REPO_ROOT / ".env.example").read_text())
+        for path in (README, CLAUDE_MD):
+            with self.subTest(path=path.name):
+                text = path.read_text()
+                self.assertIn("Диагностика слёта Claude Code auth", text)
+                self.assertIn("claude-auth-snapshot.sh snapshot", text)
+                self.assertIn("claude-auth-snapshot-host.sh", text)
+                self.assertIn("токенов в снэпшоте нет", text)
 
 
 class TestClaudeNativeZaiConfig(unittest.TestCase):

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -667,6 +667,60 @@ class TestClaudeAuthSnapshotScript(unittest.TestCase):
             self.assertFalse(snapshot["credentials"]["has_credentials"])
             self.assertIsNone(snapshot["credentials"]["sha256"])
 
+    def test_snapshot_never_leaks_token_nested_in_scopes_or_subscription(self):
+        # Codex finding (PR #90): the redaction is a scalar allowlist, so a
+        # malformed/schema-drifted file that hides a token inside a nested object
+        # under scopes/subscriptionType must NOT leak it. Only plain-string scopes
+        # and a str/None subscriptionType survive; anything else is dropped.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, claude_dir, _ = self._env(tmp_path)
+            (claude_dir / ".credentials.json").write_text(json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "refreshToken": "sk-ant-REFRESH",
+                    "expiresAt": 4102444800000,
+                    # hostile nesting: token smuggled inside scopes / subscriptionType
+                    "scopes": ["user:inference", {"accessToken": "sk-ant-NESTED"}],
+                    "subscriptionType": {"refreshToken": "sk-ant-SUBTOK"},
+                }
+            }))
+            snapshot_path, snapshot = self._snapshot(env, "nested")
+            raw = snapshot_path.read_text()
+            for forbidden in (
+                "sk-ant-SECRET", "sk-ant-REFRESH",
+                "sk-ant-NESTED", "sk-ant-SUBTOK",
+                "accessToken", "refreshToken",
+            ):
+                self.assertNotIn(forbidden, raw)
+            oauth = snapshot["credentials"]["oauth"]
+            # non-string scope dropped, string scope kept
+            self.assertEqual(oauth["scopes"], ["user:inference"])
+            # non-str/None subscriptionType coerced to None
+            self.assertIsNone(oauth["subscriptionType"])
+
+    def test_snapshot_refuses_symlinked_snapshot_dir(self):
+        # Codex finding (PR #90): the tool may run as root via `docker exec` over
+        # hapi-writable storage, and Path write follows symlinks — a hapi-planted
+        # symlinked snapshot dir could steer a root write outside it. The script
+        # must refuse to operate on a symlinked snapshot dir.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            env, claude_dir, snapshot_dir = self._env(tmp_path)
+            self._write_credentials(claude_dir, 4102444800000)
+            # replace the real snapshot dir with a symlink to a victim dir
+            victim = tmp_path / "victim"
+            victim.mkdir()
+            snapshot_dir.rmdir()
+            snapshot_dir.symlink_to(victim)
+            result = subprocess.run(
+                ["bash", str(CLAUDE_AUTH_SNAPSHOT), "snapshot", "attack"],
+                capture_output=True, text=True, env=env,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            # nothing was written into the victim dir
+            self.assertEqual(list(victim.iterdir()), [], "wrote through symlink")
+
     def test_diff_verdict_refresh_works_when_file_changes(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)


### PR DESCRIPTION
## Summary
- Add `/bin/claude-auth-snapshot.sh` for in-container Claude Code OAuth metadata snapshots with `snapshot`, `diff`, `list`, and `latest` commands.
- Add `bin/claude-auth-snapshot-host.sh` for host-side Docker inspect metadata plus nested container snapshots.
- Document the baseline/failure/diff workflow in README/CLAUDE and add optional `CLAUDE_AUTH_SNAPSHOT_DIR` documentation.

## Secret hygiene
- Snapshots never serialize `accessToken` or `refreshToken`; they keep only metadata (`expiresAt`, scopes, subscription type, sha256/mtime, permissions, process/time/network state).
- Tests and Docker smoke include grep checks proving fake token values and token field names are absent from snapshot output.

## Validation
- `python -m pytest tests/unit/test_shell_scripts.py::TestShellSyntax tests/unit/test_shell_scripts.py::TestClaudeAuthSnapshotScript -q`
- `python -m pytest tests/` (372 passed)
- `docker build -t clihost:claude-auth-snapshot-smoke --build-arg INSTALL_CLAUDE_CODE=false --build-arg INSTALL_CODEX=false --build-arg INSTALL_GEMINI=false --build-arg INSTALL_COPILOT=false --build-arg INSTALL_OPENCODE=false --build-arg INSTALL_DROID=false --build-arg INSTALL_HAPI=false --build-arg INSTALL_AO=false --build-arg INSTALL_HERMES=false --build-arg INSTALL_CLOUDFLARED=false --build-arg INSTALL_CHISEL=false .`
- Container smoke: `docker run --rm --user hapi --entrypoint bash clihost:claude-auth-snapshot-smoke ...` verified snapshot metadata and no token leakage.
- Host-wrapper smoke: `bin/claude-auth-snapshot-host.sh <container> smoke` verified Docker state/mount metadata plus nested redacted snapshot.

Closes #89