### PR TITLE
fix(security): drop PASSWORD_SECRET from proxy env + add slowloris read-timeout (#101 P0)

### DIFF
--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -32,6 +32,7 @@ from ttydproxy.config import (
     UPLOAD_DIR,
     TTYD_ROUTE_PATTERN,
     MAX_TERMINAL_ID_DIGITS,
+    REQUEST_TIMEOUT,
 )
 from ttydproxy.manager import TTYDManager
 from ttydproxy.proxy import is_websocket_request, proxy_ttyd_http, proxy_ttyd_websocket
@@ -85,6 +86,12 @@ def _get_memory_rss_mb():
 
 class TTYDProxyHandler(BaseHandler):
     """HTTP request handler for ttyd proxy routes."""
+
+    # Socket read timeout applied per connection by BaseHTTPRequestHandler
+    # (setup() calls self.connection.settimeout(self.timeout)). Caps slow-client
+    # (slowloris) threads that would otherwise block header parsing and body
+    # reads forever on a ThreadingHTTPServer worker (#101/#2).
+    timeout = REQUEST_TIMEOUT
 
     def do_GET(self):
         parsed = urlparse(self.path)

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -27,6 +27,13 @@ SSH_URL_FILE = os.environ.get("SSH_URL_FILE", "/home/hapi/ssh-url")
 MAX_UPLOAD_SIZE = env_int(os.environ.get("MAX_UPLOAD_SIZE"), 10485760, name="MAX_UPLOAD_SIZE")
 UPLOAD_DIR = os.environ.get("UPLOAD_DIR", f"{CLEANUP_ROOT}/.uploads")
 
+# Per-connection socket read timeout (seconds). Without it a slow client
+# (slowloris) holds a ThreadingHTTPServer worker thread forever: header parsing
+# and rfile.read(Content-Length) block indefinitely, and the login rate-limiter
+# only fires inside handle_login — after the slow window. minimum=1 keeps a
+# misconfigured value from disabling the timeout (0 would mean "block forever").
+REQUEST_TIMEOUT = env_int(os.environ.get("REQUEST_TIMEOUT"), 30, name="REQUEST_TIMEOUT", minimum=1)
+
 # Single source of truth for the terminal-id digit cap. Bounding the length
 # keeps int() from ever hitting Python's 4300-digit string-conversion limit on
 # an unauthenticated path; an over-long id fails to match / fails the guard and

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -466,6 +466,14 @@ ensure_dir_owned "${UPLOAD_DIR}"
 PROXY_SECRET_FILE="/run/ttyd-proxy.secret"
 install -m 400 -o "${TTYD_USER}" /dev/null "${PROXY_SECRET_FILE}"
 printf '%s' "${PASSWORD_SECRET}" > "${PROXY_SECRET_FILE}"
+# Drop PASSWORD_SECRET from this shell's environment before launching the proxy.
+# runuser (without --login) inherits the caller's whole environment, so an
+# operator-supplied `-e PASSWORD_SECRET=...` would otherwise land in the proxy's
+# /proc/<pid>/environ — readable by any TTYD_USER process (including terminal
+# shells) and enough to forge session/CSRF tokens. The file above (mode 400,
+# owner TTYD_USER) is the only channel; CLAUDE.md guarantees the secret "never
+# appears in the proxy's environment". PASSWORD_SECRET is unused past this point.
+unset PASSWORD_SECRET
 echo "Starting TTYD HTTP proxy on port ${PORT} as ${TTYD_USER}"
 PORT="${PORT}" \
 TTYD_USER="${TTYD_USER}" \

--- a/tests/unit/test_config_timeouts.py
+++ b/tests/unit/test_config_timeouts.py
@@ -24,7 +24,7 @@ class TestConfigTimeoutFloor(unittest.TestCase):
         # Restore module to a pristine (env-free) state for other tests.
         config = importlib.import_module("ttydproxy.config")
         with patch.dict(os.environ, {}, clear=False):
-            for key in ("SESSION_TIMEOUT", "CSRF_TOKEN_TTL"):
+            for key in ("SESSION_TIMEOUT", "CSRF_TOKEN_TTL", "REQUEST_TIMEOUT"):
                 os.environ.pop(key, None)
             importlib.reload(config)
 
@@ -44,6 +44,39 @@ class TestConfigTimeoutFloor(unittest.TestCase):
         )
         self.assertEqual(config.SESSION_TIMEOUT, 3600)
         self.assertEqual(config.CSRF_TOKEN_TTL, 7200)
+
+
+class TestRequestTimeout(unittest.TestCase):
+    """Slowloris guard: the per-connection read timeout must be set + fail-closed."""
+
+    def _reload_config_with(self, **env):
+        with patch.dict(os.environ, env, clear=False):
+            config = importlib.import_module("ttydproxy.config")
+            return importlib.reload(config)
+
+    def tearDown(self):
+        config = importlib.import_module("ttydproxy.config")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("REQUEST_TIMEOUT", None)
+            importlib.reload(config)
+
+    def test_default_request_timeout_is_positive(self):
+        config = self._reload_config_with()
+        self.assertEqual(config.REQUEST_TIMEOUT, 30)
+
+    def test_zero_request_timeout_clamps_to_minimum(self):
+        # 0 would mean "block forever" — the very slowloris condition the timeout
+        # exists to prevent. A non-positive value must clamp up, not disable it.
+        config = self._reload_config_with(REQUEST_TIMEOUT="0")
+        self.assertEqual(config.REQUEST_TIMEOUT, 1)
+
+    def test_handler_applies_the_timeout(self):
+        # BaseHTTPRequestHandler.setup() calls connection.settimeout(self.timeout);
+        # the proxy handler must carry a positive class-level timeout so slow
+        # clients cannot pin a ThreadingHTTPServer worker forever (#101/#2).
+        from ttydproxy import app
+        self.assertIsNotNone(app.TTYDProxyHandler.timeout)
+        self.assertGreater(app.TTYDProxyHandler.timeout, 0)
 
 
 class TestSessionTokenSurvivesFlooredTimeout(unittest.TestCase):

