### PR TITLE
feat: add explicit ssh sync command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,16 @@ not change OAuth state.
 non-secret subset in epic #17. It is copied into the image as
 `/bin/clihost-sync.sh` for parity, but the documented workflow runs it from the
 host against the container's SSH endpoint. `pull` means host to container;
-`push` means container to host.
+`push` means container to host. The separate `ssh` subcommand syncs `~/.ssh`
+only when it is called explicitly; regular `pull`/`push` never include SSH
+material.
 
 ```bash
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull --apply
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh push
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh ssh
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh ssh --apply
 ```
 
 The command is dry-run by default. `--apply` is required for a real transfer and enables
@@ -210,16 +214,26 @@ The include-list is intentionally narrow:
 - `~/.gitconfig`
 - `~/.config/gh`
 
+The `ssh` subcommand is default-off and public-by-default. It includes only
+`~/.ssh/known_hosts`, `~/.ssh/*.pub`, and `~/.ssh/config` unless
+`--include-private-keys` is passed. That flag prints a warning because private
+key material crosses the SSH relay; this is the #17 risk B relay/blast-radius
+case that keeps `~/.ssh` out of the normal sync path. Before transfer, the
+source `~/.ssh` directory must not be more open than `700`, and private keys
+must not be more open than `600`; apply mode also fixes those permissions on the
+receiver.
+
 Non-goals: do not add `~/.claude` to this command because credential persistence
-belongs to the `/home/hapi` volume; do not add private `~/.ssh` material because
-that is a separate sync task; do not add Claude `settings.json` because that
+belongs to the `/home/hapi` volume; do not add private `~/.ssh` material to
+regular `pull`/`push`; do not add Claude `settings.json` because that
 configuration is managed by the current template/bootstrap contract.
 
 Every run first SSHes into the container and fail-closed checks that the remote
 home is mounted exactly at `/home/hapi`. A parent `/home` mount, no distinct
 `/home/hapi` mount, or an unreadable mount table aborts before rsync. The command
 also guards every controlled path under `/home/hapi` against existing symlinks
-and passes `--no-links` to rsync so it never follows planted symlinks.
+including `~/.ssh` for the `ssh` subcommand, and passes `--no-links` to rsync so
+it never follows planted symlinks.
 
 ### ttyd proxy package (app/)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,10 @@ key material crosses the SSH relay; this is the #17 risk B relay/blast-radius
 case that keeps `~/.ssh` out of the normal sync path. Before transfer, the
 source `~/.ssh` directory must not be more open than `700`, and private keys
 must not be more open than `600`; apply mode also fixes those permissions on the
-receiver.
+receiver. The private-key detector is PEM-only, so PuTTY `.ppk` or DER keys are
+not selected by `--include-private-keys`. The sync contract is flat: it targets
+top-level files in `~/.ssh`; keys in subdirectories are permission-checked but
+not copied.
 
 Non-goals: do not add `~/.claude` to this command because credential persistence
 belongs to the `/home/hapi` volume; do not add private `~/.ssh` material to

--- a/README.md
+++ b/README.md
@@ -151,12 +151,15 @@ bin/claude-auth-snapshot-host.sh diff ./claude-auth-host-snapshots/<A>.json ./cl
 `bin/clihost-sync.sh` is a host-side rsync-over-SSH helper for the safe,
 non-secret sync subset in epic #17. It expects SSH access to the container's
 `sshd` as the `hapi` user. `pull` means host to container; `push` means
-container to host.
+container to host. The separate `ssh` subcommand syncs `~/.ssh` only when it is
+called explicitly; regular `pull`/`push` never include SSH material.
 
 ```bash
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh pull --apply
 CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh push
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh ssh
+CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 bin/clihost-sync.sh ssh --apply
 ```
 
 The command is dry-run by default and prints the rsync itemized changes. A real
@@ -168,16 +171,25 @@ Only these paths are included:
 - `~/.gitconfig`
 - `~/.config/gh`
 
+The `ssh` subcommand is default-off and public-by-default. It includes only
+`~/.ssh/known_hosts`, `~/.ssh/*.pub`, and `~/.ssh/config` unless
+`--include-private-keys` is passed. That flag prints a warning because private
+key material crosses the SSH relay; this is the #17 risk B relay/blast-radius
+case that keeps `~/.ssh` out of the normal sync path. Before transfer, the
+source `~/.ssh` directory must not be more open than `700`, and private keys
+must not be more open than `600`; apply mode also fixes those permissions on the
+receiver.
+
 These paths are intentionally not synced: `~/.claude` stays persisted by the
-`/home/hapi` volume, private `~/.ssh` keys are out of scope for this command,
-and Claude `settings.json` is not part of the sync contract.
+`/home/hapi` volume, private `~/.ssh` keys are out of scope for regular
+`pull`/`push`, and Claude `settings.json` is not part of the sync contract.
 
 Before every run, the helper connects over SSH and refuses to continue unless
 the remote home is a separate mount at exactly `/home/hapi`. A parent `/home`
 mount, missing `/home/hapi` mount, or unreadable mount table aborts before
 `rsync`. The helper also refuses any existing symlink on the controlled
-`/home/hapi` paths and runs rsync with `--no-links`, so it does not read or write
-through planted symlinks.
+`/home/hapi` paths, including `~/.ssh` for the `ssh` subcommand, and runs rsync
+with `--no-links`, so it does not read or write through planted symlinks.
 
 ## Архитектура
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ key material crosses the SSH relay; this is the #17 risk B relay/blast-radius
 case that keeps `~/.ssh` out of the normal sync path. Before transfer, the
 source `~/.ssh` directory must not be more open than `700`, and private keys
 must not be more open than `600`; apply mode also fixes those permissions on the
-receiver.
+receiver. The private-key detector is PEM-only, so PuTTY `.ppk` or DER keys are
+not selected by `--include-private-keys`. The sync contract is flat: it targets
+top-level files in `~/.ssh`; keys in subdirectories are permission-checked but
+not copied.
 
 These paths are intentionally not synced: `~/.claude` stays persisted by the
 `/home/hapi` volume, private `~/.ssh` keys are out of scope for regular

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REMOTE_HOME="/home/hapi"
 SYNC_LABEL="~/.gitconfig and ~/.config/gh"
