### PR TITLE
refactor: ttyd reaper, argv daemon launch, url dedup, keep-alive, retries (#101 P2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN NODE_VERSION="22.14.0" && \
     fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends bubblewrap ca-certificates curl gh git openssh-server python3-pip python3-venv rsync tini tmux util-linux xz-utils && \
-    curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+    { for i in 1 2 3 4 5; do curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && break || sleep 10; done } && \
     tar -xJf "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -C /usr/local --strip-components=1 --no-same-owner && \
     rm "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
     ln -sf /usr/local/bin/node /usr/local/bin/nodejs && \
@@ -56,8 +56,7 @@ RUN TTYD_VERSION="1.7.7" && \
     TTYD_ARCH="$(dpkg --print-architecture | sed -e 's/armhf/arm/' -e 's/amd64/x86_64/')" && \
     if [ "$TTYD_ARCH" = "arm64" ]; then TTYD_ARCH="aarch64"; fi && \
     echo "Installing ttyd for architecture: $TTYD_ARCH" && \
-    curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" \
-    -o /usr/local/bin/ttyd && \
+    { for i in 1 2 3 4 5; do curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" -o /usr/local/bin/ttyd && break || sleep 10; done } && \
     chmod +x /usr/local/bin/ttyd
 
 # Install SSH-tunnel providers (issue #79): cloudflared (default) + chisel.
@@ -76,8 +75,7 @@ RUN TUNNEL_ARCH="$(dpkg --print-architecture)" && \
       true) \
         CLOUDFLARED_VERSION="2026.6.1" && \
         echo "Installing cloudflared ${CLOUDFLARED_VERSION} for ${TUNNEL_ARCH}" && \
-        curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${TUNNEL_ARCH}" \
-          -o /usr/local/bin/cloudflared && \
+        { for i in 1 2 3 4 5; do curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${TUNNEL_ARCH}" -o /usr/local/bin/cloudflared && break || sleep 10; done } && \
         chmod +x /usr/local/bin/cloudflared ;; \
       *) echo "ERROR: INSTALL_CLOUDFLARED='${INSTALL_CLOUDFLARED}' is invalid; must be 'true' or 'false'" >&2; exit 1 ;; \
     esac && \
@@ -86,8 +84,7 @@ RUN TUNNEL_ARCH="$(dpkg --print-architecture)" && \
       true) \
         CHISEL_VERSION="1.11.5" && \
         echo "Installing chisel ${CHISEL_VERSION} for ${TUNNEL_ARCH}" && \
-        curl -fsSL "https://github.com/jpillora/chisel/releases/download/v${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_${TUNNEL_ARCH}.gz" \
-          -o /tmp/chisel.gz && \
+        { for i in 1 2 3 4 5; do curl -fsSL "https://github.com/jpillora/chisel/releases/download/v${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_${TUNNEL_ARCH}.gz" -o /tmp/chisel.gz && break || sleep 10; done } && \
         gunzip -c /tmp/chisel.gz > /usr/local/bin/chisel && \
         rm -f /tmp/chisel.gz && \
         chmod +x /usr/local/bin/chisel ;; \
@@ -177,7 +174,7 @@ ARG TARGETARCH
 RUN git init -q /src && \
     cd /src && \
     git remote add origin "${AO_REPO}" && \
-    git fetch --depth 1 origin "${AO_REF}" && \
+    { for i in 1 2 3 4 5; do git fetch --depth 1 origin "${AO_REF}" && break || sleep 10; done } && \
     git checkout -q FETCH_HEAD && \
     cd /src/backend && \
     GOARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
@@ -245,9 +242,9 @@ RUN case "${INSTALL_HERMES}" in \
       false) \
         echo "Skipping Hermes Agent (INSTALL_HERMES=false)" ;; \
       true) \
-        git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && \
+        { for i in 1 2 3 4 5; do git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-agent && break || { rm -rf /tmp/hermes-agent; sleep 10; }; done } && \
         cd /tmp/hermes-agent && \
-        pip install --break-system-packages '.[all,messaging]' && \
+        { for i in 1 2 3 4 5; do pip install --break-system-packages '.[all,messaging]' && break || sleep 10; done } && \
         which hermes && \
         rm -rf /tmp/hermes-agent ;; \
       *) \

--- a/app/assets/tab_fix_script.html
+++ b/app/assets/tab_fix_script.html
@@ -141,6 +141,13 @@
   // path so it keeps working on mobile, where the parent receives the event and
   // the iOS gesture exposes an empty getData('text/plain') (regression #66).
   window.__handleImageTransfer = handleImageTransfer;
+  // Shared helpers exported so the parent page and the virtual keyboard delegate
+  // here instead of keeping their own copies (#101/#14): containsFiles had two
+  // byte-identical definitions and the socket-discovery + '0' ttyd-protocol
+  // prefix were hard-coded in three places, so a protocol/quirk change silently
+  // diverged. sendToTTYD owns the '0' INPUT prefix — the single place to change.
+  window.__containsFiles = containsFiles;
+  window.__sendToTTYD = sendToTTYD;
 
   document.addEventListener('paste', function(e) {
     // Only images are consumed on the iframe paste path: pasted text stays

--- a/app/assets/terminal_parent_tab_handler.html
+++ b/app/assets/terminal_parent_tab_handler.html
@@ -74,9 +74,15 @@
       }
     }, true);
 
-    // Mirror the iframe's file-detection so a non-image file drop is blocked
-    // from navigating the page, without duplicating the triage.
+    // Delegate file-detection to the iframe's exported helper (#101/#14) so the
+    // triage logic lives in one place (tab_fix_script.html). A local fallback
+    // covers the brief window before the iframe script has run; keeping it
+    // behaviourally identical is fine because it is the same tiny check.
     function containsFiles(source) {
+      try {
+        var win = iframe && iframe.contentWindow;
+        if (win && win.__containsFiles) return win.__containsFiles(source);
+      } catch (e) {}
       if (!source) return false;
       if (source.files && source.files.length) return true;
       var items = source.items;

--- a/app/assets/virtual_keyboard.html
+++ b/app/assets/virtual_keyboard.html
@@ -52,10 +52,10 @@
           win.term.paste(text);
           return true;
         }
-        var socket = win && (win._ttydSocket || win.socket || win.ws);
-        if (socket && socket.readyState === 1) {
-          socket.send('0' + text);
-          return true;
+        // Fall back to the iframe's shared sender (owns socket discovery + the
+        // '0' ttyd INPUT prefix) instead of an inline copy (#101/#14).
+        if (win && win.__sendToTTYD) {
+          return win.__sendToTTYD(text);
         }
       } catch (e) {}
       return false;