--- a/tests/unit/test_config_timeouts.py
+++ b/tests/unit/test_config_timeouts.py
@@ -74,9 +74,12 @@ class TestRequestTimeout(unittest.TestCase):
         # BaseHTTPRequestHandler.setup() calls connection.settimeout(self.timeout);
         # the proxy handler must carry a positive class-level timeout so slow
         # clients cannot pin a ThreadingHTTPServer worker forever (#101/#2).
-        from ttydproxy import app
+        # Assert it is wired to the config value (not merely positive) so a
+        # regression that hard-codes or drops the wiring is caught.
+        from ttydproxy import app, config
         self.assertIsNotNone(app.TTYDProxyHandler.timeout)
         self.assertGreater(app.TTYDProxyHandler.timeout, 0)
+        self.assertEqual(app.TTYDProxyHandler.timeout, config.REQUEST_TIMEOUT)
 
 
 class TestSessionTokenSurvivesFlooredTimeout(unittest.TestCase):

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -76,6 +76,25 @@ class TestEntrypointRegressions(unittest.TestCase):
             re.compile(r'^PASSWORD_SECRET="\$\{PASSWORD_SECRET\}"', re.MULTILINE),
         )
 
+    def test_password_secret_unset_before_proxy_launch(self):
+        # runuser (no --login) inherits the caller's whole environment, so an
+        # operator-supplied `-e PASSWORD_SECRET=...` would land in the proxy's
+        # /proc/<pid>/environ unless the entrypoint drops it first. The secret
+        # must be unset AFTER it is written to the file and BEFORE the proxy is
+        # launched, so the file (mode 400) is the only channel (#101/#1).
+        unset_pos = self.text.find("unset PASSWORD_SECRET")
+        secret_file_write_pos = self.text.find('> "${PROXY_SECRET_FILE}"')
+        proxy_pos = self.text.find('runuser -u "${TTYD_USER}" -- python3')
+        self.assertGreater(unset_pos, -1, "PASSWORD_SECRET is never unset")
+        self.assertGreater(
+            unset_pos, secret_file_write_pos,
+            "PASSWORD_SECRET must be unset only after it is written to the file",
+        )
+        self.assertLess(
+            unset_pos, proxy_pos,
+            "PASSWORD_SECRET must be unset before the proxy is launched",
+        )
+
     def test_proxy_started_as_ttyd_user(self):
         # The proxy must drop root (issue #52): launched via runuser, with the
         # secret file owned by TTYD_USER so the unprivileged proxy can read it.


### PR DESCRIPTION
## Summary

Two P0 unauthenticated-security fixes from the multi-agent code review in #101.

- **#1 — `PASSWORD_SECRET` leaked into the proxy's environment** (`entrypoint.sh`). `runuser` (without `--login`) inherits the caller's whole environment, so an operator-supplied `-e PASSWORD_SECRET=...` landed in the proxy's `/proc/<pid>/environ` — readable by any `TTYD_USER` process (including terminal shells) and enough to forge session/CSRF tokens. `unset PASSWORD_SECRET` after writing the secret file and before launching the proxy makes the mode-400 file the only channel, as CLAUDE.md guarantees.
- **#2 — slowloris DoS: no socket read timeout** (`app/ttydproxy`). `BaseHTTPRequestHandler` had no read timeout, so a slow client pinned a `ThreadingHTTPServer` worker forever (the login rate-limiter only fires *after* the slow window). Added a config-driven `REQUEST_TIMEOUT` (default 30s, min 1) applied as the handler's `timeout` class attribute.

## #101 findings closed

- #1 (PASSWORD_SECRET in proxy env) — security, CONFIRMED
- #2 (slowloris DoS) — security, CONFIRMED

## New/changed env vars

- `REQUEST_TIMEOUT` — per-connection socket read timeout in seconds (default 30, min 1). Read in `config.py`, validated via `env_int`. Documented in `.env.example` by PR-B (which owns that file in this split).

Note: finding #2 targets `app/server.py` in the review, but the fix lives in `config.py` + `app.py` (the handler subclass carries the `timeout` attribute) so the value stays env-configurable and validated, rather than editing the stdlib-only `server.py`.

## Ports / volumes

No changes.

## Tests

New: `test_password_secret_unset_before_proxy_launch` (ordering assertion in `test_shell_scripts.py`), `REQUEST_TIMEOUT` config + handler-attribute tests in `test_config_timeouts.py`. Full `pytest tests/` green; `bash -n entrypoint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgvJhzd8gEhXVE4MVu18nn
