### PR TITLE
feat: add clihost rsync sync command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,12 @@ SSH_TUNNEL_PROVIDER=cloudflared          # cloudflared | chisel (по умолч
 #   chisel:       ssh -p $CHISEL_REMOTE_PORT hapi@<host из CHISEL_SERVER>
 #   к ao daemon:  добавить -L 127.0.0.1:3001:127.0.0.1:3001
 
+# Host-side sync helper (bin/clihost-sync.sh, issue #92)
+# These are read by the host command, not by the container entrypoint.
+# CLIHOST_SSH_TARGET=hapi@127.0.0.1      # Required unless --target is passed
+# CLIHOST_SSH_PORT=2222                  # Optional, same as --ssh-port
+# CLIHOST_SSH_IDENTITY_FILE=~/.ssh/id_ed25519  # Optional, same as --identity-file
+
 # TTYD Configuration
 PORT=8080                   # Порт HTTP прокси (>= 1024 — прокси работает без root)
 TTYD_USER=hapi              # Пользователь для терминала (под ним же работает прокси)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,40 @@ This is diagnostic only. It distinguishes (a) mount/persistence, (b)
 permissions/refresh write failure, and (c) network/token refresh failure; it does
 not change OAuth state.
 
+### Safe config sync over SSH
+
+`bin/clihost-sync.sh` is the host-side rsync-over-SSH sync command for the safe
+non-secret subset in epic #17. It is copied into the image as
+`/bin/clihost-sync.sh` for parity, but the documented workflow runs it from the
+host against the container's SSH endpoint. `pull` means host to container;
+`push` means container to host.
+
+```bash
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull --apply
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh push
+```
+
+The command is dry-run by default. `--apply` is required for a real transfer and enables
+rsync `--backup --backup-dir=...`; `--delete` is never used unless
+`--allow-delete` is passed explicitly.
+
+The include-list is intentionally narrow:
+
+- `~/.gitconfig`
+- `~/.config/gh`
+
+Non-goals: do not add `~/.claude` to this command because credential persistence
+belongs to the `/home/hapi` volume; do not add private `~/.ssh` material because
+that is a separate sync task; do not add Claude `settings.json` because that
+configuration is managed by the current template/bootstrap contract.
+
+Every run first SSHes into the container and fail-closed checks that the remote
+home is mounted exactly at `/home/hapi`. A parent `/home` mount, no distinct
+`/home/hapi` mount, or an unreadable mount table aborts before rsync. The command
+also guards every controlled path under `/home/hapi` against existing symlinks
+and passes `--no-links` to rsync so it never follows planted symlinks.
+
 ### ttyd proxy package (app/)
 
 `app/ttyd_proxy.py` is only a **thin process entry point** (imports `main` from `ttydproxy.app`; referenced by entrypoint.sh as `python3 /app/ttyd_proxy.py`); all logic lives in the `app/ttydproxy/` package:

--- a/Dockerfile
+++ b/Dockerfile
@@ -278,11 +278,12 @@ COPY app/ /app/
 COPY bin/tmux-wrapper.sh /bin/tmux-wrapper.sh
 COPY bin/glm /bin/glm
 COPY bin/claude-auth-snapshot.sh /bin/claude-auth-snapshot.sh
+COPY bin/clihost-sync.sh /bin/clihost-sync.sh
 COPY config/.tmux.conf /home/hapi/.tmux.conf
 COPY config/.tmux.conf /etc/skel/.tmux.conf
 RUN mkdir -p /etc/skel/.claude
 COPY config/claude-settings.json /etc/skel/.claude/settings.json
-RUN chmod +x /bin/tmux-wrapper.sh /bin/glm /bin/claude-auth-snapshot.sh && \
+RUN chmod +x /bin/tmux-wrapper.sh /bin/glm /bin/claude-auth-snapshot.sh /bin/clihost-sync.sh && \
     chown hapi:hapi /home/hapi/.tmux.conf
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -146,6 +146,39 @@ bin/claude-auth-snapshot-host.sh diff ./claude-auth-host-snapshots/<A>.json ./cl
 права/refresh-запись, (в) сетевой или token-refresh провал, но сам OAuth не
 чинит.
 