+SSH_SYNC_LABEL="~/.ssh"
 
 die() {
   echo "ERROR: $*" >&2
@@ -14,19 +15,24 @@ usage() {
 Usage:
   clihost-sync.sh pull [--target user@host] [--ssh-port port] [--identity-file path] [--apply] [--allow-delete]
   clihost-sync.sh push [--target user@host] [--ssh-port port] [--identity-file path] [--apply] [--allow-delete]
+  clihost-sync.sh ssh [pull|push] [--target user@host] [--ssh-port port] [--identity-file path] [--include-private-keys] [--apply] [--allow-delete]
 
 Direction:
   pull  copies the safe host config subset into the clihost container.
   push  copies the same safe subset from the clihost container back to the host.
+  ssh   copies ~/.ssh separately; default direction is pull (host to container).
 
 Safety:
   Dry-run is the default. Use --apply for a real rsync run.
   --delete is never used unless --allow-delete is passed explicitly.
   The remote home must be mounted exactly at /home/hapi.
+  ssh sync includes only known_hosts, *.pub, and config by default.
+  Private keys require --include-private-keys and secure source permissions.
 
 Target:
   Set --target or CLIHOST_SSH_TARGET to the SSH destination, for example:
     CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 clihost-sync.sh pull
+    CLIHOST_SSH_TARGET=hapi@127.0.0.1 CLIHOST_SSH_PORT=2222 clihost-sync.sh ssh
 EOF
 }
 
@@ -43,6 +49,115 @@ quote_join() {
     fi
   done
   printf "%s\n" "${out}"
+}
+
+reject_option_like() {
+  local label="$1"
+  local value="$2"
+
+  case "${value}" in
+    -*) die "${label} must not start with '-' (got: ${value})" ;;
+  esac
+}
+
+path_mode() {
+  local path="$1"
+
+  if stat -c '%a' "${path}" >/dev/null 2>&1; then
+    stat -c '%a' "${path}"
+  else
+    stat -f '%Lp' "${path}"
+  fi
+}
+
+reject_group_or_other_permissions() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+  local mode
+  local mode_value
+
+  mode="$(path_mode "${path}")" || die "cannot inspect permissions for ${path}"
+  mode_value=$((8#${mode}))
+  if (( mode_value & 077 )); then
+    die "${label} permissions must be ${expected} or stricter; got ${mode} at ${path}"
+  fi
+}
+
+is_private_key_file() {
+  local path="$1"
+
+  [ -f "${path}" ] || return 1
+  LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
+}
+
+validate_private_key_permissions() {
+  local ssh_dir="$1"
+  local path
+
+  [ -d "${ssh_dir}" ] || return 0
+  while IFS= read -r -d '' path; do
+    if is_private_key_file "${path}"; then
+      reject_group_or_other_permissions "${path}" "600" "private key"
+    fi
+  done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+}
+
+collect_local_private_key_includes() {
+  local ssh_dir="$1"
+  local path
+  local rel
+
+  [ -d "${ssh_dir}" ] || return 0
+  while IFS= read -r -d '' path; do
+    if is_private_key_file "${path}"; then
+      rel="${path#${ssh_dir}/}"
+      printf '%s\n' "--include=/${rel}"
+    fi
+  done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+}
+
+preflight_local_ssh_source() {
+  local host_home="$1"
+  local ssh_dir="${host_home}/.ssh"
+
+  [ -n "${host_home}" ] || die "HOME is empty; refusing to sync"
+  [ -d "${host_home}" ] || die "HOME '${host_home}' is not a directory"
+  guard_local_path "${host_home}" "${ssh_dir}"
+  [ -d "${ssh_dir}" ] || die "source SSH directory not found: ${ssh_dir}"
+  reject_group_or_other_permissions "${ssh_dir}" "700" ".ssh directory"
+  guard_local_tree_no_symlinks "${ssh_dir}"
+  validate_private_key_permissions "${ssh_dir}"
+}
+
+preflight_local_ssh_destination() {
+  local host_home="$1"
+  local ssh_dir="${host_home}/.ssh"
+
+  [ -n "${host_home}" ] || die "HOME is empty; refusing to sync"
+  [ -d "${host_home}" ] || die "HOME '${host_home}' is not a directory"
+  guard_local_path "${host_home}" "${ssh_dir}"
+  if [ -e "${ssh_dir}" ]; then
+    [ -d "${ssh_dir}" ] || die "${ssh_dir} exists but is not a directory"
+    guard_local_tree_no_symlinks "${ssh_dir}"
+  fi
+}
+
+fix_local_ssh_permissions() {
+  local host_home="$1"
+  local ssh_dir="${host_home}/.ssh"
+  local path
+
+  [ -e "${ssh_dir}" ] || return 0
+  guard_local_path "${host_home}" "${ssh_dir}"
+  [ -d "${ssh_dir}" ] || die "${ssh_dir} exists but is not a directory"
+  guard_local_tree_no_symlinks "${ssh_dir}"
+  chmod 700 "${ssh_dir}"
+  while IFS= read -r -d '' path; do
+    if is_private_key_file "${path}"; then
+      chmod 600 "${path}"
+    fi
+  done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
 }
 
 guard_local_path() {
@@ -177,10 +292,190 @@ guard_remote_tree_no_symlinks "${backup_root}"
 REMOTE
 }
 
+run_remote_ssh_helper() {
+  local action="$1"
+  local target="$2"
+  local direction="$3"
+  shift 3
+  local -a ssh_args=("$@")
+
+  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" "${action}" "${direction}" <<'REMOTE'
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+remote_home="$1"
+_mounts_file="$2"
+action="$3"
+direction="$4"
+ssh_dir="${remote_home}/.ssh"
+
+guard_remote_path() {
+  local path="$1"
+  local rel
+  local current
+  local part
+  local old_ifs
+  local -a parts
+
+  case "${path}" in
+    "${remote_home}" | "${remote_home}"/*) ;;
+    *) die "refusing to touch remote path outside /home/hapi: ${path}" ;;
+  esac
+
+  rel="${path#${remote_home}/}"
+  current="${remote_home}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a parts <<< "${rel}"
+  IFS="${old_ifs}"
+  for part in "${parts[@]}"; do
+    [ -n "${part}" ] || continue
+    current="${current}/${part}"
+    if [ -L "${current}" ]; then
+      die "${current} is a symlink; refusing to sync through it"
+    fi
+  done
+}
+
+guard_remote_tree_no_symlinks() {
+  local path="$1"
+  local found
+
+  [ -d "${path}" ] || return 0
+  found="$(find "${path}" -type l -print 2>/dev/null)" \
+    || die "cannot inspect ${path} for symlinks"
+  if [ -n "${found}" ]; then
+    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
+  fi
+}
+
+path_mode() {
+  local path="$1"
+
+  if stat -c '%a' "${path}" >/dev/null 2>&1; then
+    stat -c '%a' "${path}"
+  else
+    stat -f '%Lp' "${path}"
+  fi
+}
+
+reject_group_or_other_permissions() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+  local mode
+  local mode_value
+
+  mode="$(path_mode "${path}")" || die "cannot inspect permissions for ${path}"
+  mode_value=$((8#${mode}))
+  if (( mode_value & 077 )); then
+    die "${label} permissions must be ${expected} or stricter; got ${mode} at ${path}"
+  fi
+}
+
+is_private_key_file() {
+  local path="$1"
+
+  [ -f "${path}" ] || return 1
+  LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
+}
+
+validate_private_key_permissions() {
+  local path
+
+  [ -d "${ssh_dir}" ] || return 0
+  while IFS= read -r -d '' path; do
+    if is_private_key_file "${path}"; then
+      reject_group_or_other_permissions "${path}" "600" "private key"
+    fi
+  done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+}
+
+print_private_key_includes() {
+  local path
+  local rel
+
+  [ -d "${ssh_dir}" ] || return 0
+  while IFS= read -r -d '' path; do
+    if is_private_key_file "${path}"; then
+      rel="${path#${ssh_dir}/}"
+      printf '%s\n' "--include=/${rel}"
+    fi
+  done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+}
+
+guard_remote_path "${ssh_dir}"
+case "${action}" in
+  preflight)
+    if [ "${direction}" = "push" ]; then
+      [ -d "${ssh_dir}" ] || die "source SSH directory not found: ${ssh_dir}"
+      reject_group_or_other_permissions "${ssh_dir}" "700" ".ssh directory"
+      guard_remote_tree_no_symlinks "${ssh_dir}"
+      validate_private_key_permissions
+    else
+      if [ -e "${ssh_dir}" ]; then
+        [ -d "${ssh_dir}" ] || die "${ssh_dir} exists but is not a directory"
+        guard_remote_tree_no_symlinks "${ssh_dir}"
+      fi
+    fi
+    ;;
+  collect-private-includes)
+    [ -d "${ssh_dir}" ] || exit 0
+    guard_remote_tree_no_symlinks "${ssh_dir}"
+    print_private_key_includes
+    ;;
+  fix-permissions)
+    [ -e "${ssh_dir}" ] || exit 0
+    [ -d "${ssh_dir}" ] || die "${ssh_dir} exists but is not a directory"
+    guard_remote_tree_no_symlinks "${ssh_dir}"
+    chmod 700 "${ssh_dir}"
+    while IFS= read -r -d '' path; do
+      if is_private_key_file "${path}"; then
+        chmod 600 "${path}"
+      fi
+    done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+    ;;
+  *)
+    die "unknown remote ssh action: ${action}"
+    ;;
+esac
+REMOTE
+}
+
+run_remote_ssh_preflight() {
+  local target="$1"
+  local direction="$2"
+  local _include_private_keys="$3"
+  shift 3
+
+  run_remote_ssh_helper "preflight" "${target}" "${direction}" "$@"
+}
+
+collect_remote_private_key_includes() {
+  local target="$1"
+  shift
+
+  run_remote_ssh_helper "collect-private-includes" "${target}" "push" "$@"
+}
+
+fix_remote_ssh_permissions() {
+  local target="$1"
+  shift
+
+  run_remote_ssh_helper "fix-permissions" "${target}" "pull" "$@"
+}
+
 main() {
   local command=""
   local apply="false"
   local allow_delete="false"
+  local ssh_direction="pull"
+  local ssh_direction_set="false"
+  local include_private_keys="false"
   local target="${CLIHOST_SSH_TARGET:-}"
   local ssh_port="${CLIHOST_SSH_PORT:-}"
   local identity_file="${CLIHOST_SSH_IDENTITY_FILE:-}"
@@ -189,8 +484,40 @@ main() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       pull|push)
+        if [ "${command}" = "ssh" ]; then
+          [ "${ssh_direction_set}" = "false" ] || die "multiple ssh directions provided"
+          ssh_direction="$1"
+          ssh_direction_set="true"
+        else
+          [ -z "${command}" ] || die "multiple subcommands provided"
+          command="$1"
+        fi
+        shift
+        ;;
+      ssh)
         [ -z "${command}" ] || die "multiple subcommands provided"
-        command="$1"
+        command="ssh"
+        shift
+        ;;
+      --direction)
+        [ "$#" -ge 2 ] || die "--direction requires a value"
+        case "$2" in
+          pull|push) ssh_direction="$2" ;;
+          *) die "--direction must be pull or push" ;;
+        esac
+        ssh_direction_set="true"
+        shift 2
+        ;;
+      --direction=*)
+        case "${1#--direction=}" in
+          pull|push) ssh_direction="${1#--direction=}" ;;
+          *) die "--direction must be pull or push" ;;
+        esac
+        ssh_direction_set="true"
+        shift
+        ;;
+      --include-private-keys)
+        include_private_keys="true"
         shift
         ;;
       --apply)
@@ -239,7 +566,7 @@ main() {
     esac
   done
 
-  [ -n "${command}" ] || { usage; die "missing subcommand: pull or push"; }
+  [ -n "${command}" ] || { usage; die "missing subcommand: pull, push, or ssh"; }
   [ -n "${target}" ] || die "set --target or CLIHOST_SSH_TARGET"
   # Reject an option-like target (leading '-'). printf %q protects against SHELL
   # injection, but not OPTION injection: ssh/rsync parse a leading-dash argument
@@ -247,20 +574,17 @@ main() {
   # host during preflight — before any mount/symlink guard. Same class as the
   # dashboard ProxyCommand issue (#85). Guard the target, and pass `--` before the
   # host in ssh and before the positional operands in rsync (see below).
-  case "${target}" in
-    -*) die "SSH target must not start with '-' (got: ${target})" ;;
-  esac
+  reject_option_like "SSH target" "${target}"
   case "${ssh_port}" in
     ""|*[!0-9]*) [ -z "${ssh_port}" ] || die "SSH port must be numeric: ${ssh_port}" ;;
   esac
+  [ -z "${identity_file}" ] || reject_option_like "identity file" "${identity_file}"
   [ -z "${identity_file}" ] || [ -f "${identity_file}" ] || die "identity file not found: ${identity_file}"
 
   local backup_stamp
   backup_stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
   local local_backup_root="${host_home}/.clihost-sync-backups"
   local remote_backup_root="${REMOTE_HOME}/.clihost-sync-backups"
-
-  preflight_local "${host_home}" "${local_backup_root}"
 
   local -a ssh_args=(ssh -o BatchMode=yes)
   if [ -n "${ssh_port}" ]; then
@@ -281,19 +605,53 @@ main() {
     --human-readable
     --no-links
     --delay-updates
-    "--include=/.gitconfig"
-    "--include=/.config/"
-    "--include=/.config/gh/***"
-    "--exclude=*"
-    -e "${ssh_remote_shell}"
   )
+
+  if [ "${command}" = "ssh" ]; then
+    if [ "${ssh_direction}" = "pull" ]; then
+      preflight_local_ssh_source "${host_home}"
+    else
+      preflight_local_ssh_destination "${host_home}"
+    fi
+    run_remote_ssh_preflight "${target}" "${ssh_direction}" "${include_private_keys}" "${ssh_args[@]}"
+    rsync_args+=(
+      "--include=/known_hosts"
+      "--include=/*.pub"
+      "--include=/config"
+    )
+    if [ "${include_private_keys}" = "true" ]; then
+      echo "WARNING: --include-private-keys selected; private key material will be copied across the SSH relay and leave its source machine. ~/.ssh stays outside the default sync because of #17 risk B (relay/blast-radius)."
+      local include_rule
+      if [ "${ssh_direction}" = "pull" ]; then
+        while IFS= read -r include_rule; do
+          [ -n "${include_rule}" ] || continue
+          rsync_args+=("${include_rule}")
+        done < <(collect_local_private_key_includes "${host_home}/.ssh")
+      else
+        while IFS= read -r include_rule; do
+          [ -n "${include_rule}" ] || continue
+          rsync_args+=("${include_rule}")
+        done < <(collect_remote_private_key_includes "${target}" "${ssh_args[@]}")
+      fi
+    fi
+    rsync_args+=("--exclude=*")
+  else
+    preflight_local "${host_home}" "${local_backup_root}"
+    rsync_args+=(
+      "--include=/.gitconfig"
+      "--include=/.config/"
+      "--include=/.config/gh/***"
+      "--exclude=*"
+    )
+  fi
+  rsync_args+=(-e "${ssh_remote_shell}")
 
   if [ "${apply}" != "true" ]; then
     rsync_args+=(--dry-run)
   fi
   if [ "${apply}" = "true" ]; then
     rsync_args+=(--backup)
-    if [ "${command}" = "pull" ]; then
+    if { [ "${command}" = "pull" ]; } || { [ "${command}" = "ssh" ] && [ "${ssh_direction}" = "pull" ]; }; then
       rsync_args+=("--backup-dir=${remote_backup_root}/${backup_stamp}")
     else
       guard_local_path "${host_home}" "${local_backup_root}/${backup_stamp}"
@@ -307,10 +665,22 @@ main() {
   local source
   local destination
   local mode="dry-run"
+  local transfer_direction="${command}"
   if [ "${apply}" = "true" ]; then
     mode="apply"
   fi
-  if [ "${command}" = "pull" ]; then
+  if [ "${command}" = "ssh" ]; then
+    transfer_direction="${ssh_direction}"
+  fi
+  if [ "${command}" = "ssh" ] && [ "${transfer_direction}" = "pull" ]; then
+    source="${host_home%/}/.ssh/"
+    destination="${target}:${REMOTE_HOME}/.ssh/"
+    echo "Syncing ${SSH_SYNC_LABEL} from host to ${target}:${REMOTE_HOME}/.ssh (${mode})"
+  elif [ "${command}" = "ssh" ]; then
+    source="${target}:${REMOTE_HOME}/.ssh/"
+    destination="${host_home%/}/.ssh/"
+    echo "Syncing ${SSH_SYNC_LABEL} from ${target}:${REMOTE_HOME}/.ssh to host (${mode})"
+  elif [ "${command}" = "pull" ]; then
     source="${host_home%/}/"
     destination="${target}:${REMOTE_HOME}/"
     echo "Pulling ${SYNC_LABEL} from host to ${target}:${REMOTE_HOME} (${mode})"
@@ -323,6 +693,14 @@ main() {
   # `--` ends rsync option parsing so a `-`-leading source/dest (option injection,
   # e.g. via a hostile target) is treated as a path operand, not a flag.
   rsync "${rsync_args[@]}" -- "${source}" "${destination}"
+
+  if [ "${apply}" = "true" ] && [ "${command}" = "ssh" ]; then
+    if [ "${transfer_direction}" = "pull" ]; then
+      fix_remote_ssh_permissions "${target}" "${ssh_args[@]}"
+    else
+      fix_local_ssh_permissions "${host_home}"
+    fi
+  fi
 }
 
 main "$@"

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -100,7 +100,8 @@ is_private_key_file() {
   local path="$1"
 
   [ -f "${path}" ] || return 1
-  LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
+  LC_ALL=C tr -d '\r' < "${path}" 2>/dev/null \
+    | grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$'
 }
 
 validate_default_public_ssh_material() {
@@ -133,6 +134,11 @@ private_key_include_rule() {
   local rule
 
   reject_control_chars "SSH private key filename" "${rel}"
+  case "${rel}" in
+    *'*'*|*'?'*|*'['*|*']'*)
+      die "SSH private key filename must not contain rsync filter metacharacters: ${rel}"
+      ;;
+  esac
   rule="--include=/${rel}"
   case "${rule}" in
     --include=/*) printf '%s\n' "${rule}" ;;
@@ -207,7 +213,14 @@ append_generated_include_rule() {
 
   reject_control_chars "generated rsync include rule" "${rule}"
   case "${rule}" in
-    --include=/*) rsync_args+=("${rule}") ;;
+    --include=/*)
+      case "${rule#--include=/}" in
+        *'*'*|*'?'*|*'['*|*']'*)
+          die "generated rsync include rule must not contain rsync filter metacharacters: ${rule}"
+          ;;
+      esac
+      rsync_args+=("${rule}")
+      ;;
     -*) die "generated rsync include rule must not start with '-' (got: ${rule})" ;;
     *) die "invalid generated rsync include rule: ${rule}" ;;
   esac
@@ -459,7 +472,8 @@ is_private_key_file() {
   local path="$1"
 
   [ -f "${path}" ] || return 1
-  LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
+  LC_ALL=C tr -d '\r' < "${path}" 2>/dev/null \
+    | grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$'
 }
 
 validate_default_public_ssh_material() {
@@ -490,6 +504,11 @@ private_key_include_rule() {
   local rule
 
   reject_control_chars "SSH private key filename" "${rel}"
+  case "${rel}" in
+    *'*'*|*'?'*|*'['*|*']'*)
+      die "SSH private key filename must not contain rsync filter metacharacters: ${rel}"
+      ;;
+  esac
   rule="--include=/${rel}"
   case "${rule}" in
     --include=/*) printf '%s\n' "${rule}" ;;

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -60,6 +60,18 @@ reject_option_like() {
   esac
 }
 
+reject_control_chars() {
+  local label="$1"
+  local value="$2"
+
+  case "${value}" in
+    *$'\n'*|*$'\r'*) die "${label} must not contain control characters" ;;
+  esac
+  if LC_ALL=C printf '%s' "${value}" | grep -q '[[:cntrl:]]'; then
+    die "${label} must not contain control characters"
+  fi
+}
+
 path_mode() {
   local path="$1"
 
@@ -91,6 +103,19 @@ is_private_key_file() {
   LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
 }
 
+validate_default_public_ssh_material() {
+  local ssh_dir="$1"
+  local path
+
+  for path in "${ssh_dir}/known_hosts" "${ssh_dir}/config" "${ssh_dir}"/*.pub; do
+    [ -e "${path}" ] || continue
+    [ -f "${path}" ] || continue
+    if is_private_key_file "${path}"; then
+      die "default SSH public material contains private key block: ${path}"
+    fi
+  done
+}
+
 validate_private_key_permissions() {
   local ssh_dir="$1"
   local path
@@ -103,6 +128,19 @@ validate_private_key_permissions() {
   done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
 }
 
+private_key_include_rule() {
+  local rel="$1"
+  local rule
+
+  reject_control_chars "SSH private key filename" "${rel}"
+  rule="--include=/${rel}"
+  case "${rule}" in
+    --include=/*) printf '%s\n' "${rule}" ;;
+    -*) die "generated rsync include rule must not start with '-' (got: ${rule})" ;;
+    *) die "invalid generated rsync include rule: ${rule}" ;;
+  esac
+}
+
 collect_local_private_key_includes() {
   local ssh_dir="$1"
   local path
@@ -112,13 +150,14 @@ collect_local_private_key_includes() {
   while IFS= read -r -d '' path; do
     if is_private_key_file "${path}"; then
       rel="${path#${ssh_dir}/}"
-      printf '%s\n' "--include=/${rel}"
+      private_key_include_rule "${rel}"
     fi
   done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
 }
 
 preflight_local_ssh_source() {
   local host_home="$1"
+  local include_private_keys="$2"
   local ssh_dir="${host_home}/.ssh"
 
   [ -n "${host_home}" ] || die "HOME is empty; refusing to sync"
@@ -128,6 +167,9 @@ preflight_local_ssh_source() {
   reject_group_or_other_permissions "${ssh_dir}" "700" ".ssh directory"
   guard_local_tree_no_symlinks "${ssh_dir}"
   validate_private_key_permissions "${ssh_dir}"
+  if [ "${include_private_keys}" != "true" ]; then
+    validate_default_public_ssh_material "${ssh_dir}"
+  fi
 }
 
 preflight_local_ssh_destination() {
@@ -158,6 +200,28 @@ fix_local_ssh_permissions() {
       chmod 600 "${path}"
     fi
   done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
+}
+
+append_generated_include_rule() {
+  local rule="$1"
+
+  reject_control_chars "generated rsync include rule" "${rule}"
+  case "${rule}" in
+    --include=/*) rsync_args+=("${rule}") ;;
+    -*) die "generated rsync include rule must not start with '-' (got: ${rule})" ;;
+    *) die "invalid generated rsync include rule: ${rule}" ;;
+  esac
+}
+
+append_generated_include_rules() {
+  local include_output="$1"
+  local include_rule
+
+  [ -n "${include_output}" ] || return 0
+  while IFS= read -r include_rule || [ -n "${include_rule}" ]; do
+    [ -n "${include_rule}" ] || continue
+    append_generated_include_rule "${include_rule}"
+  done <<< "${include_output}"
 }
 
 guard_local_path() {
@@ -296,10 +360,11 @@ run_remote_ssh_helper() {
   local action="$1"
   local target="$2"
   local direction="$3"
-  shift 3
+  local include_private_keys="$4"
+  shift 4
   local -a ssh_args=("$@")
 
-  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" "${action}" "${direction}" <<'REMOTE'
+  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" "${action}" "${direction}" "${include_private_keys}" <<'REMOTE'
 set -euo pipefail
 
 die() {
@@ -311,6 +376,7 @@ remote_home="$1"
 _mounts_file="$2"
 action="$3"
 direction="$4"
+include_private_keys="$5"
 ssh_dir="${remote_home}/.ssh"
 
 guard_remote_path() {
@@ -363,6 +429,18 @@ path_mode() {
   fi
 }
 
+reject_control_chars() {
+  local label="$1"
+  local value="$2"
+
+  case "${value}" in
+    *$'\n'*|*$'\r'*) die "${label} must not contain control characters" ;;
+  esac
+  if LC_ALL=C printf '%s' "${value}" | grep -q '[[:cntrl:]]'; then
+    die "${label} must not contain control characters"
+  fi
+}
+
 reject_group_or_other_permissions() {
   local path="$1"
   local expected="$2"
@@ -384,6 +462,18 @@ is_private_key_file() {
   LC_ALL=C grep -Eq -- '^-+BEGIN [A-Z0-9 ]*PRIVATE KEY-+$' "${path}" 2>/dev/null
 }
 
+validate_default_public_ssh_material() {
+  local path
+
+  for path in "${ssh_dir}/known_hosts" "${ssh_dir}/config" "${ssh_dir}"/*.pub; do
+    [ -e "${path}" ] || continue
+    [ -f "${path}" ] || continue
+    if is_private_key_file "${path}"; then
+      die "default SSH public material contains private key block: ${path}"
+    fi
+  done
+}
+
 validate_private_key_permissions() {
   local path
 
@@ -395,6 +485,19 @@ validate_private_key_permissions() {
   done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
 }
 
+private_key_include_rule() {
+  local rel="$1"
+  local rule
+
+  reject_control_chars "SSH private key filename" "${rel}"
+  rule="--include=/${rel}"
+  case "${rule}" in
+    --include=/*) printf '%s\n' "${rule}" ;;
+    -*) die "generated rsync include rule must not start with '-' (got: ${rule})" ;;
+    *) die "invalid generated rsync include rule: ${rule}" ;;
+  esac
+}
+
 print_private_key_includes() {
   local path
   local rel
@@ -403,7 +506,7 @@ print_private_key_includes() {
   while IFS= read -r -d '' path; do
     if is_private_key_file "${path}"; then
       rel="${path#${ssh_dir}/}"
-      printf '%s\n' "--include=/${rel}"
+      private_key_include_rule "${rel}"
     fi
   done < <(find "${ssh_dir}" -type f -print0 2>/dev/null)
 }
@@ -416,6 +519,9 @@ case "${action}" in
       reject_group_or_other_permissions "${ssh_dir}" "700" ".ssh directory"
       guard_remote_tree_no_symlinks "${ssh_dir}"
       validate_private_key_permissions
+      if [ "${include_private_keys}" != "true" ]; then
+        validate_default_public_ssh_material
+      fi
     else
       if [ -e "${ssh_dir}" ]; then
         [ -d "${ssh_dir}" ] || die "${ssh_dir} exists but is not a directory"
@@ -449,24 +555,24 @@ REMOTE
 run_remote_ssh_preflight() {
   local target="$1"
   local direction="$2"
-  local _include_private_keys="$3"
+  local include_private_keys="$3"
   shift 3
 
-  run_remote_ssh_helper "preflight" "${target}" "${direction}" "$@"
+  run_remote_ssh_helper "preflight" "${target}" "${direction}" "${include_private_keys}" "$@"
 }
 
 collect_remote_private_key_includes() {
   local target="$1"
   shift
 
-  run_remote_ssh_helper "collect-private-includes" "${target}" "push" "$@"
+  run_remote_ssh_helper "collect-private-includes" "${target}" "push" "true" "$@"
 }
 
 fix_remote_ssh_permissions() {
   local target="$1"
   shift
 
-  run_remote_ssh_helper "fix-permissions" "${target}" "pull" "$@"
+  run_remote_ssh_helper "fix-permissions" "${target}" "pull" "false" "$@"
 }
 
 main() {
@@ -609,7 +715,7 @@ main() {
 
   if [ "${command}" = "ssh" ]; then
     if [ "${ssh_direction}" = "pull" ]; then
-      preflight_local_ssh_source "${host_home}"
+      preflight_local_ssh_source "${host_home}" "${include_private_keys}"
     else
       preflight_local_ssh_destination "${host_home}"
     fi
@@ -621,18 +727,17 @@ main() {
     )
     if [ "${include_private_keys}" = "true" ]; then
       echo "WARNING: --include-private-keys selected; private key material will be copied across the SSH relay and leave its source machine. ~/.ssh stays outside the default sync because of #17 risk B (relay/blast-radius)."
-      local include_rule
+      local include_output
       if [ "${ssh_direction}" = "pull" ]; then
-        while IFS= read -r include_rule; do
-          [ -n "${include_rule}" ] || continue
-          rsync_args+=("${include_rule}")
-        done < <(collect_local_private_key_includes "${host_home}/.ssh")
+        if ! include_output="$(collect_local_private_key_includes "${host_home}/.ssh")"; then
+          exit 1
+        fi
       else
-        while IFS= read -r include_rule; do
-          [ -n "${include_rule}" ] || continue
-          rsync_args+=("${include_rule}")
-        done < <(collect_remote_private_key_includes "${target}" "${ssh_args[@]}")
+        if ! include_output="$(collect_remote_private_key_includes "${target}" "${ssh_args[@]}")"; then
+          exit 1
+        fi
       fi
+      append_generated_include_rules "${include_output}"
     fi
     rsync_args+=("--exclude=*")
   else

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -737,7 +737,9 @@ class TestClihostSyncScript(unittest.TestCase):
             fake_ssh = tmp_path / "ssh"
             fake_ssh.write_text(
                 "#!/bin/bash\n"
-                f'printf "SSH"; printf " [%s]" "$@"; printf "\\n" >> "{ssh_log}"\n'
+                f'printf "SSH" >> "{ssh_log}"\n'
+                f'printf " [%s]" "$@" >> "{ssh_log}"\n'
+                f'printf "\\n" >> "{ssh_log}"\n'
                 "while [ \"$#\" -gt 0 ]; do\n"
                 "  if [ \"$1\" = \"bash\" ]; then\n"
                 "    shift\n"
@@ -827,6 +829,82 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertIn("--include=/id_ed25519", out["rsync_args"])
         self.assertIn("private key material", out["result"].stdout)
         self.assertIn("relay/blast-radius", out["result"].stdout)
+
+    def test_ssh_rejects_local_private_key_name_with_control_character(self):
+        def make_local(home):
+            ssh_dir = self._make_ssh_material(home)
+            hostile = ssh_dir / "id\n--delete-excluded"
+            hostile.write_text(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                "private-test-fixture\n"
+                "-----END OPENSSH PRIVATE KEY-----\n"
+            )
+            hostile.chmod(0o600)
+
+        out = self._run_sync(
+            ["ssh", "--include-private-keys"],
+            make_local=make_local,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("control", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_rejects_remote_private_key_name_with_control_character(self):
+        def make_remote(home):
+            ssh_dir = self._make_ssh_material(home)
+            hostile = ssh_dir / "id\n--delete-excluded"
+            hostile.write_text(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                "private-test-fixture\n"
+                "-----END OPENSSH PRIVATE KEY-----\n"
+            )
+            hostile.chmod(0o600)
+
+        out = self._run_sync(
+            ["ssh", "push", "--include-private-keys"],
+            make_remote=make_remote,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("control", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_rejects_private_key_disguised_as_public_file(self):
+        def make_local(home):
+            ssh_dir = self._make_ssh_material(home)
+            disguised = ssh_dir / "id_ed25519.pub"
+            disguised.write_text(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                "private-test-fixture\n"
+                "-----END OPENSSH PRIVATE KEY-----\n"
+            )
+            disguised.chmod(0o600)
+
+        out = self._run_sync(["ssh"], make_local=make_local)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("public", out["result"].stderr)
+        self.assertIn("private key", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_rejects_remote_private_key_disguised_as_public_file(self):
+        def make_remote(home):
+            ssh_dir = self._make_ssh_material(home)
+            disguised = ssh_dir / "id_ed25519.pub"
+            disguised.write_text(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                "private-test-fixture\n"
+                "-----END OPENSSH PRIVATE KEY-----\n"
+            )
+            disguised.chmod(0o600)
+
+        out = self._run_sync(["ssh", "push"], make_remote=make_remote)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("public", out["result"].stderr)
+        self.assertIn("private key", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
 
     def test_ssh_refuses_open_private_key_permissions_before_rsync(self):
         def make_local(home):
@@ -996,6 +1074,8 @@ class TestClihostSyncScript(unittest.TestCase):
                 self.assertIn("~/.config/gh", text)
                 self.assertIn("--include-private-keys", text)
                 self.assertIn("relay/blast-radius", text)
+                self.assertIn("PEM-only", text)
+                self.assertIn("flat", text)
                 self.assertNotRegex(
                     text,
                     re.compile(r"clihost-sync\.sh[^\n]*(\.claude|settings\.json)"),

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -870,6 +870,48 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertIn("control", out["result"].stderr)
         self.assertEqual(out["rsync_args"], [])
 
+    def test_ssh_rejects_local_private_key_name_with_rsync_filter_glob(self):
+        def make_local(home):
+            ssh_dir = self._make_ssh_material(home)
+            for name in ("*", "***"):
+                hostile = ssh_dir / name
+                hostile.write_text(
+                    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                    "private-test-fixture\n"
+                    "-----END OPENSSH PRIVATE KEY-----\n"
+                )
+                hostile.chmod(0o600)
+
+        out = self._run_sync(
+            ["ssh", "--include-private-keys"],
+            make_local=make_local,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("rsync filter", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_rejects_remote_private_key_name_with_rsync_filter_glob(self):
+        def make_remote(home):
+            ssh_dir = self._make_ssh_material(home)
+            for name in ("*", "***"):
+                hostile = ssh_dir / name
+                hostile.write_text(
+                    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                    "private-test-fixture\n"
+                    "-----END OPENSSH PRIVATE KEY-----\n"
+                )
+                hostile.chmod(0o600)
+
+        out = self._run_sync(
+            ["ssh", "push", "--include-private-keys"],
+            make_remote=make_remote,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("rsync filter", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
     def test_ssh_rejects_private_key_disguised_as_public_file(self):
         def make_local(home):
             ssh_dir = self._make_ssh_material(home)
@@ -888,6 +930,24 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertIn("private key", out["result"].stderr)
         self.assertEqual(out["rsync_args"], [])
 
+    def test_ssh_rejects_private_key_disguised_as_public_file_with_crlf_pem(self):
+        def make_local(home):
+            ssh_dir = self._make_ssh_material(home)
+            disguised = ssh_dir / "id_ed25519.pub"
+            disguised.write_bytes(
+                b"-----BEGIN OPENSSH PRIVATE KEY-----\r\n"
+                b"private-test-fixture\r\n"
+                b"-----END OPENSSH PRIVATE KEY-----\r\n"
+            )
+            disguised.chmod(0o600)
+
+        out = self._run_sync(["ssh"], make_local=make_local)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("public", out["result"].stderr)
+        self.assertIn("private key", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
     def test_ssh_rejects_remote_private_key_disguised_as_public_file(self):
         def make_remote(home):
             ssh_dir = self._make_ssh_material(home)
@@ -896,6 +956,24 @@ class TestClihostSyncScript(unittest.TestCase):
                 "-----BEGIN OPENSSH PRIVATE KEY-----\n"
                 "private-test-fixture\n"
                 "-----END OPENSSH PRIVATE KEY-----\n"
+            )
+            disguised.chmod(0o600)
+
+        out = self._run_sync(["ssh", "push"], make_remote=make_remote)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("public", out["result"].stderr)
+        self.assertIn("private key", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_rejects_remote_private_key_disguised_as_public_file_with_crlf_pem(self):
+        def make_remote(home):
+            ssh_dir = self._make_ssh_material(home)
+            disguised = ssh_dir / "id_ed25519.pub"
+            disguised.write_bytes(
+                b"-----BEGIN OPENSSH PRIVATE KEY-----\r\n"
+                b"private-test-fixture\r\n"
+                b"-----END OPENSSH PRIVATE KEY-----\r\n"
             )
             disguised.chmod(0o600)
 

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -689,7 +689,23 @@ class TestSyncFoundationBootstrap(unittest.TestCase):
 
 
 class TestClihostSyncScript(unittest.TestCase):
-    """rsync-over-SSH sync command contract (issue #92)."""
+    """rsync-over-SSH sync command contract (issues #92 and #93)."""
+
+    def _make_ssh_material(self, home, *, dir_mode=0o700, key_mode=0o600):
+        ssh_dir = home / ".ssh"
+        ssh_dir.mkdir()
+        (ssh_dir / "known_hosts").write_text("example.test ssh-ed25519 AAAA\n")
+        (ssh_dir / "config").write_text("Host example\n  HostName example.test\n")
+        (ssh_dir / "id_ed25519.pub").write_text("ssh-ed25519 AAAA public\n")
+        private_key = ssh_dir / "id_ed25519"
+        private_key.write_text(
+            "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            "private-test-fixture\n"
+            "-----END OPENSSH PRIVATE KEY-----\n"
+        )
+        ssh_dir.chmod(dir_mode)
+        private_key.chmod(key_mode)
+        return ssh_dir
 
     def _run_sync(self, args, *, mounts=None, make_remote=None, make_local=None):
         with tempfile.TemporaryDirectory() as tmp:
@@ -727,6 +743,8 @@ class TestClihostSyncScript(unittest.TestCase):
                 "    shift\n"
                 "    if [ \"${1:-}\" = \"-s\" ]; then shift; fi\n"
                 "    if [ \"${1:-}\" = \"--\" ]; then shift; fi\n"
+                "    [ \"$#\" -ge 1 ] && shift\n"
+                "    [ \"$#\" -ge 1 ] && shift\n"
                 f'    exec bash -s -- "{fake_remote_home}" "{mounts_file}" "$@"\n'
                 "  fi\n"
                 "  shift\n"
@@ -769,6 +787,110 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertIn("--dry-run", out["rsync_args"])
         self.assertNotIn("--delete", out["rsync_args"])
         self.assertIn("hapi@example.test:/home/hapi/", out["rsync_args"])
+
+    def test_ssh_defaults_to_dry_run(self):
+        out = self._run_sync(["ssh"], make_local=self._make_ssh_material)
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertIn("--dry-run", out["rsync_args"])
+        self.assertNotIn("--delete", out["rsync_args"])
+        self.assertIn(str(out["local_home"] / ".ssh") + "/", out["rsync_args"])
+        self.assertIn("hapi@example.test:/home/hapi/.ssh/", out["rsync_args"])
+
+    def test_ssh_push_direction_syncs_container_to_host(self):
+        out = self._run_sync(["ssh", "push"], make_remote=self._make_ssh_material)
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertIn("--dry-run", out["rsync_args"])
+        self.assertIn("hapi@example.test:/home/hapi/.ssh/", out["rsync_args"])
+        self.assertIn(str(out["local_home"] / ".ssh") + "/", out["rsync_args"])
+
+    def test_ssh_default_include_list_is_public_material_only(self):
+        out = self._run_sync(["ssh"], make_local=self._make_ssh_material)
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        includes = [arg for arg in out["rsync_args"] if arg.startswith("--include=")]
+        self.assertEqual(
+            includes,
+            ["--include=/known_hosts", "--include=/*.pub", "--include=/config"],
+        )
+        joined = "\n".join(out["rsync_args"])
+        self.assertNotIn("id_ed25519", joined)
+
+    def test_ssh_include_private_keys_adds_private_material_and_warning(self):
+        out = self._run_sync(
+            ["ssh", "--include-private-keys"],
+            make_local=self._make_ssh_material,
+        )
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertIn("--include=/id_ed25519", out["rsync_args"])
+        self.assertIn("private key material", out["result"].stdout)
+        self.assertIn("relay/blast-radius", out["result"].stdout)
+
+    def test_ssh_refuses_open_private_key_permissions_before_rsync(self):
+        def make_local(home):
+            self._make_ssh_material(home, key_mode=0o644)
+
+        out = self._run_sync(["ssh"], make_local=make_local)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("private key", out["result"].stderr)
+        self.assertIn("600", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_refuses_open_ssh_dir_permissions_before_rsync(self):
+        def make_local(home):
+            self._make_ssh_material(home, dir_mode=0o755)
+
+        out = self._run_sync(["ssh"], make_local=make_local)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn(".ssh", out["result"].stderr)
+        self.assertIn("700", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_option_like_target_is_rejected_before_ssh_or_rsync(self):
+        out = self._run_sync(
+            ["ssh", "--target", "-oProxyCommand=touch /tmp/pwned"],
+            make_local=self._make_ssh_material,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("must not start with '-'", out["result"].stderr)
+        self.assertEqual(out["ssh_log"], "")
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_option_like_identity_file_is_rejected_before_ssh_or_rsync(self):
+        out = self._run_sync(
+            ["ssh", "--identity-file", "-oProxyCommand=touch /tmp/pwned"],
+            make_local=self._make_ssh_material,
+        )
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("must not start with '-'", out["result"].stderr)
+        self.assertEqual(out["ssh_log"], "")
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_dir_symlink_attack_is_refused(self):
+        def make_local(home):
+            victim = home.parent / "victim-ssh"
+            victim.mkdir()
+            (home / ".ssh").symlink_to(victim)
+
+        out = self._run_sync(["ssh"], make_local=make_local)
+
+        self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
+        self.assertIn("symlink", out["result"].stderr)
+        self.assertEqual(out["rsync_args"], [])
+
+    def test_ssh_apply_without_allow_delete_does_not_delete(self):
+        out = self._run_sync(["ssh", "--apply"], make_local=self._make_ssh_material)
+
+        self.assertEqual(out["result"].returncode, 0, out["result"].stderr)
+        self.assertNotIn("--dry-run", out["rsync_args"])
+        self.assertIn("--backup", out["rsync_args"])
+        self.assertNotIn("--delete", out["rsync_args"])
 
     def test_apply_uses_backup_without_dry_run(self):
         out = self._run_sync(["pull", "--apply"])
@@ -868,12 +990,15 @@ class TestClihostSyncScript(unittest.TestCase):
             with self.subTest(path=path.name):
                 text = path.read_text()
                 self.assertIn("clihost-sync.sh pull", text)
+                self.assertIn("clihost-sync.sh ssh", text)
                 self.assertIn("dry-run", text)
                 self.assertIn("~/.gitconfig", text)
                 self.assertIn("~/.config/gh", text)
+                self.assertIn("--include-private-keys", text)
+                self.assertIn("relay/blast-radius", text)
                 self.assertNotRegex(
                     text,
-                    re.compile(r"clihost-sync\.sh[^\n]*(\.claude|\.ssh|settings\.json)"),
+                    re.compile(r"clihost-sync\.sh[^\n]*(\.claude|settings\.json)"),
                 )
 
 


### PR DESCRIPTION
## Summary
- add explicit `clihost-sync.sh ssh` command for default-off `~/.ssh` sync
- keep normal `pull`/`push` include-list limited to `~/.gitconfig` and `~/.config/gh`
- default SSH sync to dry-run and public material only: `known_hosts`, `*.pub`, `config`
- require `--include-private-keys` for private key material with a visible relay/blast-radius warning
- add fail-closed option-injection, symlink, mount, and permission guards plus post-apply chmod on receivers
- document the new command and risks in README/CLAUDE

Closes #93

## Tests
- `python -m pytest tests/`
- `npm ci`
- `npm test`