@@ -94,33 +94,31 @@
 
       try {
         var win = iframe.contentWindow;
-        var socket = win && (win._ttydSocket || win.socket || win.ws);
-        if (socket && socket.readyState === 1) {
-          var data = null;
-          var ESC = String.fromCharCode(27);
-          switch (key) {
-            case 'esc': data = ESC; break;
-            case 'ctrl-c': data = String.fromCharCode(3); break;
-            case 'ctrl-b': data = String.fromCharCode(2); break;
-            case 'ctrl-l': data = String.fromCharCode(12); break;
-            case 'up': data = ESC + '[A'; break;
-            case 'down': data = ESC + '[B'; break;
-            case 'right': data = ESC + '[C'; break;
-            case 'left': data = ESC + '[D'; break;
-            case '1': case '2': case '3': case '4': case '5':
-              data = key; break;
-            case 'slash': data = '/'; break;
-            case 'bang': data = '!'; break;
-            case 'backspace': data = String.fromCharCode(127); break;
-            case 'enter': data = '\r'; break;
-            // tmux prefix (Ctrl+B) + m — toggles tmux mouse mode (scroll on/off)
-            case 'scroll': data = String.fromCharCode(2) + 'm'; break;
-            case 'at': data = '@'; break;
-          }
-          if (data) {
-            socket.send('0' + data);
-            return;
-          }
+        var data = null;
+        var ESC = String.fromCharCode(27);
+        switch (key) {
+          case 'esc': data = ESC; break;
+          case 'ctrl-c': data = String.fromCharCode(3); break;
+          case 'ctrl-b': data = String.fromCharCode(2); break;
+          case 'ctrl-l': data = String.fromCharCode(12); break;
+          case 'up': data = ESC + '[A'; break;
+          case 'down': data = ESC + '[B'; break;
+          case 'right': data = ESC + '[C'; break;
+          case 'left': data = ESC + '[D'; break;
+          case '1': case '2': case '3': case '4': case '5':
+            data = key; break;
+          case 'slash': data = '/'; break;
+          case 'bang': data = '!'; break;
+          case 'backspace': data = String.fromCharCode(127); break;
+          case 'enter': data = '\r'; break;
+          // tmux prefix (Ctrl+B) + m — toggles tmux mouse mode (scroll on/off)
+          case 'scroll': data = String.fromCharCode(2) + 'm'; break;
+          case 'at': data = '@'; break;
+        }
+        // Send via the iframe's shared sender (owns socket discovery + the '0'
+        // ttyd INPUT prefix) instead of an inline socket copy (#101/#14).
+        if (data && win && win.__sendToTTYD) {
+          win.__sendToTTYD(data);
         }
       } catch (e) {}
     }

--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -482,6 +482,13 @@ class TTYDProxyHandler(BaseHandler):
         if not terminal:
             self.send_json(404, {"error": f"Terminal ttyd{terminal_id} not found"})
             return
+        # NOTE (#101/#8, deferred): the lock is released inside get_terminal(),
+        # so this `port` is not revalidated at connect time. If terminal_id is
+        # deleted and its port reused (lowest-free, see _allocate_port) before
+        # the connect below, an in-flight request could reach a different
+        # terminal's ttyd. The window is narrow (usually ECONNREFUSED->502) and
+        # not a security boundary; a proper fix (a per-terminal lease/refcount
+        # holding the port until the request completes) is tracked separately.
         port = terminal["port"]
         parsed = urlparse(self.path)
         prefix = f"/ttyd{terminal_id}"
@@ -525,6 +532,10 @@ def main():
     else:
         print("WARNING: Failed to auto-create first terminal", file=sys.stderr, flush=True)
 
+    # Background reaper: a ttyd that dies while no one lists/gets it (or polls
+    # /health) would otherwise stay a defunct zombie holding its PID slot (#7).
+    ttyd_manager.start_reaper()
+
     try:
         httpd = ThreadingHTTPServer(server_address, TTYDProxyHandler)
         httpd.daemon_threads = True
@@ -534,6 +545,7 @@ def main():
 
     def signal_handler(signum, _frame):
         print(f"Received signal {signum}, shutting down gracefully...", flush=True)
+        ttyd_manager.stop_reaper()
         with ttyd_manager.lock:
             terminal_ids = list(ttyd_manager.terminals.keys())
         for terminal_id in terminal_ids:

--- a/app/ttydproxy/manager.py
+++ b/app/ttydproxy/manager.py
@@ -26,9 +26,24 @@ class TTYDManager:
         self.ttyd_user = ttyd_user
         self.ttyd_binary = ttyd_binary
         self.tmux_wrapper = tmux_wrapper
+        # Background reaper state (#101/#7). Without it, a dead ttyd is only
+        # reaped lazily inside list_terminals()/get_terminal(); with no
+        # list/get/health traffic a defunct zombie would pin its PID slot
+        # forever. The reaper thread polls periodically as a safety net.
+        self._reaper_thread = None
+        self._reaper_stop = threading.Event()
 
     def _allocate_port(self):
-        """Find the next available port, reusing freed ports."""
+        """Find the next available port, reusing freed ports.
+
+        NOTE (#101/#8, deferred): lowest-free reuse means a just-freed port can
+        be handed to a new terminal immediately. Combined with the connect-time
+        gap in handle_ttyd_proxy (the lock is dropped before connect), an
+        in-flight request to a deleted terminal could reach the new terminal's
+        ttyd. The window is narrow and not a security boundary; the proper fix
+        (a per-terminal lease that holds the port for the request's lifetime) is
+        tracked separately.
+        """
         used_ports = {terminal["port"] for terminal in self.terminals.values()}
         max_port = self.base_port + self.max_terminals
         port = self.base_port
@@ -106,6 +121,46 @@ class TTYDManager:
             if process and process.poll() is not None:
                 dead.append((terminal_id, info))
         return dead
+
+    def reap_dead_terminals(self):
+        """Collect dead ttyd processes under the lock, then clean them up
+        outside it (tmux kill can block). Returns the number reaped. Safe to
+        call from the background reaper or any request path (#101/#7)."""
+        with self.lock:
+            dead = self._collect_dead_terminals()
+            for terminal_id, _info in dead:
+                del self.terminals[terminal_id]
+        for terminal_id, info in dead:
+            self._cleanup_terminal(
+                terminal_id, info, f"Terminal ttyd{terminal_id} died, reaped"
+            )
+        return len(dead)
+
+    def _reaper_loop(self, interval):
+        # Poll until stop() is signalled. Event.wait doubles as the sleep so a
+        # shutdown returns promptly instead of after a full interval.
+        while not self._reaper_stop.wait(interval):
+            try:
+                self.reap_dead_terminals()
+            except Exception as exc:  # never let the daemon thread die
+                print(f"Reaper error: {exc}", file=sys.stderr, flush=True)
+
+    def start_reaper(self, interval=30):
+        """Start the background reaper thread (idempotent)."""
+        if self._reaper_thread and self._reaper_thread.is_alive():
+            return
+        self._reaper_stop.clear()
+        self._reaper_thread = threading.Thread(
+            target=self._reaper_loop, args=(interval,), daemon=True, name="ttyd-reaper"
+        )
+        self._reaper_thread.start()
+
+    def stop_reaper(self):
+        """Signal the reaper thread to stop and join it briefly."""
+        self._reaper_stop.set()
+        thread = self._reaper_thread
+        if thread and thread.is_alive():
+            thread.join(timeout=5)
 
     def create_terminal(self, wait=False):
         """Spawn a new ttyd process. Returns terminal info dict, 'limit', or None."""