+### Safe config sync over SSH
+
+`bin/clihost-sync.sh` is a host-side rsync-over-SSH helper for the safe,
+non-secret sync subset in epic #17. It expects SSH access to the container's
+`sshd` as the `hapi` user. `pull` means host to container; `push` means
+container to host.
+
+```bash
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull --apply
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh push
+```
+
+The command is dry-run by default and prints the rsync itemized changes. A real
+run requires `--apply`; apply mode also uses `--backup --backup-dir=...`.
+`--delete` is never passed to rsync unless you also pass `--allow-delete`.
+
+Only these paths are included:
+
+- `~/.gitconfig`
+- `~/.config/gh`
+
+These paths are intentionally not synced: `~/.claude` stays persisted by the
+`/home/hapi` volume, private `~/.ssh` keys are out of scope for this command,
+and Claude `settings.json` is not part of the sync contract.
+
+Before every run, the helper connects over SSH and refuses to continue unless
+the remote home is a separate mount at exactly `/home/hapi`. A parent `/home`
+mount, missing `/home/hapi` mount, or unreadable mount table aborts before
+`rsync`. The helper also refuses any existing symlink on the controlled
+`/home/hapi` paths and runs rsync with `--no-links`, so it does not read or write
+through planted symlinks.
+
 ## Архитектура
 
 ```

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -105,7 +105,7 @@ run_remote_preflight() {
   shift
   local -a ssh_args=("$@")
 
-  "${ssh_args[@]}" "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" <<'REMOTE'
+  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" <<'REMOTE'
 set -euo pipefail
 
 die() {
@@ -241,6 +241,15 @@ main() {
 
   [ -n "${command}" ] || { usage; die "missing subcommand: pull or push"; }
   [ -n "${target}" ] || die "set --target or CLIHOST_SSH_TARGET"
+  # Reject an option-like target (leading '-'). printf %q protects against SHELL
+  # injection, but not OPTION injection: ssh/rsync parse a leading-dash argument
+  # as a flag, so a target like `-oProxyCommand=<cmd>` runs <cmd> LOCALLY on the
+  # host during preflight — before any mount/symlink guard. Same class as the
+  # dashboard ProxyCommand issue (#85). Guard the target, and pass `--` before the
+  # host in ssh and before the positional operands in rsync (see below).
+  case "${target}" in
+    -*) die "SSH target must not start with '-' (got: ${target})" ;;
+  esac
   case "${ssh_port}" in
     ""|*[!0-9]*) [ -z "${ssh_port}" ] || die "SSH port must be numeric: ${ssh_port}" ;;
   esac
@@ -311,7 +320,9 @@ main() {
     echo "Pushing ${SYNC_LABEL} from ${target}:${REMOTE_HOME} to host (${mode})"
   fi
 
-  rsync "${rsync_args[@]}" "${source}" "${destination}"
+  # `--` ends rsync option parsing so a `-`-leading source/dest (option injection,
+  # e.g. via a hostile target) is treated as a path operand, not a flag.
+  rsync "${rsync_args[@]}" -- "${source}" "${destination}"
 }
 
 main "$@"

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+set -euo pipefail
+
+REMOTE_HOME="/home/hapi"
+SYNC_LABEL="~/.gitconfig and ~/.config/gh"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  clihost-sync.sh pull [--target user@host] [--ssh-port port] [--identity-file path] [--apply] [--allow-delete]
+  clihost-sync.sh push [--target user@host] [--ssh-port port] [--identity-file path] [--apply] [--allow-delete]
+
+Direction:
+  pull  copies the safe host config subset into the clihost container.
+  push  copies the same safe subset from the clihost container back to the host.
+
+Safety:
+  Dry-run is the default. Use --apply for a real rsync run.
+  --delete is never used unless --allow-delete is passed explicitly.
+  The remote home must be mounted exactly at /home/hapi.
+
+Target:
+  Set --target or CLIHOST_SSH_TARGET to the SSH destination, for example:
+    CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 clihost-sync.sh pull
+EOF
+}
+
+quote_join() {
+  local out=""
+  local quoted
+  local arg
+  for arg in "$@"; do
+    printf -v quoted "%q" "${arg}"
+    if [ -n "${out}" ]; then
+      out="${out} ${quoted}"
+    else
+      out="${quoted}"
+    fi
+  done
+  printf "%s\n" "${out}"
+}
+
+guard_local_path() {
+  local root="$1"
+  local path="$2"
+  local rel
+  local current
+  local part
+  local old_ifs
+  local -a parts
+
+  case "${path}" in
+    "${root}" | "${root}"/*) ;;
+    *) die "refusing to touch local path outside HOME: ${path}" ;;
+  esac
+
+  rel="${path#${root}/}"
+  current="${root}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a parts <<< "${rel}"
+  IFS="${old_ifs}"
+  for part in "${parts[@]}"; do
+    [ -n "${part}" ] || continue
+    current="${current}/${part}"
+    if [ -L "${current}" ]; then
+      die "${current} is a symlink; refusing to sync through it"
+    fi
+  done
+}
+
+guard_local_tree_no_symlinks() {
+  local path="$1"
+  local found
+
+  [ -d "${path}" ] || return 0
+  found="$(find "${path}" -type l -print 2>/dev/null)" \
+    || die "cannot inspect ${path} for symlinks"
+  if [ -n "${found}" ]; then
+    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
+  fi
+}
+
+preflight_local() {
+  local host_home="$1"
+  local backup_root="$2"
+
+  [ -n "${host_home}" ] || die "HOME is empty; refusing to sync"
+  [ -d "${host_home}" ] || die "HOME '${host_home}' is not a directory"
+  guard_local_path "${host_home}" "${host_home}/.gitconfig"
+  guard_local_path "${host_home}" "${host_home}/.config"
+  guard_local_path "${host_home}" "${host_home}/.config/gh"
+  guard_local_path "${host_home}" "${backup_root}"
+  guard_local_tree_no_symlinks "${host_home}/.config/gh"
+  guard_local_tree_no_symlinks "${backup_root}"
+}
+
+run_remote_preflight() {
+  local target="$1"
+  shift
+  local -a ssh_args=("$@")
+
+  "${ssh_args[@]}" "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" <<'REMOTE'
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+remote_home="$1"
+mounts_file="$2"
+backup_root="${remote_home}/.clihost-sync-backups"
+
+[ -d "${remote_home}" ] || die "${remote_home} is not a directory; refusing to sync"
+[ ! -L "${remote_home}" ] || die "${remote_home} is a symlink; refusing to sync through it"
+[ -r "${mounts_file}" ] || die "cannot read ${mounts_file}; refusing to sync"
+
+if ! awk -v home="${remote_home}" '$2 == home {found=1} END {exit !found}' "${mounts_file}"; then
+  if awk '$2 == "/home" {found=1} END {exit !found}' "${mounts_file}"; then
+    die "volume is mounted at /home, not exactly /home/hapi; refusing to sync"
+  fi
+  die "no separate volume mount at /home/hapi; refusing to sync"
+fi
+
+guard_remote_path() {
+  local path="$1"
+  local rel
+  local current
+  local part
+  local old_ifs
+  local -a parts
+
+  case "${path}" in
+    "${remote_home}" | "${remote_home}"/*) ;;
+    *) die "refusing to touch remote path outside /home/hapi: ${path}" ;;
+  esac
+
+  rel="${path#${remote_home}/}"
+  current="${remote_home}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a parts <<< "${rel}"
+  IFS="${old_ifs}"
+  for part in "${parts[@]}"; do
+    [ -n "${part}" ] || continue
+    current="${current}/${part}"
+    if [ -L "${current}" ]; then
+      die "${current} is a symlink; refusing to sync through it"
+    fi
+  done
+}
+
+guard_remote_tree_no_symlinks() {
+  local path="$1"
+  local found
+
+  [ -d "${path}" ] || return 0
+  found="$(find "${path}" -type l -print 2>/dev/null)" \
+    || die "cannot inspect ${path} for symlinks"
+  if [ -n "${found}" ]; then
+    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
+  fi
+}
+
+guard_remote_path "${remote_home}/.gitconfig"
+guard_remote_path "${remote_home}/.config"
+guard_remote_path "${remote_home}/.config/gh"
+guard_remote_path "${backup_root}"
+guard_remote_tree_no_symlinks "${remote_home}/.config/gh"
+guard_remote_tree_no_symlinks "${backup_root}"
+REMOTE
+}
+
+main() {
+  local command=""
+  local apply="false"
+  local allow_delete="false"
+  local target="${CLIHOST_SSH_TARGET:-}"
+  local ssh_port="${CLIHOST_SSH_PORT:-}"
+  local identity_file="${CLIHOST_SSH_IDENTITY_FILE:-}"
+  local host_home="${HOME:-}"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      pull|push)
+        [ -z "${command}" ] || die "multiple subcommands provided"
+        command="$1"
+        shift
+        ;;
+      --apply)
+        apply="true"
+        shift
+        ;;
+      --allow-delete)
+        allow_delete="true"
+        shift
+        ;;
+      --target)
+        [ "$#" -ge 2 ] || die "--target requires a value"
+        target="$2"
+        shift 2
+        ;;
+      --target=*)
+        target="${1#--target=}"
+        shift
+        ;;
+      --ssh-port|--port)
+        [ "$#" -ge 2 ] || die "$1 requires a value"
+        ssh_port="$2"
+        shift 2
+        ;;
+      --ssh-port=*|--port=*)
+        ssh_port="${1#*=}"
+        shift
+        ;;
+      --identity-file|-i)
+        [ "$#" -ge 2 ] || die "$1 requires a value"
+        identity_file="$2"
+        shift 2
+        ;;
+      --identity-file=*)
+        identity_file="${1#--identity-file=}"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [ -n "${command}" ] || { usage; die "missing subcommand: pull or push"; }
+  [ -n "${target}" ] || die "set --target or CLIHOST_SSH_TARGET"
+  case "${ssh_port}" in
+    ""|*[!0-9]*) [ -z "${ssh_port}" ] || die "SSH port must be numeric: ${ssh_port}" ;;
+  esac
+  [ -z "${identity_file}" ] || [ -f "${identity_file}" ] || die "identity file not found: ${identity_file}"
+
+  local backup_stamp
+  backup_stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  local local_backup_root="${host_home}/.clihost-sync-backups"
+  local remote_backup_root="${REMOTE_HOME}/.clihost-sync-backups"
+
+  preflight_local "${host_home}" "${local_backup_root}"
+
+  local -a ssh_args=(ssh -o BatchMode=yes)
+  if [ -n "${ssh_port}" ]; then
+    ssh_args+=(-p "${ssh_port}")
+  fi
+  if [ -n "${identity_file}" ]; then
+    ssh_args+=(-i "${identity_file}")
+  fi
+
+  run_remote_preflight "${target}" "${ssh_args[@]}"
+
+  local ssh_remote_shell
+  ssh_remote_shell="$(quote_join "${ssh_args[@]}")"
+
+  local -a rsync_args=(
+    -a
+    --itemize-changes
+    --human-readable
+    --no-links
+    --delay-updates
+    "--include=/.gitconfig"
+    "--include=/.config/"
+    "--include=/.config/gh/***"
+    "--exclude=*"
+    -e "${ssh_remote_shell}"
+  )
+
+  if [ "${apply}" != "true" ]; then
+    rsync_args+=(--dry-run)
+  fi
+  if [ "${apply}" = "true" ]; then
+    rsync_args+=(--backup)
+    if [ "${command}" = "pull" ]; then
+      rsync_args+=("--backup-dir=${remote_backup_root}/${backup_stamp}")
+    else
+      guard_local_path "${host_home}" "${local_backup_root}/${backup_stamp}"
+      rsync_args+=("--backup-dir=${local_backup_root}/${backup_stamp}")
+    fi
+  fi
+  if [ "${allow_delete}" = "true" ]; then
+    rsync_args+=(--delete)
+  fi
+
+  local source
+  local destination
+  local mode="dry-run"
+  if [ "${apply}" = "true" ]; then
+    mode="apply"
+  fi
+  if [ "${command}" = "pull" ]; then
+    source="${host_home%/}/"
+    destination="${target}:${REMOTE_HOME}/"
+    echo "Pulling ${SYNC_LABEL} from host to ${target}:${REMOTE_HOME} (${mode})"
+  else
+    source="${target}:${REMOTE_HOME}/"
+    destination="${host_home%/}/"
+    echo "Pushing ${SYNC_LABEL} from ${target}:${REMOTE_HOME} to host (${mode})"
+  fi
+
+  rsync "${rsync_args[@]}" "${source}" "${destination}"
+}
+
+main "$@"

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -822,6 +822,41 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertIn("symlink", out["result"].stderr)
         self.assertEqual(out["rsync_args"], [])
 
+    def test_option_like_target_is_rejected_before_ssh_or_rsync(self):
+        # Codex + Claude finding (PR #96, both reproduced host RCE): printf %q
+        # guards SHELL injection but not OPTION injection — ssh/rsync parse a
+        # leading-dash target as a flag, so `-oProxyCommand=<cmd>` executes <cmd>
+        # LOCALLY during preflight, before any mount/symlink guard. Same class as
+        # the dashboard ProxyCommand issue (#85). The script must reject a target
+        # starting with '-' and never reach ssh/rsync. A canary file proves the
+        # ProxyCommand never ran.
+        with tempfile.TemporaryDirectory() as canary_dir:
+            canary = pathlib.Path(canary_dir) / "PWNED"
+            env = dict(os.environ)
+            # a real ssh would run this ProxyCommand locally on an option-like target
+            hostile = f'-oProxyCommand=touch {canary}'
+            env["CLIHOST_SSH_TARGET"] = hostile
+            # keep a real HOME so arg-parse reaches the target validation
+            with tempfile.TemporaryDirectory() as home:
+                (pathlib.Path(home) / ".gitconfig").write_text("")
+                env["HOME"] = home
+                result = subprocess.run(
+                    ["bash", str(CLIHOST_SYNC), "pull"],
+                    capture_output=True, text=True, env=env,
+                )
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("must not start with '-'", result.stderr)
+            self.assertFalse(canary.exists(),
+                             "ProxyCommand executed — option injection not blocked")
+
+    def test_ssh_and_rsync_calls_use_end_of_options_separator(self):
+        # Defence-in-depth alongside the target reject: the ssh preflight and the
+        # rsync invocation both pass `--` before the host/positional operands so a
+        # `-`-leading value can never be parsed as a flag.
+        text = CLIHOST_SYNC.read_text()
+        self.assertRegex(text, r'\$\{ssh_args\[@\]\}"\s+--\s+"\$\{target\}"')
+        self.assertRegex(text, r'rsync "\$\{rsync_args\[@\]\}"\s+--\s+')
+
     def test_dockerfile_installs_container_sync_script(self):
         dockerfile = DOCKERFILE.read_text()
         self.assertIn("COPY bin/clihost-sync.sh /bin/clihost-sync.sh", dockerfile)

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -18,6 +18,7 @@ TMUX_WRAPPER = REPO_ROOT / "bin/tmux-wrapper.sh"
 GLM = REPO_ROOT / "bin/glm"
 CLAUDE_AUTH_SNAPSHOT = REPO_ROOT / "bin/claude-auth-snapshot.sh"
 CLAUDE_AUTH_SNAPSHOT_HOST = REPO_ROOT / "bin/claude-auth-snapshot-host.sh"
+CLIHOST_SYNC = REPO_ROOT / "bin/clihost-sync.sh"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 CLAUDE_SETTINGS_TEMPLATE = REPO_ROOT / "config/claude-settings.json"
@@ -47,6 +48,7 @@ class TestShellSyntax(unittest.TestCase):
             TMUX_WRAPPER,
             CLAUDE_AUTH_SNAPSHOT,
             CLAUDE_AUTH_SNAPSHOT_HOST,
+            CLIHOST_SYNC,
         ):
             with self.subTest(script=script.name):
                 result = subprocess.run(
@@ -684,6 +686,160 @@ class TestSyncFoundationBootstrap(unittest.TestCase):
             )
             # the planted symlink itself is left as-is (not turned into a real dir)
             self.assertTrue((home / ".ssh").is_symlink())
+
+
+class TestClihostSyncScript(unittest.TestCase):
+    """rsync-over-SSH sync command contract (issue #92)."""
+
+    def _run_sync(self, args, *, mounts=None, make_remote=None, make_local=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            fake_remote_home = tmp_path / "remote-home"
+            fake_local_home = tmp_path / "local-home"
+            fake_remote_home.mkdir()
+            fake_local_home.mkdir()
+            if mounts is None:
+                mounts = [
+                    "proc /proc proc rw 0 0",
+                    f"/dev/sda1 {fake_remote_home} ext4 rw 0 0",
+                ]
+            (fake_local_home / ".gitconfig").write_text("[user]\n\tname = host\n")
+            (fake_local_home / ".config" / "gh").mkdir(parents=True)
+            (fake_local_home / ".config" / "gh" / "hosts.yml").write_text(
+                "github.com:\n  user: axisrow\n"
+            )
+            if make_remote is not None:
+                make_remote(fake_remote_home)
+            if make_local is not None:
+                make_local(fake_local_home)
+
+            mounts_file = tmp_path / "mounts"
+            mounts_file.write_text("\n".join(mounts) + "\n")
+            ssh_log = tmp_path / "ssh.log"
+            rsync_log = tmp_path / "rsync.log"
+
+            fake_ssh = tmp_path / "ssh"
+            fake_ssh.write_text(
+                "#!/bin/bash\n"
+                f'printf "SSH"; printf " [%s]" "$@"; printf "\\n" >> "{ssh_log}"\n'
+                "while [ \"$#\" -gt 0 ]; do\n"
+                "  if [ \"$1\" = \"bash\" ]; then\n"
+                "    shift\n"
+                "    if [ \"${1:-}\" = \"-s\" ]; then shift; fi\n"
+                "    if [ \"${1:-}\" = \"--\" ]; then shift; fi\n"
+                f'    exec bash -s -- "{fake_remote_home}" "{mounts_file}" "$@"\n'
+                "  fi\n"
+                "  shift\n"
+                "done\n"
+                "cat >/dev/null\n"
+            )
+            fake_ssh.chmod(0o755)
+
+            fake_rsync = tmp_path / "rsync"
+            fake_rsync.write_text(
+                "#!/bin/bash\n"
+                f'for a in "$@"; do printf "%s\\n" "$a" >> "{rsync_log}"; done\n'
+                'printf "rsync %s\\n" "$*"\n'
+            )
+            fake_rsync.chmod(0o755)
+
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+            env["HOME"] = str(fake_local_home)
+            env["CLIHOST_SSH_TARGET"] = "hapi@example.test"
+            result = subprocess.run(
+                ["bash", str(CLIHOST_SYNC), *args],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            return {
+                "result": result,
+                "rsync_args": rsync_log.read_text().splitlines()
+                if rsync_log.exists() else [],
+                "ssh_log": ssh_log.read_text() if ssh_log.exists() else "",
+                "local_home": fake_local_home,
+                "remote_home": fake_remote_home,
+            }
+
+    def test_pull_defaults_to_dry_run_and_never_deletes(self):
+        out = self._run_sync(["pull"])
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertIn("--dry-run", out["rsync_args"])
+        self.assertNotIn("--delete", out["rsync_args"])
+        self.assertIn("hapi@example.test:/home/hapi/", out["rsync_args"])
+
+    def test_apply_uses_backup_without_dry_run(self):
+        out = self._run_sync(["pull", "--apply"])
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertNotIn("--dry-run", out["rsync_args"])
+        self.assertIn("--backup", out["rsync_args"])
+        self.assertTrue(
+            any(arg.startswith("--backup-dir=/home/hapi/.clihost-sync-backups/")
+                for arg in out["rsync_args"]),
+            out["rsync_args"],
+        )
+
+    def test_allow_delete_is_the_only_way_to_pass_delete(self):
+        dry = self._run_sync(["pull"])
+        deleting = self._run_sync(["pull", "--allow-delete"])
+
+        self.assertNotIn("--delete", dry["rsync_args"])
+        self.assertIn("--delete", deleting["rsync_args"])
+
+    def test_aborts_when_home_is_not_mounted_at_home_hapi(self):
+        out = self._run_sync(
+            ["pull"],
+            mounts=["proc /proc proc rw 0 0", "/dev/sda1 /home ext4 rw 0 0"],
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("/home/hapi", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_include_list_is_only_gitconfig_and_gh_config(self):
+        out = self._run_sync(["pull"])
+        joined = "\n".join(out["rsync_args"])
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertIn("/.gitconfig", joined)
+        self.assertIn("/.config/gh/***", joined)
+        self.assertNotIn(".claude", joined)
+        self.assertNotIn(".ssh", joined)
+        self.assertNotIn("settings.json", joined)
+
+    def test_remote_symlink_guard_refuses_to_follow_target(self):
+        def make_remote(home):
+            victim = home.parent / "victim"
+            victim.mkdir()
+            (home / ".gitconfig").symlink_to(victim / "gitconfig")
+
+        out = self._run_sync(["pull"], make_remote=make_remote)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("symlink", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_dockerfile_installs_container_sync_script(self):
+        dockerfile = DOCKERFILE.read_text()
+        self.assertIn("COPY bin/clihost-sync.sh /bin/clihost-sync.sh", dockerfile)
+        self.assertIn("/bin/clihost-sync.sh", dockerfile)
+
+    def test_docs_and_env_document_safe_sync_command(self):
+        self.assertIn("CLIHOST_SSH_TARGET", (REPO_ROOT / ".env.example").read_text())
+        for path in (README, CLAUDE_MD):
+            with self.subTest(path=path.name):
+                text = path.read_text()
+                self.assertIn("clihost-sync.sh pull", text)
+                self.assertIn("dry-run", text)
+                self.assertIn("~/.gitconfig", text)
+                self.assertIn("~/.config/gh", text)
+                self.assertNotRegex(
+                    text,
+                    re.compile(r"clihost-sync\.sh[^\n]*(\.claude|\.ssh|settings\.json)"),
+                )
 
 
 class TestClaudeConfigPersistence(unittest.TestCase):


### PR DESCRIPTION
Closes #92

## Summary
- Add `bin/clihost-sync.sh`, a host-side rsync-over-SSH helper with `pull` as host -> container and `push` as container -> host.
- Restrict sync to the safe subset: `~/.gitconfig` and `~/.config/gh` only.
- Install the helper into the image at `/bin/clihost-sync.sh` and document usage in README, CLAUDE.md, and `.env.example`.

## Safety checks
- Dry-run is the default; real transfers require `--apply`.
- Apply mode adds rsync `--backup --backup-dir=...`.
- `--delete` is never passed unless `--allow-delete` is explicit.
- Remote preflight aborts unless the home volume is mounted exactly at `/home/hapi`.
- Symlink guards reject controlled `/home/hapi` paths and existing symlinks under the synced `gh` tree; rsync also uses `--no-links`.
- Non-goals remain out of scope: no `~/.claude`, private `~/.ssh`, or Claude `settings.json` sync.

## Validation
- `python -m pytest tests/` -> 387 passed
- `docker build -t clihost:issue-92-sync .`
- `docker run --rm --entrypoint bash clihost:issue-92-sync -lc 'test -x /bin/clihost-sync.sh && /bin/clihost-sync.sh --help >/tmp/clihost-sync-help 2>&1 && grep -q "clihost-sync.sh pull" /tmp/clihost-sync-help'`