### PR TITLE
feat: add sync rsync foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ npm test           # node --test over tests/js/**/*.test.mjs
 
 ## Architecture
 
-Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Droid, ao, Hermes Agent), with an integrated multi-terminal web UI (TTYD).
+Docker container running hapi CLI runner alongside OpenSSH server, bundling AI CLI tools (Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Droid, ao, Hermes Agent), with an integrated multi-terminal web UI (TTYD). The base image also includes `rsync` as the transport foundation for the sync epic (#17); actual sync orchestration is intentionally outside this image bootstrap.
 
 **Multi-process layout:**
 - `sshd` (port 22) — SSH access, the container's main process (`exec` at end of entrypoint.sh)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN NODE_VERSION="22.14.0" && \
       exit 1; \
     fi && \
     apt-get update && \
-    apt-get install -y --no-install-recommends bubblewrap ca-certificates curl gh git openssh-server python3-pip python3-venv tini tmux util-linux xz-utils && \
+    apt-get install -y --no-install-recommends bubblewrap ca-certificates curl gh git openssh-server python3-pip python3-venv rsync tini tmux util-linux xz-utils && \
     curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
     tar -xJf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -C /usr/local --strip-components=1 --no-same-owner && \
     rm "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,8 +104,25 @@ ensure_dir_owned() {
 
 ensure_ssh_dir() {
   local ssh_dir="${HAPI_USER_HOME}/.ssh"
+  # Runs as root before the privilege drop, and /home/hapi is hapi-writable via
+  # the persistent volume. A hapi-planted ~/.ssh *symlink* (e.g. -> /etc or another
+  # tenant's home) would be dereferenced by chown -R / chmod, letting root re-perm /
+  # re-own an attacker-chosen target (arbitrary-path chmod+chown). Bail on any
+  # pre-existing symlink, and only touch a real, non-symlink directory. Mirrors the
+  # symlink hardening in ensure_claude_settings / uploads.py.
+  if [ -L "${ssh_dir}" ]; then
+    echo "WARNING: ${ssh_dir} is a symlink; refusing to chmod/chown it" >&2
+    return 0
+  fi
+  if [ -e "${ssh_dir}" ] && [ ! -d "${ssh_dir}" ]; then
+    echo "WARNING: ${ssh_dir} exists but is not a directory; leaving it alone" >&2
+    return 0
+  fi
   ensure_dir_owned "${ssh_dir}"
-  chmod 700 "${ssh_dir}"
+  # Re-check after mkdir -p (defence in depth) before the root chmod follows the path.
+  if [ -d "${ssh_dir}" ] && [ ! -L "${ssh_dir}" ]; then
+    chmod 700 "${ssh_dir}"
+  fi
 }
 
 ensure_gitconfig_file() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,6 +102,20 @@ ensure_dir_owned() {
   done
 }
 
+ensure_ssh_dir() {
+  local ssh_dir="${HAPI_USER_HOME}/.ssh"
+  ensure_dir_owned "${ssh_dir}"
+  chmod 700 "${ssh_dir}"
+}
+
+ensure_gitconfig_file() {
+  local gitconfig_file="${HAPI_USER_HOME}/.gitconfig"
+  if [ ! -e "${gitconfig_file}" ] && [ ! -L "${gitconfig_file}" ]; then
+    : > "${gitconfig_file}"
+    chown "${HAPI_USER}:${HAPI_USER}" "${gitconfig_file}"
+  fi
+}
+
 ensure_local_bin_env() {
   LOCAL_BIN_DIR="${HAPI_USER_HOME}/.local/bin"
   LOCAL_BIN_ENV="${LOCAL_BIN_DIR}/env"
@@ -195,6 +209,8 @@ cleanup_runner_state() {
 ensure_home_owned
 ensure_dir_owned "${HAPI_USER_HOME}/.config/gh"
 ensure_dir_owned "${HAPI_USER_HOME}/.claude"
+ensure_ssh_dir
+ensure_gitconfig_file
 ensure_local_bin_env
 ensure_claude_settings
 

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -634,6 +634,57 @@ class TestSyncFoundationBootstrap(unittest.TestCase):
 
         self.assertEqual(result["gitconfig_content"], existing)
 
+    def test_ssh_dir_symlink_attack_is_refused(self):
+        # Codex + Claude finding (PR #95): ensure_ssh_dir runs as root before the
+        # privilege drop over hapi-writable /home/hapi. A hapi-planted ~/.ssh
+        # *symlink* must NOT be followed — otherwise the root chmod/chown re-perms
+        # and re-owns the attacker-chosen target (arbitrary-path chmod+chown). Uses
+        # the REAL chmod (not the fake logger) so a follow-through actually mutates
+        # the victim and the assertion catches it. Mirrors the #90 symlink tests.
+        helpers = self._extract_helpers()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            home = tmp_path / "home" / "hapi"
+            home.mkdir(parents=True)
+            victim = tmp_path / "victim"
+            victim.mkdir()
+            victim.chmod(0o755)
+            (home / ".ssh").symlink_to(victim)  # attack: ~/.ssh -> victim dir
+
+            chown_log = tmp_path / "chown.log"
+            fake_chown = tmp_path / "chown"
+            fake_chown.write_text(
+                "#!/bin/bash\n" 'printf "%%s\\n" "$*" >> "%s"\n' % chown_log
+            )
+            fake_chown.chmod(0o755)
+            # NOTE: no fake chmod here — use the real one so a symlink follow bites.
+            script = (
+                "set -euo pipefail\n"
+                'HAPI_USER="hapi"\n'
+                f'HAPI_USER_HOME="{home}"\n'
+                f"{helpers}\n"
+                "ensure_ssh_dir\n"
+            )
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, env=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            # victim must be untouched: mode still 0755, and it was never chowned.
+            self.assertEqual(
+                stat.S_IMODE(victim.stat().st_mode), 0o755,
+                "chmod followed the ~/.ssh symlink onto the victim dir",
+            )
+            self.assertFalse(
+                any(str(victim) in line for line in
+                    (chown_log.read_text().splitlines()
+                     if chown_log.exists() else [])),
+                "chown followed the ~/.ssh symlink onto the victim dir",
+            )
+            # the planted symlink itself is left as-is (not turned into a real dir)
+            self.assertTrue((home / ".ssh").is_symlink())
+
 
 class TestClaudeConfigPersistence(unittest.TestCase):
     """The 'Claude Code login keeps resetting' report (issue #59 tail) blamed

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import re
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -515,6 +516,123 @@ class TestEntrypointHomeOwnershipBehaviour(unittest.TestCase):
                     target == home or target.startswith(f"{home}/"),
                     f"chown escaped HAPI_USER_HOME: {target}",
                 )
+
+
+class TestSyncFoundationBootstrap(unittest.TestCase):
+    """Bootstrap contract for sync foundation directories (issue #91).
+
+    Sources the real entrypoint helpers and runs them with fake chown/chmod
+    binaries on PATH, so ownership/mode intent is proven without root or Docker.
+    """
+
+    def _extract_helpers(self):
+        text = ENTRYPOINT.read_text()
+        helpers = []
+        for name in ("ensure_dir_owned", "ensure_ssh_dir", "ensure_gitconfig_file"):
+            match = re.search(
+                rf"^{name}\(\) \{{\n.*?^\}}", text, re.MULTILINE | re.DOTALL
+            )
+            self.assertIsNotNone(match, f"{name} not found in entrypoint.sh")
+            helpers.append(match.group(0))
+        return "\n\n".join(helpers)
+
+    def _run_helpers(self, existing_gitconfig=None):
+        helpers = self._extract_helpers()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            home = tmp_path / "home" / "hapi"
+            home.mkdir(parents=True)
+            gitconfig = home / ".gitconfig"
+            if existing_gitconfig is not None:
+                gitconfig.write_text(existing_gitconfig)
+
+            chown_log = tmp_path / "chown.log"
+            chmod_log = tmp_path / "chmod.log"
+
+            fake_chown = tmp_path / "chown"
+            fake_chown.write_text(
+                "#!/bin/bash\n"
+                'printf "%%s\\n" "$*" >> "%s"\n' % chown_log
+            )
+            fake_chown.chmod(0o755)
+
+            fake_chmod = tmp_path / "chmod"
+            fake_chmod.write_text(
+                "#!/bin/bash\n"
+                'printf "%%s\\n" "$*" >> "%s"\n'
+                'exec /bin/chmod "$@"\n' % chmod_log
+            )
+            fake_chmod.chmod(0o755)
+
+            script = (
+                "set -euo pipefail\n"
+                'HAPI_USER="hapi"\n'
+                f'HAPI_USER_HOME="{home}"\n'
+                f"{helpers}\n"
+                "ensure_ssh_dir\n"
+                "ensure_gitconfig_file\n"
+            )
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+            result = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, env=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            ssh_dir = home / ".ssh"
+            return {
+                "home": str(home),
+                "ssh": str(ssh_dir),
+                "ssh_is_dir": ssh_dir.is_dir(),
+                "ssh_mode": stat.S_IMODE(ssh_dir.stat().st_mode)
+                if ssh_dir.exists() else None,
+                "gitconfig": str(gitconfig),
+                "gitconfig_is_file": gitconfig.is_file(),
+                "gitconfig_content": gitconfig.read_text()
+                if gitconfig.exists() else None,
+                "chown": chown_log.read_text().splitlines()
+                if chown_log.exists() else [],
+                "chmod": chmod_log.read_text().splitlines()
+                if chmod_log.exists() else [],
+            }
+
+    def test_dockerfile_installs_rsync_in_base_apt_layer(self):
+        self.assertRegex(
+            DOCKERFILE.read_text(),
+            r"apt-get install -y --no-install-recommends[^\n]*\brsync\b",
+        )
+
+    def test_ssh_dir_created_chowned_and_mode_700(self):
+        result = self._run_helpers()
+
+        self.assertTrue(result["ssh_is_dir"])
+        self.assertEqual(result["ssh_mode"], 0o700)
+        self.assertTrue(
+            any("hapi:hapi" in line and result["ssh"] in line
+                for line in result["chown"]),
+            f".ssh was not chowned to hapi: {result['chown']}",
+        )
+        self.assertTrue(
+            any(re.fullmatch(rf"0?700 {re.escape(result['ssh'])}", line)
+                for line in result["chmod"]),
+            f".ssh chmod 700 call missing: {result['chmod']}",
+        )
+
+    def test_gitconfig_created_when_missing_and_chowned(self):
+        result = self._run_helpers()
+
+        self.assertTrue(result["gitconfig_is_file"])
+        self.assertEqual(result["gitconfig_content"], "")
+        self.assertTrue(
+            any("hapi:hapi" in line and result["gitconfig"] in line
+                for line in result["chown"]),
+            f".gitconfig was not chowned to hapi: {result['chown']}",
+        )
+
+    def test_existing_gitconfig_is_not_overwritten(self):
+        existing = "[user]\n\tname = persisted\n"
+        result = self._run_helpers(existing_gitconfig=existing)
+
+        self.assertEqual(result["gitconfig_content"], existing)
 
 
 class TestClaudeConfigPersistence(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Install `rsync` in the base apt layer.
- Bootstrap `/home/hapi/.ssh` with mode `0700` and create `/home/hapi/.gitconfig` only when missing.
- Add TDD coverage for the Dockerfile and entrypoint bootstrap behavior, plus document the rsync foundation in `CLAUDE.md`.

## Validation
- `python -m pytest tests/` (`378 passed`)

Closes #91