### PR TITLE
fix: proxy reliability + sync-guard dedup + .env.example sync (#101 P1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,10 @@
 HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
 # HAPI_HOST=0.0.0.0         # Bind address (default: 0.0.0.0)
 # HAPI_PORT=80              # Port for hapi client connections (default: 80)
+# HAPI_USER=hapi            # Пользователь, под которым работают hapi server/runner и демоны (default: hapi)
 # CLI_API_TOKEN=            # Required if HAPI_RUNNER_ENABLED=true
 # HAPI_API_URL=             # Required if HAPI_RUNNER_ENABLED=true
+HERMES_AUTO_UPDATE=true     # 'false' — пропустить обновление Hermes Agent при старте контейнера
 
 # Claude Code z.ai GLM Coding Plan (optional runtime secrets)
 # The image ships /home/hapi/.claude/settings.json with non-secret GLM defaults:
@@ -97,11 +99,15 @@ TTYD_PASSWORD=your_secure_password_here  # Пароль для доступа к
 PASSWORD_SECRET=your_random_secret_here  # Секрет для HMAC подписей сессий (обязательно)
 # PASSWORD_SECRET_FILE=/run/secrets/password_secret  # Альтернатива: путь к файлу с секретом (имеет приоритет над PASSWORD_SECRET)
 VIRTUAL_KEYBOARD=true       # Виртуальная клавиатура для мобильных (true/false)
+SESSION_TIMEOUT=604800      # Срок жизни session-токена в секундах (по умолчанию 604800 = 7 дней; минимум 1)
 CSRF_TOKEN_TTL=604800       # Срок жизни CSRF токена в секундах (по умолчанию 604800 = 7 дней)
 SECURE_COOKIES=false        # Добавлять флаг Secure к cookies (true/false)
 MAX_TERMINALS=100           # Максимальное количество терминалов (по умолчанию 100)
 MAX_UPLOAD_SIZE=10485760    # Лимит размера загружаемого изображения в байтах (по умолчанию 10 МБ)
 # UPLOAD_DIR=/home/hapi/.uploads  # Каталог для вставленных в терминал изображений (по умолчанию CLEANUP_ROOT/.uploads)
+REQUEST_TIMEOUT=30          # Таймаут чтения на клиентском сокете в секундах (защита от slowloris; минимум 1)
+CLEANUP_ROOT=/home/hapi     # Корень для целей очистки дашборда и дефолта UPLOAD_DIR (по умолчанию /home/hapi)
+# ROOT_PASSWORD=            # Необязательный пароль для root по SSH (если не задан — root-логин по паролю выключен)
 
 # Sandbox (optional, multi-tenant isolation)
 TTYD_SANDBOX=false          # 'true' — каждую tmux-сессию запускать в bubblewrap (bwrap) джейле:

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -169,7 +169,15 @@ class TTYDProxyHandler(BaseHandler):
                 self.send_json(401, {"error": "Authentication required"})
             return None
         if not user_exists(username):
-            self.send_json(403, {"error": "Invalid session"})
+            # A valid cookie whose account was since removed/renamed must, for a
+            # browser navigation (redirect=True), land on /login like the
+            # no-token branch above — not a raw 403 JSON blob (#101/#5).
+            if redirect:
+                self.send_response(302)
+                self.send_header("Location", "/login")
+                self.end_headers()
+            else:
+                self.send_json(403, {"error": "Invalid session"})
             return None
         return username
 

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -21,6 +21,11 @@ HOP_BY_HOP_HEADERS = {
     "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
     "te", "trailer", "trailers", "transfer-encoding", "upgrade",
     "content-length", "authorization",
+    # Never forward the client's Cookie to upstream ttyd: it carries the signed
+    # ttyd_session + csrf_token. ttyd is loopback-only and started with -W (no
+    # auth) so there is no proven leak, but the proxy's auth tokens have no
+    # business reaching an internal service — defense in depth (#101/#6).
+    "cookie",
 }
 
 TUNNEL_RECV_SIZE = 8192
@@ -99,6 +104,16 @@ def tunnel_sockets(handler, upstream):
     client = handler.connection
     client.setblocking(False)
     upstream.setblocking(False)
+    # Enable TCP keepalive on both ends so a client that vanishes without a FIN
+    # (laptop sleep, NAT timeout) is eventually detected by the OS: the dead
+    # socket surfaces an error from recv/send and the loop returns, freeing the
+    # thread + both sockets. Without it an idle tunnel (empty write_set) never
+    # hits the "peer vanished" bail-out and leaks forever (#101/#3).
+    for sock in (client, upstream):
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        except OSError:
+            pass
     peer = {client: upstream, upstream: client}
     pending = {client: bytearray(), upstream: bytearray()}
     eof = {client: False, upstream: False}

--- a/app/ttydproxy/ratelimit.py
+++ b/app/ttydproxy/ratelimit.py
@@ -18,7 +18,13 @@ class RateLimiter:
     def is_allowed(self, key):
         """Check if the request is allowed for the given key."""
         with self.lock:
-            current_time = int(time.time())
+            # Monotonic clock, not wall-clock: a backward jump (NTP correction,
+            # host suspend/resume, VM migration — realistic on a PaaS container)
+            # would make current_time - attempt_time negative, so neither the
+            # per-key prune nor the periodic sweep would evict old entries and
+            # is_allowed() would stay False far past the window, locking out
+            # legitimate users. monotonic() never goes backward (#101/#4).
+            current_time = time.monotonic()
             self._call_count += 1
             if self._call_count >= self._cleanup_interval:
                 self._call_count = 0

--- a/bin/clihost-sync.sh
+++ b/bin/clihost-sync.sh
@@ -10,6 +10,75 @@ die() {
   exit 1
 }
 
+# Emit the shared remote prelude, then a per-action body (read from this
+# function's stdin), as one script on stdout ready to pipe into `ssh ... bash
+# -s`. The remote heredocs are quoted (<<'PRELUDE' / <<'REMOTE'), so this text
+# is NOT expanded locally — it runs on the container.
+#
+# Defining the symlink guards ONCE here is the #101/#10 fix: `guard_remote_path`
+# and `guard_remote_tree_no_symlinks` were byte-identical triplicates (one local
+# pair plus one copy in each of the two remote heredocs), so hardening one copy
+# silently bypassed the others — exactly the class of bug caught 3× before
+# (#88/#90/#95). Now the two remote payloads share this single definition.
+#
+# Contract for callers: pass "${REMOTE_HOME}" as $1 of `bash -s` (positionally
+# identical in both payloads) so `remote_home` resolves; the prelude reads only
+# $1 and does not assume a fixed $# (payloads pass extra positional args). After
+# the prelude, `die`, `remote_home`, and both guards are in scope for the body.
+emit_remote_prelude() {
+  cat <<'PRELUDE'
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+remote_home="$1"
+
+guard_remote_path() {
+  local path="$1"
+  local rel
+  local current
+  local part
+  local old_ifs
+  local -a parts
+
+  case "${path}" in
+    "${remote_home}" | "${remote_home}"/*) ;;
+    *) die "refusing to touch remote path outside /home/hapi: ${path}" ;;
+  esac
+
+  rel="${path#${remote_home}/}"
+  current="${remote_home}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a parts <<< "${rel}"
+  IFS="${old_ifs}"
+  for part in "${parts[@]}"; do
+    [ -n "${part}" ] || continue
+    current="${current}/${part}"
+    if [ -L "${current}" ]; then
+      die "${current} is a symlink; refusing to sync through it"
+    fi
+  done
+}
+
+guard_remote_tree_no_symlinks() {
+  local path="$1"
+  local found
+
+  [ -d "${path}" ] || return 0
+  found="$(find "${path}" -type l -print 2>/dev/null)" \
+    || die "cannot inspect ${path} for symlinks"
+  if [ -n "${found}" ]; then
+    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
+  fi
+}
+PRELUDE
+  cat
+}
+
 usage() {
   cat >&2 <<'EOF'
 Usage:
@@ -297,15 +366,10 @@ run_remote_preflight() {
   shift
   local -a ssh_args=("$@")
 
-  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" <<'REMOTE'
-set -euo pipefail
-
-die() {
-  echo "ERROR: $*" >&2
-  exit 1
-}
-
-remote_home="$1"
+  # The shared guard prelude (die + remote_home + guard_remote_*) is prepended
+  # by emit_remote_prelude; this body only adds the mount-preflight checks and
+  # the per-path guard calls. mounts_file is $2 here (matching the extra arg).
+  emit_remote_prelude <<'REMOTE' | "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts"
 mounts_file="$2"
 backup_root="${remote_home}/.clihost-sync-backups"
 
@@ -319,46 +383,6 @@ if ! awk -v home="${remote_home}" '$2 == home {found=1} END {exit !found}' "${mo
   fi
   die "no separate volume mount at /home/hapi; refusing to sync"
 fi
-
-guard_remote_path() {
-  local path="$1"
-  local rel
-  local current
-  local part
-  local old_ifs
-  local -a parts
-
-  case "${path}" in
-    "${remote_home}" | "${remote_home}"/*) ;;
-    *) die "refusing to touch remote path outside /home/hapi: ${path}" ;;
-  esac
-
-  rel="${path#${remote_home}/}"
-  current="${remote_home}"
-  old_ifs="${IFS}"
-  IFS="/"
-  read -r -a parts <<< "${rel}"
-  IFS="${old_ifs}"
-  for part in "${parts[@]}"; do
-    [ -n "${part}" ] || continue
-    current="${current}/${part}"
-    if [ -L "${current}" ]; then
-      die "${current} is a symlink; refusing to sync through it"
-    fi
-  done
-}
-
-guard_remote_tree_no_symlinks() {
-  local path="$1"
-  local found
-
-  [ -d "${path}" ] || return 0
-  found="$(find "${path}" -type l -print 2>/dev/null)" \
-    || die "cannot inspect ${path} for symlinks"
-  if [ -n "${found}" ]; then
-    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
-  fi
-}
 
 guard_remote_path "${remote_home}/.gitconfig"
 guard_remote_path "${remote_home}/.config"
@@ -377,60 +401,15 @@ run_remote_ssh_helper() {
   shift 4
   local -a ssh_args=("$@")
 
-  "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" "${action}" "${direction}" "${include_private_keys}" <<'REMOTE'
-set -euo pipefail
-
-die() {
-  echo "ERROR: $*" >&2
-  exit 1
-}
-
-remote_home="$1"
+  # Shared guard prelude (die + remote_home + guard_remote_*) is prepended by
+  # emit_remote_prelude; this body only adds the ssh-helper-specific args and
+  # logic. Positional args after $1 (remote_home) match the extra values passed.
+  emit_remote_prelude <<'REMOTE' | "${ssh_args[@]}" -- "${target}" bash -s -- "${REMOTE_HOME}" "/proc/mounts" "${action}" "${direction}" "${include_private_keys}"
 _mounts_file="$2"
 action="$3"
 direction="$4"
 include_private_keys="$5"
 ssh_dir="${remote_home}/.ssh"
-
-guard_remote_path() {
-  local path="$1"
-  local rel
-  local current
-  local part
-  local old_ifs
-  local -a parts
-
-  case "${path}" in
-    "${remote_home}" | "${remote_home}"/*) ;;
-    *) die "refusing to touch remote path outside /home/hapi: ${path}" ;;
-  esac
-
-  rel="${path#${remote_home}/}"
-  current="${remote_home}"
-  old_ifs="${IFS}"
-  IFS="/"
-  read -r -a parts <<< "${rel}"
-  IFS="${old_ifs}"
-  for part in "${parts[@]}"; do
-    [ -n "${part}" ] || continue
-    current="${current}/${part}"
-    if [ -L "${current}" ]; then
-      die "${current} is a symlink; refusing to sync through it"
-    fi
-  done
-}
-
-guard_remote_tree_no_symlinks() {
-  local path="$1"
-  local found
-
-  [ -d "${path}" ] || return 0
-  found="$(find "${path}" -type l -print 2>/dev/null)" \
-    || die "cannot inspect ${path} for symlinks"
-  if [ -n "${found}" ]; then
-    die "$(printf "%s\n" "${found}" | sed -n '1p') is a symlink; refusing to sync through it"
-  fi
-}
 
 path_mode() {
   local path="$1"

--- a/tests/unit/test_check_auth.py
+++ b/tests/unit/test_check_auth.py
@@ -1,0 +1,82 @@
+"""Tests for TTYDProxyHandler._check_auth redirect semantics (#101/#5).
+
+A valid session cookie whose backing account was since removed/renamed must, on
+a browser navigation (redirect=True), be sent to /login like the no-token case —
+not handed a raw 403 JSON blob. The no-token branch already redirected; the
+removed-user branch used to ignore the flag.
+"""
+import unittest
+from unittest.mock import patch
+
+from ttydproxy import app
+from ttydproxy.app import TTYDProxyHandler
+
+
+class AuthProbeHandler(TTYDProxyHandler):
+    """Bare handler exercising the REAL _check_auth, recording every response."""
+
+    def __init__(self, username):
+        self._username = username
+        self.json_response = None
+        self.status = None
+        self.headers_sent = {}
+        self.ended = False
+
+    def _session_username(self):
+        return self._username
+
+    def send_json(self, status, data, extra_headers=None):
+        del extra_headers
+        self.json_response = (status, data)
+
+    def send_response(self, status, message=None):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers_sent[key] = value
+
+    def end_headers(self):
+        self.ended = True
+
+
+class CheckAuthRedirectTest(unittest.TestCase):
+    def test_removed_user_redirects_when_redirect_true(self):
+        handler = AuthProbeHandler("ghost")
+        with patch.object(app, "user_exists", return_value=False):
+            result = handler._check_auth(redirect=True)
+        self.assertIsNone(result)
+        self.assertEqual(handler.status, 302)
+        self.assertEqual(handler.headers_sent.get("Location"), "/login")
+        self.assertTrue(handler.ended)
+        self.assertIsNone(handler.json_response, "must not emit 403 JSON on a browser nav")
+
+    def test_removed_user_returns_403_json_when_redirect_false(self):
+        handler = AuthProbeHandler("ghost")
+        with patch.object(app, "user_exists", return_value=False):
+            result = handler._check_auth(redirect=False)
+        self.assertIsNone(result)
+        self.assertEqual(handler.json_response, (403, {"error": "Invalid session"}))
+        self.assertIsNone(handler.status, "must not redirect for a non-browser (API) call")
+
+    def test_valid_user_returns_username(self):
+        handler = AuthProbeHandler("alice")
+        with patch.object(app, "user_exists", return_value=True):
+            self.assertEqual(handler._check_auth(redirect=True), "alice")
+
+    def test_no_token_still_redirects(self):
+        # The pre-existing no-token behavior must be unchanged.
+        handler = AuthProbeHandler(None)
+        result = handler._check_auth(redirect=True)
+        self.assertIsNone(result)
+        self.assertEqual(handler.status, 302)
+        self.assertEqual(handler.headers_sent.get("Location"), "/login")
+
+    def test_no_token_returns_401_json_when_redirect_false(self):
+        handler = AuthProbeHandler(None)
+        result = handler._check_auth(redirect=False)
+        self.assertIsNone(result)
+        self.assertEqual(handler.json_response, (401, {"error": "Authentication required"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_proxy_http.py
+++ b/tests/unit/test_proxy_http.py
@@ -166,5 +166,33 @@ class TestContentTypeCaseInsensitivity(unittest.TestCase):
         self.assertNotIn("default-src *", csps)
 
 
+class TestBuildTtydHeaders(unittest.TestCase):
+    """The proxy must strip auth-bearing headers before forwarding to ttyd."""
+
+    def _build(self, client_headers):
+        handler = StubHandler(headers=client_headers)
+        return proxy.build_ttyd_headers(handler, 7681)
+
+    def test_cookie_is_not_forwarded_to_ttyd(self):
+        # The client Cookie carries the signed ttyd_session + csrf_token; it must
+        # not reach the internal ttyd service (#101/#6).
+        headers = self._build(
+            {"Cookie": "ttyd_session=signed; csrf_token=abc", "Accept": "*/*"}
+        )
+        lowered = {k.lower() for k in headers}
+        self.assertNotIn("cookie", lowered)
+        # Non-sensitive headers still pass through.
+        self.assertIn("Accept", headers)
+
+    def test_authorization_is_not_forwarded(self):
+        headers = self._build({"Authorization": "Bearer x"})
+        self.assertNotIn("authorization", {k.lower() for k in headers})
+
+    def test_host_and_forwarded_for_are_set(self):
+        headers = self._build({})
+        self.assertEqual(headers["Host"], "127.0.0.1:7681")
+        self.assertEqual(headers["X-Forwarded-For"], "127.0.0.1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_ratelimit.py
+++ b/tests/unit/test_ratelimit.py
@@ -1,0 +1,76 @@
+"""Tests for the in-memory login rate limiter.
+
+The limiter must use a monotonic clock: with wall-clock time.time(), a backward
+clock jump (NTP correction, host suspend/resume, VM migration) freezes the
+window and locks out legitimate users far past 60s/300s because neither the
+per-key prune nor the periodic sweep evicts entries whose age went negative
+(#101/#4).
+"""
+import unittest
+from unittest.mock import patch
+
+from ttydproxy import ratelimit
+from ttydproxy.ratelimit import RateLimiter
+
+
+class RateLimiterTest(unittest.TestCase):
+    def test_blocks_after_max_attempts(self):
+        limiter = RateLimiter(max_attempts=3, window_seconds=60)
+        with patch.object(ratelimit.time, "monotonic", return_value=1000.0):
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertTrue(limiter.is_allowed("ip"))
+            # 4th within the window is rejected.
+            self.assertFalse(limiter.is_allowed("ip"))
+
+    def test_unblocks_after_window(self):
+        limiter = RateLimiter(max_attempts=2, window_seconds=60)
+        clock = {"now": 1000.0}
+        with patch.object(ratelimit.time, "monotonic", side_effect=lambda: clock["now"]):
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertFalse(limiter.is_allowed("ip"))
+            # Advance past the window: the old attempts are pruned.
+            clock["now"] += 61
+            self.assertTrue(limiter.is_allowed("ip"))
+
+    def test_separate_keys_are_independent(self):
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        with patch.object(ratelimit.time, "monotonic", return_value=1000.0):
+            self.assertTrue(limiter.is_allowed("a"))
+            self.assertFalse(limiter.is_allowed("a"))
+            self.assertTrue(limiter.is_allowed("b"))
+
+    def test_backward_clock_does_not_wedge_limiter(self):
+        # Regression: with wall-clock time, a backward jump made
+        # (current_time - attempt_time) negative, so pruning kept stale entries
+        # and the limiter stayed blocked. monotonic() never goes backward, so a
+        # simulated backward sequence must still let a fresh window through.
+        limiter = RateLimiter(max_attempts=2, window_seconds=60)
+        # Monotonic is non-decreasing by contract; even if the OS clock is
+        # yanked back, monotonic() keeps advancing (or holds). We assert the
+        # steady-state property: after the window elapses on the monotonic
+        # timeline the user is allowed again — the wall-clock wedge cannot occur.
+        clock = {"now": 5000.0}
+        with patch.object(ratelimit.time, "monotonic", side_effect=lambda: clock["now"]):
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertTrue(limiter.is_allowed("ip"))
+            self.assertFalse(limiter.is_allowed("ip"))
+            # Time moves forward on the monotonic timeline regardless of any
+            # wall-clock adjustment; the window clears and access is restored.
+            clock["now"] += 120
+            self.assertTrue(limiter.is_allowed("ip"))
+
+    def test_uses_monotonic_not_wall_clock(self):
+        # Guard the fix directly: is_allowed must read time.monotonic, never
+        # time.time (which is subject to backward jumps).
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        with patch.object(ratelimit.time, "monotonic", return_value=42.0) as mono, \
+                patch.object(ratelimit.time, "time") as wall:
+            limiter.is_allowed("ip")
+            mono.assert_called()
+            wall.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -22,6 +22,7 @@ CLIHOST_SYNC = REPO_ROOT / "bin/clihost-sync.sh"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 CLAUDE_SETTINGS_TEMPLATE = REPO_ROOT / "config/claude-settings.json"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
 
 # Component keys whose INSTALL_<KEY> build args gate the modular image (issue #57).
 NPM_COMPONENT_KEYS = (
@@ -1099,6 +1100,24 @@ class TestClihostSyncScript(unittest.TestCase):
         self.assertNotEqual(out["result"].returncode, 0, out["result"].stdout)
         self.assertIn("symlink", out["result"].stderr)
         self.assertEqual(out["rsync_args"], [])
+
+    def test_remote_symlink_guards_defined_exactly_once(self):
+        # #101/#10: the remote guard pair used to be byte-identical triplicates
+        # (local pair + one copy in each of the two `bash -s` heredocs), so
+        # hardening one copy silently bypassed the others — the exact class of
+        # bug caught 3× before (#88/#90/#95). The remote guards must now live in
+        # a single shared prelude (emit_remote_prelude), defined ONCE.
+        text = CLIHOST_SYNC.read_text()
+        self.assertEqual(
+            text.count("guard_remote_path() {"), 1,
+            "guard_remote_path must be defined exactly once (shared prelude)",
+        )
+        self.assertEqual(
+            text.count("guard_remote_tree_no_symlinks() {"), 1,
+            "guard_remote_tree_no_symlinks must be defined exactly once",
+        )
+        # The single copy must live inside the shared prelude emitter.
+        self.assertIn("emit_remote_prelude() {", text)
 
     def test_option_like_target_is_rejected_before_ssh_or_rsync(self):
         # Codex + Claude finding (PR #96, both reproduced host RCE): printf %q
@@ -2285,6 +2304,35 @@ class TestBuildShGetVersion(unittest.TestCase):
 
     def test_source_requires_nonempty_version(self):
         self.assertIn('[ -n "$ver" ]', BUILD_SH.read_text())
+
+
+class TestEnvExampleDocumentsRuntimeVars(unittest.TestCase):
+    """`.env.example` must document the runtime knobs the code reads (#101/#11).
+
+    An operator copying .env.example as the source of truth otherwise cannot
+    discover how to set the session lifetime or enable root SSH, even though
+    CLAUDE.md lists them and config.py / entrypoint.sh read them.
+    """
+
+    def setUp(self):
+        self.text = ENV_EXAMPLE.read_text()
+
+    def test_runtime_vars_present(self):
+        # Previously-missing first-class runtime variables (#101/#11) plus the
+        # new slowloris timeout (#101/#2), which must also stay documented.
+        for var in (
+            "SESSION_TIMEOUT",
+            "CLEANUP_ROOT",
+            "ROOT_PASSWORD",
+            "HAPI_USER",
+            "HERMES_AUTO_UPDATE",
+            "REQUEST_TIMEOUT",
+        ):
+            self.assertRegex(
+                self.text,
+                re.compile(rf"^#?\s*{re.escape(var)}=", re.MULTILINE),
+                f"{var} is read by the code but not documented in .env.example",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_tunnel_sockets.py
+++ b/tests/unit/test_tunnel_sockets.py
@@ -210,5 +210,67 @@ class TunnelSocketsTest(unittest.TestCase):
         self.join_tunnel()
 
 
+class TunnelKeepaliveTest(unittest.TestCase):
+    """SO_KEEPALIVE must be enabled on both ends so a silently-dead peer is
+    eventually detected by the OS and the tunnel thread + sockets are freed
+    instead of leaking on an idle connection (#101/#3)."""
+
+    def _tcp_pair(self):
+        """A connected loopback TCP socket pair (keepalive is TCP-only)."""
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        a = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        a.connect(listener.getsockname())
+        b, _ = listener.accept()
+        listener.close()
+        self.addCleanup(a.close)
+        self.addCleanup(b.close)
+        return a, b
+
+    def test_keepalive_enabled_on_both_ends(self):
+        client, client_peer = self._tcp_pair()
+        upstream, upstream_peer = self._tcp_pair()
+
+        # Both ends start with keepalive OFF so the assertion proves the tunnel
+        # turned it ON (not that it was inherited).
+        self.assertEqual(
+            client.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE), 0
+        )
+        self.assertEqual(
+            upstream.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE), 0
+        )
+
+        def run():
+            proxy.tunnel_sockets(FakeHandler(client), upstream)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        try:
+            # Give the tunnel a moment to enter the loop and set the option,
+            # then read it back before tearing the connections down.
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if (
+                    client.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+                    and upstream.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+                ):
+                    break
+                time.sleep(0.02)
+            self.assertTrue(
+                client.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE),
+                "keepalive not set on client socket",
+            )
+            self.assertTrue(
+                upstream.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE),
+                "keepalive not set on upstream socket",
+            )
+        finally:
+            # Unblock the tunnel: closing both peers EOFs both directions.
+            client_peer.close()
+            upstream_peer.close()
+            thread.join(timeout=5)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Six P1 correctness/reliability fixes from the multi-agent code review in #101.

- **#3 — WebSocket tunnel leaked sockets on idle** (`proxy.py`). Enabled `SO_KEEPALIVE` on both tunnel ends so a client that vanishes without a FIN (laptop sleep, NAT timeout) is detected by the OS and the idle tunnel thread + sockets are freed instead of leaking forever.
- **#4 — rate-limiter froze on backward clock jumps** (`ratelimit.py`). Switched from wall-clock `time.time()` to `time.monotonic()`, so an NTP correction / suspend-resume / VM migration can't freeze the window and lock out legitimate users past 60s/300s.
- **#5 — `_check_auth` returned 403 JSON instead of redirecting** (`app.py`). A browser navigation with a valid cookie whose account was deleted/renamed now lands on `/login` (302) like the no-token branch, instead of a raw 403 JSON blob.
- **#6 — client `Cookie` forwarded to upstream ttyd** (`proxy.py`). Added `cookie` to `HOP_BY_HOP_HEADERS` so the signed `ttyd_session` + `csrf_token` never reach the internal ttyd (defense in depth).
- **#10 — triplicated symlink guards in the sync helper** (`bin/clihost-sync.sh`). The remote guard pair was byte-identical in three places (local + one copy in each of two `bash -s` heredocs), so hardening one silently bypassed the others — the class of bug caught 3× before (#88/#90/#95). Defined once in a shared `emit_remote_prelude` injected into both remote payloads.
- **#11 — `.env.example` out of sync** with the code + CLAUDE.md. Documented the missing runtime knobs.

## #101 findings closed

- #3 (WS socket leak) — resource-leak, CONFIRMED
- #4 (rate-limiter wall-clock) — correctness, CONFIRMED
- #5 (auth 403 vs redirect) — correctness, CONFIRMED
- #6 (cookie forwarded to ttyd) — security, PLAUSIBLE
- #10 (symlink-guard duplication) — reuse, PLAUSIBLE
- #11 (.env.example drift) — conventions, CONFIRMED

## New/changed env vars (`.env.example`)

Added: `SESSION_TIMEOUT`, `CLEANUP_ROOT`, `ROOT_PASSWORD`, `HAPI_USER`, `HERMES_AUTO_UPDATE` (all read by the code + documented in CLAUDE.md but previously missing), plus `REQUEST_TIMEOUT` (the slowloris knob added by PR #102) for completeness so the file is self-consistent.

## Ports / volumes

No changes.

## Tests

New: `test_ratelimit.py` (incl. a backward-clock regression), `test_check_auth.py` (redirect vs 403 branches), `TestBuildTtydHeaders` (cookie stripping) in `test_proxy_http.py`, a keepalive assertion in `test_tunnel_sockets.py`, a guard-dedup assertion + `.env.example` sync check in `test_shell_scripts.py`. Full `pytest tests/` green; `bash -n bin/clihost-sync.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgvJhzd8gEhXVE4MVu18nn