--- a/app/ttydproxy/proxy.py
+++ b/app/ttydproxy/proxy.py
@@ -17,7 +17,7 @@ TTYD_PROXY_HTML_CSP = (
     "style-src 'self' 'unsafe-inline'"
 )
 
-HOP_BY_HOP_HEADERS = {
+HOP_BY_HOP_HEADERS = frozenset({
     "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
     "te", "trailer", "trailers", "transfer-encoding", "upgrade",
     "content-length", "authorization",
@@ -26,7 +26,10 @@ HOP_BY_HOP_HEADERS = {
     # auth) so there is no proven leak, but the proxy's auth tokens have no
     # business reaching an internal service — defense in depth (#101/#6).
     "cookie",
-}
+})
+# Response headers to drop for an HTML response (the proxy sets its own hardened
+# CSP). Precomputed once instead of `set(HOP_BY_HOP_HEADERS)` per response (#13).
+_SKIP_RESPONSE_HEADERS_HTML = HOP_BY_HOP_HEADERS | {"content-security-policy"}
 
 TUNNEL_RECV_SIZE = 8192
 TUNNEL_MAX_PENDING = 1048576  # 1 MiB per direction before backpressure kicks in
@@ -254,35 +257,39 @@ def proxy_ttyd_http(handler, upstream_path, port):
         resp = conn.getresponse()
         data = resp.read()
 
+        # Read the upstream headers once and reuse the list (#13): the same
+        # tuples drive the content-type sniff and the header-forwarding loop.
+        resp_headers = resp.getheaders()
+
         content_type = ""
-        for key, value in resp.getheaders():
+        for key, value in resp_headers:
             if key.lower() == "content-type":
                 content_type = value
                 break
         # Normalize the value so injection + CSP hardening fire regardless of
         # upstream header casing (e.g. 'Text/HTML') (B6).
         content_type = content_type.lower()
+        is_html = "text/html" in content_type
 
-        if "text/html" in content_type and data:
+        if is_html and data:
             data = inject_tab_fix_script(data)
 
         handler.send_response(resp.status, resp.reason)
 
-        if "text/html" in content_type:
+        if is_html:
             handler.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
             handler.send_header("Pragma", "no-cache")
             handler.send_header("Expires", "0")
 
-        skip_headers = set(HOP_BY_HOP_HEADERS)
-        if "text/html" in content_type:
-            skip_headers.add("content-security-policy")
+        # Precomputed skip-sets (frozenset constants) — no per-response set() (#13).
+        skip_headers = _SKIP_RESPONSE_HEADERS_HTML if is_html else HOP_BY_HOP_HEADERS
 
-        for key, value in resp.getheaders():
+        for key, value in resp_headers:
             if key.lower() in skip_headers:
                 continue
             handler.send_header(key, value)
 
-        if "text/html" in content_type:
+        if is_html:
             handler.send_header("Content-Security-Policy", TTYD_PROXY_HTML_CSP)
 
         handler.send_header("Content-Length", str(len(data)))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,15 +173,13 @@ ensure_claude_settings() {
   chown "${HAPI_USER}:${HAPI_USER}" "${settings_file}"
 }
 
-run_as_hapi() {
-  local command="$1"
-  runuser -u "${HAPI_USER}" -- sh -c "cd \"${HAPI_USER_HOME}\" && env HOME=\"${HAPI_USER_HOME}\" PATH=\"${HAPI_RUN_PATH}\" HAPI_HOME=\"${HAPI_HOME}\" ${command}"
-}
-
-# argv-based variant of run_as_hapi: the program and its arguments are passed as
-# separate argv elements (NOT interpolated into an `sh -c` string), so values
-# containing shell metacharacters (quotes, $(), backticks, ;) can never be
-# executed as code.
+# Run a program as the hapi user, dropping root privileges. The program and its
+# arguments are passed as separate argv elements (NOT interpolated into an
+# `sh -c` string), so values containing shell metacharacters (quotes, $(),
+# backticks, ;) can never be executed as code. The former string-based
+# `run_as_hapi` (which interpolated its argument into `sh -c`) was removed in
+# favor of this argv form for droid/ao/hapi startup — a latent root-context
+# command-injection surface even though callers guarded their inputs (#101/#9).
 #
 # Secrets (tunnel token/auth) must NEVER appear in argv — not even briefly as an
 # `env NAME=VALUE` argument — because argv is world-readable via `ps` /
@@ -291,7 +289,7 @@ if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
     esac
 
     echo "Registering Droid computer '${DROID_COMPUTER_NAME}'..."
-    if ! run_as_hapi "droid computer register \"${DROID_COMPUTER_NAME}\" -y 2>&1"; then
+    if ! run_as_hapi_argv -- droid computer register "${DROID_COMPUTER_NAME}" -y 2>&1; then
       echo "ERROR: Droid computer registration failed; daemon not started" >&2
       exit 1
     fi
@@ -300,7 +298,10 @@ if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
     touch "${DROID_DAEMON_LOG}"
     chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"
     echo "Starting droid daemon --remote-access in background (logs: ${DROID_DAEMON_LOG})..."
-    run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \"${DROID_DAEMON_LOG}\"" &
+    # argv form (no `sh -c` interpolation): the log is written via a redirect
+    # instead of `| tee` (argv cannot express a pipe), matching the tunnel
+    # helpers. The dashboard reads the log file, not container stdout (#101/#9).
+    run_as_hapi_argv -- stdbuf -oL droid daemon --remote-access >>"${DROID_DAEMON_LOG}" 2>&1 &
     DROID_DAEMON_PID=$!
     echo "Droid daemon started with PID: ${DROID_DAEMON_PID}"
   else
@@ -336,7 +337,9 @@ if [ "${AO_DAEMON_ENABLED}" = "true" ]; then
     touch "${AO_DAEMON_LOG}"
     chown "${HAPI_USER}:${HAPI_USER}" "${AO_DAEMON_LOG}"
     echo "Starting ao daemon on 127.0.0.1:${AO_PORT} in background (logs: ${AO_DAEMON_LOG})..."
-    run_as_hapi "AO_PORT=\"${AO_PORT}\" stdbuf -oL ao daemon 2>&1 | tee \"${AO_DAEMON_LOG}\"" &
+    # argv form: AO_PORT is passed as an env assignment consumed by run_as_hapi_argv's
+    # `env` (not interpolated into `sh -c`), and the log via redirect not `| tee`.
+    run_as_hapi_argv -- env "AO_PORT=${AO_PORT}" stdbuf -oL ao daemon >>"${AO_DAEMON_LOG}" 2>&1 &
     AO_DAEMON_PID=$!
     echo "ao daemon started with PID: ${AO_DAEMON_PID}"
   else
@@ -498,27 +501,34 @@ if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
   touch "${HAPI_SERVER_LOG}"
   chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"
   echo "Starting hapi server --relay in background (logs: ${HAPI_SERVER_LOG})..."
-  run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay 2>&1 | tee \"${HAPI_SERVER_LOG}\"" &
+  # argv form: HAPI_RELAY_FORCE_TCP via env, log via redirect not `| tee` (#101/#9).
+  run_as_hapi_argv -- env HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay >>"${HAPI_SERVER_LOG}" 2>&1 &
   HAPI_SERVER_PID=$!
   echo "Hapi server started with PID: ${HAPI_SERVER_PID}"
 
-  # Extract tunnel URL and token, build full connection URL
-  # (HAPI_URL_FILE was set + cleared above; recreated here only on a fresh URL.)
+  # Build the legacy connection URL file by delegating to the SAME builder the
+  # dashboard uses (ttydproxy.views.build_hapi_url_from_runtime), instead of a
+  # second bash reimplementation. The two copies had already drifted — bash took
+  # the FIRST relay URL (head -1) while views took the LAST, and bash left the
+  # token un-encoded while views quote()s it — so a token with &/+/% produced a
+  # broken /home/hapi/url that disagreed with the working on-demand dashboard
+  # link (#101/#12). One builder = no drift.
   HAPI_SETTINGS_FILE="${HAPI_HOME}/settings.json"
   (
     for i in $(seq 1 60); do
       if [ -f "${HAPI_SERVER_LOG}" ] && [ -f "${HAPI_SETTINGS_FILE}" ]; then
-        # Extract relay URL from log: https://xxx.relay.hapi.run
-        # Allow valid DNS-label chars (hyphen + mixed case): a subdomain like
-        # my-sub-01.relay.hapi.run must match or the URL is never built (B12).
-        RELAY_URL=$(grep -oE 'https://[A-Za-z0-9-]+\.relay\.hapi\.run' "${HAPI_SERVER_LOG}" 2>/dev/null | head -1 || true)
-        # Extract token from settings.json
-        TOKEN=$(grep -oE '"cliApiToken":\s*"[^"]+"' "${HAPI_SETTINGS_FILE}" 2>/dev/null | sed 's/.*"cliApiToken":\s*"\([^"]*\)".*/\1/' || true)
-        if [ -n "$RELAY_URL" ] && [ -n "$TOKEN" ]; then
-          # URL-encode the relay URL (replace : with %3A, / with %2F)
-          ENCODED_URL=$(echo "$RELAY_URL" | sed 's/:/%3A/g; s/\//%2F/g')
-          # Build full connection URL
-          FULL_URL="https://app.hapi.run/?hub=${ENCODED_URL}&token=${TOKEN}"
+        # PYTHONPATH=/app makes the ttydproxy package importable (same layout as
+        # `python3 /app/ttyd_proxy.py`). The helper returns the URL or nothing.
+        FULL_URL=$(PYTHONPATH=/app python3 -c '
+import sys
+from ttydproxy.views import build_hapi_url_from_runtime
+log = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+settings = open(sys.argv[2], encoding="utf-8", errors="replace").read()
+url = build_hapi_url_from_runtime(log, settings)
+if url:
+    print(url)
+' "${HAPI_SERVER_LOG}" "${HAPI_SETTINGS_FILE}" 2>/dev/null || true)
+        if [ -n "$FULL_URL" ]; then
           echo "$FULL_URL" > "${HAPI_URL_FILE}"
           chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_URL_FILE}"
           echo "Hapi connection URL: ${FULL_URL}"
@@ -537,16 +547,16 @@ if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
   # Start hapi runner if enabled (reads config from volume)
   if [ "${HAPI_RUNNER_ENABLED}" = "true" ]; then
     echo "Starting hapi runner..."
-    if ! run_as_hapi "hapi runner start 2>&1"; then
+    if ! run_as_hapi_argv -- hapi runner start 2>&1; then
       echo '=== RUNNER START FAILED ===' >&2
     fi
 
     # Verify runner is running
     echo "Checking hapi runner status..."
-    if ! run_as_hapi "hapi runner status 2>&1"; then
+    if ! run_as_hapi_argv -- hapi runner status 2>&1; then
       echo '=== RUNNER NOT RUNNING ===' >&2
       echo 'Running hapi doctor for diagnostics:' >&2
-      run_as_hapi "hapi doctor 2>&1" || true
+      run_as_hapi_argv -- hapi doctor 2>&1 || true
     fi
     echo "Hapi runner startup complete"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -295,7 +295,9 @@ if [ "${DROID_DAEMON_ENABLED}" = "true" ]; then
     fi
 
     DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"
-    touch "${DROID_DAEMON_LOG}"
+    # `: >` (truncate-or-create), not `touch`: the launch appends via `>>`, so
+    # truncate at startup to cap unbounded growth on the persistent volume.
+    : > "${DROID_DAEMON_LOG}"
     chown "${HAPI_USER}:${HAPI_USER}" "${DROID_DAEMON_LOG}"
     echo "Starting droid daemon --remote-access in background (logs: ${DROID_DAEMON_LOG})..."
     # argv form (no `sh -c` interpolation): the log is written via a redirect
@@ -334,7 +336,9 @@ if [ "${AO_DAEMON_ENABLED}" = "true" ]; then
   esac
   if PATH="${HAPI_RUN_PATH}" command -v ao >/dev/null 2>&1; then
     AO_DAEMON_LOG="${HAPI_HOME}/ao-daemon.log"
-    touch "${AO_DAEMON_LOG}"
+    # `: >` (truncate-or-create), not `touch`: the launch appends via `>>`, so
+    # truncate at startup to cap unbounded growth on the persistent volume.
+    : > "${AO_DAEMON_LOG}"
     chown "${HAPI_USER}:${HAPI_USER}" "${AO_DAEMON_LOG}"
     echo "Starting ao daemon on 127.0.0.1:${AO_PORT} in background (logs: ${AO_DAEMON_LOG})..."
     # argv form: AO_PORT is passed as an env assignment consumed by run_as_hapi_argv's
@@ -497,8 +501,13 @@ rm -f "${HAPI_URL_FILE}" 2>/dev/null || true
 if PATH="${HAPI_RUN_PATH}" command -v hapi >/dev/null 2>&1; then
   # Start hapi server with relay in background (logs to file, force TCP relay)
   HAPI_SERVER_LOG="${HAPI_HOME}/server.log"
-  # Pre-create the log so the URL-extraction loop's -f check passes immediately
-  touch "${HAPI_SERVER_LOG}"
+  # Truncate-or-create the log at startup (`: >`, not `touch`): the launch now
+  # appends via `>>` instead of the old `| tee` which truncated on open, so
+  # without this a persistent-volume server.log would keep stale relay URLs
+  # across restarts (a brief window where the /home/hapi/url fallback pairs a
+  # fresh token with an old URL) and grow unbounded. `: >` restores the old
+  # truncate semantics. Also makes the URL-extraction loop's -f check pass.
+  : > "${HAPI_SERVER_LOG}"
   chown "${HAPI_USER}:${HAPI_USER}" "${HAPI_SERVER_LOG}"
   echo "Starting hapi server --relay in background (logs: ${HAPI_SERVER_LOG})..."
   # argv form: HAPI_RELAY_FORCE_TCP via env, log via redirect not `| tee` (#101/#9).

--- a/tests/js/virtual_keyboard.test.mjs
+++ b/tests/js/virtual_keyboard.test.mjs
@@ -50,6 +50,18 @@ function bootVkbd({ clipboardText = 'CLIP', readTextRejects = false,
   const iframeWin = iframe.contentWindow;
   iframeWin.term = term;
   iframeWin._ttydSocket = socket;
+  // In production, tab_fix_script.html (injected INTO the iframe) exports
+  // __sendToTTYD; the vkbd delegates to it instead of an inline socket copy
+  // (#101/#14). The fake iframe doesn't run that script, so provide the same
+  // exported helper here — it owns socket discovery + the '0' INPUT prefix.
+  iframeWin.__sendToTTYD = (data) => {
+    const s = iframeWin._ttydSocket || iframeWin.socket || iframeWin.ws;
+    if (s && s.readyState === 1) {
+      s.send('0' + data);
+      return true;
+    }
+    return false;
+  };
   // jsdom's textarea focus path needs the helper textarea to exist.
   const ta = iframeWin.document.createElement('textarea');
   ta.className = 'xterm-helper-textarea';

--- a/tests/unit/test_proxy_http.py
+++ b/tests/unit/test_proxy_http.py
@@ -19,11 +19,13 @@ class FakeResponse:
         self.reason = reason
         self._headers = headers or []
         self._body = body
+        self.getheaders_calls = 0
 
     def read(self):
         return self._body
 
     def getheaders(self):
+        self.getheaders_calls += 1
         return self._headers
 
 
@@ -192,6 +194,26 @@ class TestBuildTtydHeaders(unittest.TestCase):
         headers = self._build({})
         self.assertEqual(headers["Host"], "127.0.0.1:7681")
         self.assertEqual(headers["X-Forwarded-For"], "127.0.0.1")
+
+
+class TestResponseHeaderEfficiency(unittest.TestCase):
+    """#13: response headers must be read once and skip-sets are constants."""
+
+    def test_getheaders_called_once(self):
+        resp = FakeResponse(
+            headers=[("Content-Type", "text/html"), ("X-Extra", "1")], body=b"<html>"
+        )
+        _reset_conn(resp)
+        handler = StubHandler(headers={}, command="GET")
+        with patch.object(proxy.http.client, "HTTPConnection", FakeConn):
+            proxy.proxy_ttyd_http(handler, "/", 7681)
+        # Old code called resp.getheaders() twice (content-type sniff + forward).
+        self.assertEqual(resp.getheaders_calls, 1)
+
+    def test_skip_sets_are_frozenset_constants(self):
+        self.assertIsInstance(proxy.HOP_BY_HOP_HEADERS, frozenset)
+        self.assertIsInstance(proxy._SKIP_RESPONSE_HEADERS_HTML, frozenset)
+        self.assertIn("content-security-policy", proxy._SKIP_RESPONSE_HEADERS_HTML)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -145,8 +145,9 @@ class TestEntrypointRegressions(unittest.TestCase):
         # The log file must exist before the URL-extraction loop starts so the
         # [ -f "$HAPI_SERVER_LOG" ] guard passes on the first iteration.
         touch_pos = self.text.find('touch "${HAPI_SERVER_LOG}"')
-        server_start_pos = self.text.find("hapi server --relay 2>&1")
+        server_start_pos = self.text.find("stdbuf -oL hapi server --relay")
         self.assertGreater(touch_pos, -1, "HAPI_SERVER_LOG is not pre-created")
+        self.assertGreater(server_start_pos, -1, "hapi server --relay start not found")
         self.assertLess(touch_pos, server_start_pos)
 
     def test_hapi_commands_are_skipped_when_cli_missing(self):
@@ -159,10 +160,10 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertGreater(guard_pos, -1, "hapi command guard is missing")
         self.assertGreater(warning_pos, guard_pos)
         for marker in (
-            'run_as_hapi "HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay',
-            'run_as_hapi "hapi runner start 2>&1"',
-            'run_as_hapi "hapi runner status 2>&1"',
-            'run_as_hapi "hapi doctor 2>&1"',
+            'run_as_hapi_argv -- env HAPI_RELAY_FORCE_TCP=true stdbuf -oL hapi server --relay',
+            'run_as_hapi_argv -- hapi runner start 2>&1',
+            'run_as_hapi_argv -- hapi runner status 2>&1',
+            'run_as_hapi_argv -- hapi doctor 2>&1',
         ):
             with self.subTest(marker=marker):
                 pos = self.text.find(marker)
@@ -178,11 +179,13 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertIn(': "${DROID_COMPUTER_NAME:=}"', self.text)
         self.assertIn('[ "${DROID_DAEMON_ENABLED}" = "true" ]', self.text)
         self.assertIn("DROID_DAEMON_ENABLED=true requires DROID_COMPUTER_NAME", self.text)
-        self.assertIn('droid computer register \\"${DROID_COMPUTER_NAME}\\" -y', self.text)
+        # argv form (#101/#9): DROID_COMPUTER_NAME is a bare argv element, never
+        # interpolated into an `sh -c` string.
+        self.assertIn('run_as_hapi_argv -- droid computer register "${DROID_COMPUTER_NAME}" -y', self.text)
         self.assertIn('DROID_DAEMON_LOG="${HAPI_HOME}/droid-daemon.log"', self.text)
         self.assertIn('PATH="${HAPI_RUN_PATH}" command -v droid', self.text)
         self.assertIn(
-            'run_as_hapi "stdbuf -oL droid daemon --remote-access 2>&1 | tee \\"${DROID_DAEMON_LOG}\\"" &',
+            'run_as_hapi_argv -- stdbuf -oL droid daemon --remote-access >>"${DROID_DAEMON_LOG}" 2>&1 &',
             self.text,
         )
 
@@ -196,8 +199,9 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertIn('PATH="${HAPI_RUN_PATH}" command -v ao', self.text)
         self.assertIn("ao CLI not found; skipping ao daemon startup", self.text)
         self.assertIn('AO_DAEMON_LOG="${HAPI_HOME}/ao-daemon.log"', self.text)
+        # argv form (#101/#9): AO_PORT passed via `env NAME=VAL`, log via redirect.
         self.assertIn(
-            'run_as_hapi "AO_PORT=\\"${AO_PORT}\\" stdbuf -oL ao daemon 2>&1 | tee \\"${AO_DAEMON_LOG}\\"" &',
+            'run_as_hapi_argv -- env "AO_PORT=${AO_PORT}" stdbuf -oL ao daemon >>"${AO_DAEMON_LOG}" 2>&1 &',
             self.text,
         )
         self.assertIn(
@@ -465,6 +469,54 @@ class TestRunAsHapiArgvSecretHygiene(unittest.TestCase):
         # The injection must not have fired during _run (file unlinked in finally,
         # but assert it was never created in the first place via a fresh check is
         # racy; the unlink-in-finally + no exception is the guarantee here).
+
+    def test_droid_computer_name_reaches_argv_verbatim_not_executed(self):
+        # #101/#9: droid registration now uses `run_as_hapi_argv -- droid computer
+        # register "${DROID_COMPUTER_NAME}" -y`, so a hostile value cannot be shell
+        # -parsed. Prove it: a $(...) payload reaches argv as ONE literal element
+        # and never executes. (In production DROID_COMPUTER_NAME is charset-guarded
+        # too, but the argv form removes the injection surface entirely.)
+        helper = self._extract_helper()
+        payload = "x$(touch /tmp/clihost_droid_pwned)y"
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            argv_log = tmp_path / "argv.log"
+            fake_runuser = tmp_path / "runuser"
+            fake_runuser.write_text(
+                "#!/bin/bash\n"
+                'for a in "$@"; do printf "%%s\\n" "$a" >> "%s"; done\n' % argv_log
+            )
+            fake_runuser.chmod(0o755)
+            script = (
+                "set -euo pipefail\n"
+                'HAPI_USER="hapi"\n'
+                'HAPI_USER_HOME="/home/hapi"\n'
+                'HAPI_RUN_PATH="/usr/local/bin:/usr/bin:/bin"\n'
+                'HAPI_HOME="/home/hapi/.hapi"\n'
+                f"{helper}\n"
+                'DROID_COMPUTER_NAME="${PAYLOAD}"\n'
+                'run_as_hapi_argv -- droid computer register "${DROID_COMPUTER_NAME}" -y\n'
+            )
+            env = dict(os.environ)
+            env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+            env["PAYLOAD"] = payload
+            try:
+                result = subprocess.run(
+                    ["bash", "-c", script], capture_output=True, text=True, env=env,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                argv = argv_log.read_text().splitlines()
+                # The whole payload appears as ONE argv element (not split, not run).
+                self.assertIn(payload, argv,
+                              "DROID_COMPUTER_NAME must reach argv as one literal element")
+                self.assertIn("register", argv)
+                # The command substitution must NOT have executed.
+                self.assertFalse(
+                    pathlib.Path("/tmp/clihost_droid_pwned").exists(),
+                    "command injection fired — argv form did not block it",
+                )
+            finally:
+                pathlib.Path("/tmp/clihost_droid_pwned").unlink(missing_ok=True)
 
 
 class TestEntrypointHomeOwnershipBehaviour(unittest.TestCase):
@@ -1869,6 +1921,51 @@ class TestTmuxWrapperSandboxRegressions(unittest.TestCase):
         self.assertIn("new-session -A -s", self.text)
 
 
+class TestDockerNetworkRetries(unittest.TestCase):
+    """#101/#15: every network fetch must use the CLAUDE.md retry loop
+    (`for i in 1 2 3 4 5; do ... && break || sleep 10; done`), not a single
+    attempt — a transient failure must not break the whole build."""
+
+    def setUp(self):
+        self.text = DOCKERFILE.read_text()
+
+    def _assert_wrapped(self, needle):
+        # The retry loop and the command must share a line (the loop body).
+        for line in self.text.splitlines():
+            if needle in line:
+                self.assertIn(
+                    "for i in 1 2 3 4 5", line,
+                    f"network step is not wrapped in a retry loop: {needle}",
+                )
+                # Backoff between attempts (a bare `sleep 10` or inside a
+                # cleanup group like `{ rm -rf ...; sleep 10; }`).
+                self.assertIn("sleep 10", line)
+                self.assertIn("&& break", line)
+                return
+        self.fail(f"network step not found in Dockerfile: {needle}")
+
+    def test_node_curl_retried(self):
+        self._assert_wrapped("nodejs.org/dist/")
+
+    def test_ttyd_curl_retried(self):
+        self._assert_wrapped("tsl0922/ttyd/releases/download")
+
+    def test_cloudflared_curl_retried(self):
+        self._assert_wrapped("cloudflare/cloudflared/releases/download")
+
+    def test_chisel_curl_retried(self):
+        self._assert_wrapped("jpillora/chisel/releases/download")
+
+    def test_ao_git_fetch_retried(self):
+        self._assert_wrapped("git fetch --depth 1 origin")
+
+    def test_hermes_git_clone_retried(self):
+        self._assert_wrapped("git clone --depth 1 https://github.com/NousResearch")
+
+    def test_hermes_pip_install_retried(self):
+        self._assert_wrapped("pip install --break-system-packages")
+
+
 class TestDockerPackageRegressions(unittest.TestCase):
     def test_bubblewrap_is_installed_for_ttyd_sandbox(self):
         dockerfile = DOCKERFILE.read_text()
@@ -2216,49 +2313,60 @@ class TestBuildShRegressions(unittest.TestCase):
         self.assertLess(cd_match.start(), build_match.start())
 
 
-class TestEntrypointRelayUrlRegex(unittest.TestCase):
-    """B12: the relay-URL subdomain class must accept valid DNS-label chars.
+class TestEntrypointRelayUrlDelegation(unittest.TestCase):
+    """#101/#12: entrypoint must build the legacy /home/hapi/url via the SAME
+    Python builder the dashboard uses, not a second bash reimplementation.
 
-    A subdomain like my-sub-01.relay.hapi.run (hyphens, digits) must match so
-    the connection URL is built; the original [a-z0-9]+ silently dropped it.
+    The bash copy had drifted from ttydproxy.views.build_hapi_url_from_runtime:
+    it took the FIRST relay URL (head -1) vs the LAST, and left the token
+    un-encoded vs quote()d — so a token with &/+/% produced a broken URL. The
+    relay-URL regex + last-wins + encoding correctness (formerly B12) is now
+    tested against the shared builder in test_load_hapi_url.py.
     """
 
     def setUp(self):
         self.text = ENTRYPOINT.read_text()
 
-    def _extract_grep_regex(self):
-        # Pull the actual grep -oE pattern out of the real script so the test
-        # cannot drift from the source.
-        match = re.search(
-            r"grep -oE '(https://[^']*relay\\.hapi\\.run)'", self.text
-        )
-        self.assertIsNotNone(match, "relay-URL grep pattern not found in entrypoint.sh")
-        return match.group(1)
+    def test_delegates_to_python_builder(self):
+        self.assertIn("build_hapi_url_from_runtime", self.text)
+        self.assertIn("PYTHONPATH=/app python3", self.text)
 
-    def _grep_relay_url(self, log):
-        """Run the real entrypoint grep pattern over `log`, return the match."""
-        result = subprocess.run(
-            ["grep", "-oE", self._extract_grep_regex()],
-            input=log, capture_output=True, text=True,
-        )
-        return result.stdout.strip()
+    def test_no_bash_reimplementation_remains(self):
+        # The old bash extraction/encoding must be gone (no drift possible).
+        self.assertNotIn("grep -oE 'https://", self.text)
+        self.assertNotIn("s/:/%3A/g", self.text)
+        self.assertNotIn("cliApiToken", self.text)
 
-    def test_regex_matches_hyphenated_subdomain(self):
-        self.assertEqual(
-            self._grep_relay_url("noise\nready at https://my-sub-01.relay.hapi.run now\n"),
-            "https://my-sub-01.relay.hapi.run",
-            "hyphenated relay subdomain was not matched (B12)",
-        )
-
-    def test_regex_matches_plain_lowercase_subdomain(self):
-        self.assertEqual(
-            self._grep_relay_url("x https://abc123.relay.hapi.run y\n"),
-            "https://abc123.relay.hapi.run",
-        )
-
-    def test_source_uses_dns_label_class(self):
-        self.assertIn("[A-Za-z0-9-]+\\.relay\\.hapi\\.run", self.text)
-        self.assertNotIn("[a-z0-9]+\\.relay\\.hapi\\.run", self.text)
+    def test_end_to_end_matches_shared_builder(self):
+        # Run the exact python -c the entrypoint uses and confirm it agrees with
+        # the dashboard builder: LAST relay URL wins, token is percent-encoded.
+        import tempfile
+        from ttydproxy.views import build_hapi_url_from_runtime
+        log = "old https://first.relay.hapi.run\nnew https://last-02.relay.hapi.run\n"
+        settings = '{"cliApiToken": "tok+a&b%c"}'
+        with tempfile.TemporaryDirectory() as d:
+            log_path = pathlib.Path(d) / "server.log"
+            settings_path = pathlib.Path(d) / "settings.json"
+            log_path.write_text(log)
+            settings_path.write_text(settings)
+            snippet = (
+                "import sys\n"
+                "from ttydproxy.views import build_hapi_url_from_runtime\n"
+                "log = open(sys.argv[1], encoding='utf-8', errors='replace').read()\n"
+                "settings = open(sys.argv[2], encoding='utf-8', errors='replace').read()\n"
+                "url = build_hapi_url_from_runtime(log, settings)\n"
+                "print(url) if url else None\n"
+            )
+            env = dict(os.environ)
+            env["PYTHONPATH"] = str(REPO_ROOT / "app")
+            result = subprocess.run(
+                ["python3", "-c", snippet, str(log_path), str(settings_path)],
+                capture_output=True, text=True, env=env,
+            )
+        expected = build_hapi_url_from_runtime(log, settings)
+        self.assertEqual(result.stdout.strip(), expected, result.stderr)
+        self.assertIn("last-02.relay.hapi.run", result.stdout)  # last wins
+        self.assertIn("tok%2Ba%26b%25c", result.stdout)         # token encoded
 
 
 class TestDockerEntrypointSignals(unittest.TestCase):

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -142,13 +142,16 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertIn('chown "${HAPI_USER}:${HAPI_USER}" "${LOCAL_BIN_ENV}"', self.text)
 
     def test_hapi_server_log_precreated(self):
-        # The log file must exist before the URL-extraction loop starts so the
-        # [ -f "$HAPI_SERVER_LOG" ] guard passes on the first iteration.
-        touch_pos = self.text.find('touch "${HAPI_SERVER_LOG}"')
+        # The log file must be truncated-or-created before the URL-extraction
+        # loop starts so the [ -f "$HAPI_SERVER_LOG" ] guard passes on the first
+        # iteration. `: >` (not `touch`) restores the old `| tee` truncate-at-
+        # startup semantics now that the launch appends via `>>` (#101/#9), so a
+        # persistent server.log can't retain stale relay URLs or grow unbounded.
+        precreate_pos = self.text.find(': > "${HAPI_SERVER_LOG}"')
         server_start_pos = self.text.find("stdbuf -oL hapi server --relay")
-        self.assertGreater(touch_pos, -1, "HAPI_SERVER_LOG is not pre-created")
+        self.assertGreater(precreate_pos, -1, "HAPI_SERVER_LOG is not truncated/pre-created")
         self.assertGreater(server_start_pos, -1, "hapi server --relay start not found")
-        self.assertLess(touch_pos, server_start_pos)
+        self.assertLess(precreate_pos, server_start_pos)
 
     def test_hapi_commands_are_skipped_when_cli_missing(self):
         guard_pos = self.text.find(

--- a/tests/unit/test_ttyd_manager.py
+++ b/tests/unit/test_ttyd_manager.py
@@ -210,6 +210,78 @@ class TestAllocatePort(unittest.TestCase):
         self.assertIsNone(manager._allocate_port())
 
 
+class TestReaper(unittest.TestCase):
+    """Background reaper collects dead ttyd zombies without list/get traffic
+    (#101/#7)."""
+
+    @patch("ttydproxy.manager.subprocess.run")
+    @patch("ttydproxy.manager.subprocess.Popen")
+    def test_reap_removes_dead_without_list_or_get(self, mock_popen, _mock_run):
+        alive = MagicMock()
+        alive.pid = 100
+        alive.poll.return_value = None
+        dead = MagicMock()
+        dead.pid = 101
+        dead.poll.return_value = 1
+        mock_popen.side_effect = [alive, dead]
+
+        manager = TTYDManager(base_port=9000)
+        manager.create_terminal()  # id 1, alive
+        manager.create_terminal()  # id 2, dead
+
+        # Reap directly — do NOT call list_terminals()/get_terminal().
+        reaped = manager.reap_dead_terminals()
+        self.assertEqual(reaped, 1)
+        self.assertEqual(set(manager.terminals.keys()), {1})
+
+    @patch("ttydproxy.manager.subprocess.run")
+    @patch("ttydproxy.manager.subprocess.Popen")
+    def test_reap_keeps_alive_terminals(self, mock_popen, _mock_run):
+        alive = MagicMock()
+        alive.pid = 100
+        alive.poll.return_value = None
+        mock_popen.return_value = alive
+
+        manager = TTYDManager(base_port=9000)
+        manager.create_terminal()
+        self.assertEqual(manager.reap_dead_terminals(), 0)
+        self.assertEqual(set(manager.terminals.keys()), {1})
+
+    @patch("ttydproxy.manager.subprocess.run")
+    @patch("ttydproxy.manager.subprocess.Popen")
+    def test_background_reaper_thread_reaps(self, mock_popen, _mock_run):
+        import time
+        dead = MagicMock()
+        dead.pid = 101
+        dead.poll.return_value = 1
+        mock_popen.return_value = dead
+
+        manager = TTYDManager(base_port=9000)
+        manager.create_terminal()  # id 1, dead
+        self.assertEqual(set(manager.terminals.keys()), {1})
+
+        # A short interval so the thread ticks quickly in the test.
+        manager.start_reaper(interval=0.05)
+        try:
+            deadline = time.monotonic() + 5
+            while manager.terminals and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertEqual(manager.terminals, {}, "reaper thread did not reap the zombie")
+        finally:
+            manager.stop_reaper()
+        self.assertFalse(
+            manager._reaper_thread.is_alive(), "reaper thread did not stop"
+        )
+
+    def test_start_reaper_is_idempotent(self):
+        manager = TTYDManager(base_port=9000)
+        manager.start_reaper(interval=10)
+        first = manager._reaper_thread
+        manager.start_reaper(interval=10)  # must not spawn a second thread
+        self.assertIs(manager._reaper_thread, first)
+        manager.stop_reaper()
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/unit/test_vkbd_html.py
+++ b/tests/unit/test_vkbd_html.py
@@ -41,7 +41,11 @@ class TestVKBDEnabled(unittest.TestCase):
     def test_updated_javascript_present(self):
         self.assertIn("function sendKey(key)", self.html)
         self.assertIn("navigator.clipboard.readText()", self.html)
-        self.assertIn("socket.send('0' + data)", self.html)
+        # Keys are now sent through the iframe's shared __sendToTTYD helper (owns
+        # socket discovery + the '0' INPUT prefix) instead of an inline
+        # socket.send('0' + data) copy (#101/#14).
+        self.assertIn("win.__sendToTTYD(data)", self.html)
+        self.assertNotIn("socket.send('0' + data)", self.html)
         self.assertIn("win.sendTabKey", self.html)
 
     def test_ctrl_v_uses_term_paste_with_socket_fallback(self):


### PR DESCRIPTION
## Summary

Six P2 refactoring-debt fixes from the multi-agent code review in #101, plus NOTE comments for the deferred TOCTOU finding (#8).

- **#7 — dead ttyd processes not reaped without traffic** (`manager.py`, `app.py`). Added a background daemon reaper thread; zombies were only reaped lazily inside `list_terminals()`/`get_terminal()`, so with no list/get/health traffic a defunct process pinned its PID slot forever. Start/stop wired into `main()` + the signal handler.
- **#9 — `run_as_hapi` interpolated args into `sh -c`** (`entrypoint.sh`). Routed droid/ao/hapi startup through the argv-safe `run_as_hapi_argv` (a latent root-context command-injection surface). `| tee` → redirect (argv can't express a pipe, matching the tunnel helpers), inline env via `env NAME=VAL`; the unused string `run_as_hapi` is removed.
- **#12 — relay-URL built by a drifted bash reimplementation** (`entrypoint.sh`). Delegated the legacy `/home/hapi/url` writer to the same `ttydproxy.views.build_hapi_url_from_runtime` the dashboard uses (bash took the FIRST relay URL + left the token un-encoded; views takes the LAST + `quote()`s both).
- **#13 — per-request allocation in the HTTP proxy** (`proxy.py`). `HOP_BY_HOP_HEADERS` is now a `frozenset`, the HTML skip-set is precomputed, and `resp.getheaders()` is read once (was twice per response). A keep-alive connection pool was intentionally **not** added — a shared `HTTPConnection` across `ThreadingHTTPServer` workers would introduce a concurrency bug.
- **#14 — duplicated JS helpers across assets** (`app/assets/*.html`). Exported `window.__containsFiles` / `window.__sendToTTYD` from the injected `tab_fix_script` and delegated to them from the parent page + virtual keyboard, removing byte-identical `containsFiles` copies and three hard-coded socket-discovery + `'0'` ttyd-prefix sites.
- **#15 — network fetches with no retry** (`Dockerfile`). Wrapped the Node/ttyd/cloudflared/chisel curl downloads and the ao git-fetch + Hermes git-clone/pip steps in the CLAUDE.md retry loop, previously applied only to npm.

## #101 findings closed

- #7 (zombie ttyd not reaped) — resource-leak, PLAUSIBLE
- #9 (`run_as_hapi` sh -c injection) — security, PLAUSIBLE
- #12 (relay-URL double parsing) — reuse, PLAUSIBLE
- #13 (no keep-alive / per-request alloc) — efficiency, PLAUSIBLE
- #14 (JS helper duplication) — reuse, PLAUSIBLE
- #15 (curl/git without retry) — conventions, PLAUSIBLE

**Deferred:** #8 (port-reuse TOCTOU) — narrow window (usually `ECONNREFUSED`→502), not a security boundary. NOTE comments added in `app.py` + `manager.py` pointing at a per-terminal lease/refcount as the proper fix, tracked separately.

## New/changed env vars

None.

## Ports / volumes

No changes.

## Tests

New: reaper tests in `test_ttyd_manager.py`, `TestResponseHeaderEfficiency` in `test_proxy_http.py`, `TestDockerNetworkRetries` + a droid-daemon injection test + relay-URL delegation tests in `test_shell_scripts.py`, `__sendToTTYD` delegation in the vkbd JS tests. Full `pytest tests/` and `npm test` green; `bash -n entrypoint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgvJhzd8gEhXVE4MVu18nn
