### PR TITLE
feat: host-side billing foundation for Dokku (issue #37, PR1+PR2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 
 # Orchestrator worker task briefs (scratch, not project artifacts)
 TASK_BRIEF_*.md
+
+# Host-side billing store (issue #37) — JSONL samples/state, host-only, never committed
+.clihost-billing/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,74 @@ Syncthing / real-time sync is explicitly deferred. The accepted design is
 rsync-first for this release; a long-running bidirectional file watcher is
 over-engineering until the manual contract proves insufficient.
 
+### Host-side billing (Dokku usage accounting, issue #37)
+
+`bin/clihost-billing.sh` + `bin/clihost_billing_lib.py` are a **host-only** pair
+(like `claude-auth-snapshot-host.sh`): they are **never** copied into the image
+(`Dockerfile` is not touched) — inside the container billing is meaningless and
+unsafe (no `docker.sock`). They live on the Dokku host (e.g. `/home/dokku/bin/`)
+and run as the `dokku` user, who is in the `docker` group and can therefore call
+`docker stats/ps -s/inspect` **without sudo** (`sudo` needs a password and is
+unavailable). This is the accounting foundation for issue #37 (PR1 + PR2:
+collect + report); the operational subcommands (`diagnose`/`restart`,
+`gc-mounts`, `idle-sleep`) and stage 2 (tariffs/invoices) are follow-up PRs.
+
+The bash file is a thin dispatcher (`set -euo pipefail`, `die`/`usage`/`main`
++`case`, one docker/I-O owner); all pure logic (parsers + aggregation +
+formatting) lives in the stdlib-only `clihost_billing_lib.py` so it is unit
+tested without root or Docker (`tests/unit/test_clihost_billing_agg.py`, plus
+static+end-to-end checks in `tests/unit/test_shell_scripts.py`). No `jq`/`sqlite3`
+(not guaranteed on the host); the dispatcher shells out to `python3` inline.
+
+**Subcommands:**
+
+| Subcommand | Purpose |
+|---|---|
+| `collect` | Sample every `clihost-*` container once (cron-driven). Idempotent, `flock`-serialized, appends JSONL. |
+| `cron-line` | Print a ready-to-paste `crontab` line — the operator installs it manually (`crontab -e` as `dokku`; we never auto-install into a crontab, no sudo). |
+| `report [--json]` | Aggregated usage table per app (avg CPU cores / avg mem / disk / container-hours / uptime% / COST). |
+| `raw` | Alias for `report --json` (machine-readable). |
+| `help` | Usage. |
+
+**Storage** — append-only JSONL under `${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}`
+(gitignored: `.clihost-billing/`):
+- `samples/YYYY-MM.jsonl` — one JSON sample object per container per collect (monthly rotation).
+- `state/collect.lock` — `flock` guard so overlapping cron runs don't interleave.
+- `state/last-collect.json` — last-collect metadata (feeds the "collector likely
+  not running" warning `report` prints when the newest sample is older than
+  `2 × interval`).
+- `rates.json` (stage 2) — not present yet; `report` calls `apply_rates(rows, None)`
+  so COST renders as an em dash (`—`) until rates exist.
+
+**Data sources** (docker only, no sudo, **no `du`** — the `dokku` user can't read
+the root storage mount):
+- CPU%/Mem: `docker stats --no-stream --format '{{json .}}'` (one call, running
+  containers only).
+- Disk: `docker ps -a -s` writable-layer `Size` field (`"2.54GB (virtual 5.73GB)"`);
+  `rootfs` = first number, `image` = `virtual − rootfs`.
+- Diagnostics carried per sample: `docker inspect` `RestartCount`/`Status`/
+  `ExitCode`/`OOMKilled` (used by the follow-up `diagnose` PR).
+
+**Container-hours** are **left-Riemann** integrated over the *actual* `dt`
+between consecutive samples *of the same container* (an app with several
+`.web.N` instances sums each container's contribution — grouping only by app
+would fabricate bogus intervals). Two guards: `dt <= 0` (clock skew / duplicate)
+is skipped, and `dt > 2.5 × CLIHOST_BILLING_INTERVAL` is treated as a **gap**
+(collector down / server asleep) and excluded from billed time. A stopped
+container writes a `running:false` sample: its seconds count toward the billed
+denominator (uptime%) but not toward billable *running* hours; disk is still
+tracked. Disk is a point-in-time size (latest per container summed), not integrated.
+
+**Environment:** `CLIHOST_BILLING_DIR` (storage root), `CLIHOST_BILLING_INTERVAL`
+(collector cadence in seconds, default 300 — also the gap-detection base),
+`CLIHOST_APP_PREFIX` (container/app prefix to account, default `clihost-`).
+
+**Verification:** `python -m pytest tests/unit/test_clihost_billing_agg.py
+tests/unit/test_shell_scripts.py`; on the server, copy both files to
+`/home/dokku/bin/`, run `clihost-billing.sh collect` a few times with a pause,
+then `clihost-billing.sh report` — the table should list `clihost-axisrow` /
+`clihost-work1nw`. `clihost-billing.sh cron-line` prints the collector line.
+
 ### ttyd proxy package (app/)
 
 `app/ttyd_proxy.py` is only a **thin process entry point** (imports `main` from `ttydproxy.app`; referenced by entrypoint.sh as `python3 /app/ttyd_proxy.py`); all logic lives in the `app/ttydproxy/` package:

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+set -euo pipefail
+
+# Host-side usage accounting for clihost apps on a Dokku host (issue #37).
+#
+# This is a HOST-ONLY tool (like claude-auth-snapshot-host.sh): it is NOT copied
+# into the image — inside the container it is meaningless and unsafe (no access
+# to docker.sock). It lives on the Dokku host (e.g. /home/dokku/bin/) and is run
+# by the `dokku` user, who is in the `docker` group and can therefore call
+# `docker stats/ps -s/inspect` WITHOUT sudo.
+#
+# Subcommands (PR1 + PR2 — accounting + report):
+#   collect     take one sample of every clihost-* container (cron-driven).
+#   cron-line   print a ready-to-paste crontab line (operator installs it).
+#   report      render an aggregated usage table (per app).
+#   raw         emit aggregated rows as JSON (machine-readable).
+#   help        usage.
+#
+# Storage is append-only JSONL under ${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}:
+#   samples/YYYY-MM.jsonl   monthly-rotated samples (one JSON object per line)
+#   state/collect.lock      flock guard so overlapping cron runs don't interleave
+#   state/last-collect.json last sample metadata (for the "collector down" warning)
+#
+# Pure parsing/aggregation lives in bin/clihost_billing_lib.py so it is unit
+# tested without root or Docker; this dispatcher owns all docker calls and I/O.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BILLING_LIB="${SCRIPT_DIR}/clihost_billing_lib.py"
+
+: "${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}"
+: "${CLIHOST_BILLING_INTERVAL:=300}"
+: "${CLIHOST_APP_PREFIX:=clihost-}"
+
+SAMPLES_DIR="${CLIHOST_BILLING_DIR}/samples"
+STATE_DIR="${CLIHOST_BILLING_DIR}/state"
+LOCK_FILE="${STATE_DIR}/collect.lock"
+LAST_COLLECT_FILE="${STATE_DIR}/last-collect.json"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  clihost-billing.sh collect            take one sample of all clihost-* containers
+  clihost-billing.sh cron-line          print a crontab line to install the collector
+  clihost-billing.sh report [--json]    aggregated usage table (per app)
+  clihost-billing.sh raw                aggregated rows as JSON (alias for report --json)
+  clihost-billing.sh help               this message
+
+Environment:
+  CLIHOST_BILLING_DIR       storage root (default: /home/dokku/.clihost-billing)
+  CLIHOST_BILLING_INTERVAL  collector cadence in seconds (default: 300); used as
+                            the gap-detection base (dt > 2.5x interval = server down)
+  CLIHOST_APP_PREFIX        container/app name prefix to account (default: clihost-)
+EOF
+}
+
+require_python() {
+  command -v python3 >/dev/null 2>&1 || die "python3 not found"
+  [ -f "${BILLING_LIB}" ] || die "billing library not found: ${BILLING_LIB}"
+}
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 || die "docker CLI not found"
+}
+
+ensure_dirs() {
+  mkdir -p "${SAMPLES_DIR}" "${STATE_DIR}"
+}
+
+current_month() {
+  date -u '+%Y-%m'
+}
+
+iso_now() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+# collect: sample every clihost-* container once and append JSONL lines.
+cmd_collect() {
+  [ "$#" -eq 0 ] || die "collect accepts no arguments"
+  require_python
+  require_docker
+  ensure_dirs
+
+  # Serialize concurrent collectors (cron overlap) with a non-blocking flock.
+  exec 9>"${LOCK_FILE}"
+  if ! flock -n 9; then
+    echo "another collect run holds the lock; skipping" >&2
+    return 0
+  fi
+
+  local stats_json ps_json inspect_json ts sample_file
+  ts="$(iso_now)"
+  sample_file="${SAMPLES_DIR}/$(current_month).jsonl"
+
+  # docker stats only lists RUNNING containers; docker ps -a lists all (the
+  # source of truth for the container set). inspect gives restart_count/status.
+  # Each may be empty (no containers yet) — that is not an error.
+  stats_json="$(docker stats --no-stream --format '{{json .}}' 2>/dev/null || true)"
+  ps_json="$(docker ps -a -s --format '{{json .}}' 2>/dev/null || true)"
+  inspect_json="$(docker ps -a --filter "name=${CLIHOST_APP_PREFIX}" --format '{{.Names}}' 2>/dev/null \
+    | while IFS= read -r name; do
+        [ -n "${name}" ] || continue
+        docker inspect --format \
+          '{"name":{{printf "%q" .Name}},"restart_count":{{.RestartCount}},"status":{{printf "%q" .State.Status}},"exit_code":{{.State.ExitCode}},"oom_killed":{{.State.OOMKilled}}}' \
+          "${name}" 2>/dev/null || true
+      done)"
+
+  local out
+  out="$(
+    CLIHOST_TS="${ts}" \
+    CLIHOST_PREFIX="${CLIHOST_APP_PREFIX}" \
+    CLIHOST_STATS_JSON="${stats_json}" \
+    CLIHOST_PS_JSON="${ps_json}" \
+    CLIHOST_INSPECT_JSON="${inspect_json}" \
+    CLIHOST_BILLING_LIB="${BILLING_LIB}" \
+    python3 <<'PY'
+import json
+import os
+import sys
+
+lib_path = os.environ["CLIHOST_BILLING_LIB"]
+lib_dir = os.path.dirname(lib_path)
+sys.path.insert(0, lib_dir)
+import clihost_billing_lib as lib  # noqa: E402
+
+ts = os.environ["CLIHOST_TS"]
+prefix = os.environ["CLIHOST_PREFIX"]
+
+
+def parse_json_lines(text):
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+stats_rows = parse_json_lines(os.environ.get("CLIHOST_STATS_JSON", ""))
+ps_rows = parse_json_lines(os.environ.get("CLIHOST_PS_JSON", ""))
+inspect_rows = parse_json_lines(os.environ.get("CLIHOST_INSPECT_JSON", ""))
+
+
+def strip_slash(name):
+    # docker inspect .Name has a leading slash ("/clihost-axisrow.web.1").
+    return name[1:] if name.startswith("/") else name
+
+
+def app_of(container):
+    # clihost-axisrow.web.1 -> clihost-axisrow ; strip the .web.N suffix.
+    base = container
+    dot = base.find(".")
+    return base[:dot] if dot != -1 else base
+
+
+# Index stats and ps by container name.
+stats_by_name = {}
+for row in stats_rows:
+    name = row.get("Name") or row.get("Container") or ""
+    if name:
+        stats_by_name[name] = row
+
+ps_by_name = {}
+for row in ps_rows:
+    names = row.get("Names") or ""
+    for name in names.split(","):
+        name = name.strip()
+        if name:
+            ps_by_name[name] = row
+
+inspect_by_name = {}
+for row in inspect_rows:
+    name = strip_slash(row.get("name") or "")
+    if name:
+        inspect_by_name[name] = row
+
+# The container set is every clihost-* container in `docker ps -a`.
+lines = []
+for name, ps_row in sorted(ps_by_name.items()):
+    if not name.startswith(prefix):
+        continue
+    stats_row = stats_by_name.get(name, {})
+    inspect_row = inspect_by_name.get(name, {})
+
+    status = (inspect_row.get("status") or ps_row.get("State") or "").lower()
+    running = status == "running"
+
+    cpu_perc = lib.parse_cpu_perc(stats_row.get("CPUPerc")) if running else 0.0
+    mem_used, _mem_limit = lib.parse_mem_usage(stats_row.get("MemUsage")) if running else (0, 0)
+    rootfs_bytes, virtual_bytes = lib.parse_size_field(ps_row.get("Size"))
+    image_bytes = max(virtual_bytes - rootfs_bytes, 0)
+
+    sample = {
+        "ts": ts,
+        "app": app_of(name),
+        "container": name,
+        "running": running,
+        "status": status,
+        "cpu_perc": cpu_perc,
+        "mem_bytes": mem_used,
+        "rootfs_bytes": rootfs_bytes,
+        "image_bytes": image_bytes,
+        "restart_count": inspect_row.get("restart_count", 0),
+        "oom_killed": bool(inspect_row.get("oom_killed", False)),
+        "exit_code": inspect_row.get("exit_code", 0),
+    }
+    lines.append(json.dumps(sample, sort_keys=True))
+
+sys.stdout.write("\n".join(lines))
+if lines:
+    sys.stdout.write("\n")
+PY
+  )"
+
+  # Append atomically-ish: write via >> (single write per line is small enough
+  # to be atomic on local fs; the flock already serializes collectors).
+  if [ -n "${out}" ]; then
+    printf '%s' "${out}" >> "${sample_file}"
+  fi
+
+  # Record last-collect metadata for the "collector down" warning in report.
+  printf '{"ts":%s,"samples":%s}\n' \
+    "\"${ts}\"" \
+    "$(printf '%s' "${out}" | grep -c . || true)" \
+    > "${LAST_COLLECT_FILE}"
+
+  local n
+  n="$(printf '%s' "${out}" | grep -c . || true)"
+  echo "collected ${n} sample(s) at ${ts} -> ${sample_file}"
+}
+
+# cron-line: print a crontab line the operator installs manually (no sudo, we do
+# NOT auto-install into anyone's crontab).
+cmd_cron_line() {
+  [ "$#" -eq 0 ] || die "cron-line accepts no arguments"
+  local self minutes
+  self="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+  # Default cadence 5 min; keep in step with CLIHOST_BILLING_INTERVAL=300.
+  minutes=$(( CLIHOST_BILLING_INTERVAL / 60 ))
+  [ "${minutes}" -ge 1 ] || minutes=1
+  cat <<EOF
+# clihost billing collector (issue #37) — paste into: crontab -e  (as the dokku user)
+*/${minutes} * * * * ${self} collect >> ${CLIHOST_BILLING_DIR}/state/collect.log 2>&1
+EOF
+}
+
+# Gather every samples/*.jsonl file (all months) for aggregation.
+list_sample_files() {
+  [ -d "${SAMPLES_DIR}" ] || return 0
+  find "${SAMPLES_DIR}" -maxdepth 1 -type f -name '*.jsonl' | sort
+}
+
+cmd_report() {
+  local want_json="false"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json) want_json="true"; shift ;;
+      --) shift; break ;;
+      -*) die "unknown option: $1" ;;
+      *) die "report takes no operands" ;;
+    esac
+  done
+  require_python
+
+  local files
+  files="$(list_sample_files)"
+  if [ -z "${files}" ]; then
+    if [ "${want_json}" = "true" ]; then
+      echo "[]"
+    else
+      echo "no samples yet under ${SAMPLES_DIR}; run 'collect' (or install the cron-line)." >&2
+    fi
+    return 0
+  fi
+
+  CLIHOST_WANT_JSON="${want_json}" \
+  CLIHOST_INTERVAL="${CLIHOST_BILLING_INTERVAL}" \
+  CLIHOST_LAST_COLLECT="${LAST_COLLECT_FILE}" \
+  CLIHOST_BILLING_LIB="${BILLING_LIB}" \
+  CLIHOST_SAMPLE_FILES="${files}" \
+  python3 <<'PY'
+import json
+import os
+import sys
+import time
+
+lib_path = os.environ["CLIHOST_BILLING_LIB"]
+sys.path.insert(0, os.path.dirname(lib_path))
+import clihost_billing_lib as lib  # noqa: E402
+
+want_json = os.environ.get("CLIHOST_WANT_JSON") == "true"
+interval = int(os.environ.get("CLIHOST_INTERVAL") or lib.DEFAULT_INTERVAL_SECONDS)
+
+samples = []
+for path in os.environ.get("CLIHOST_SAMPLE_FILES", "").splitlines():
+    path = path.strip()
+    if not path:
+        continue
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for sample in lib.iter_samples(handle):
+                samples.append(sample)
+    except OSError:
+        continue
+
+rows = lib.aggregate(samples, interval_seconds=interval)
+rows = lib.apply_rates(rows, rates=None)  # stage-2 hook: no rates.json yet.
+
+# Warn if the newest sample is older than 2x the interval (collector likely
+# stopped) — mirrors the plan's verification requirement.
+warning = None
+newest = None
+for row in rows:
+    epoch = lib.parse_ts(row.get("last_ts"))
+    if epoch is not None and (newest is None or epoch > newest):
+        newest = epoch
+if newest is not None:
+    age = time.time() - newest
+    if age > 2 * interval:
+        warning = ("last sample is %d s old (> 2x interval %d s); "
+                   "collector likely not running" % (int(age), interval))
+
+if want_json:
+    print(json.dumps({"rows": rows, "warning": warning}, indent=2, sort_keys=True))
+else:
+    print(lib.format_report_table(rows))
+    if warning:
+        sys.stderr.write("WARNING: %s\n" % warning)
+PY
+}
+
+main() {
+  local command="${1:-}"
+  case "${command}" in
+    collect)
+      shift
+      cmd_collect "$@"
+      ;;
+    cron-line)
+      shift
+      cmd_cron_line "$@"
+      ;;
+    report)
+      shift
+      cmd_report "$@"
+      ;;
+    raw)
+      shift
+      [ "$#" -eq 0 ] || die "raw accepts no arguments"
+      cmd_report --json
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    "")
+      usage
+      exit 2
+      ;;
+    *)
+      die "unknown subcommand: ${command} (try 'help')"
+      ;;
+  esac
+}
+
+main "$@"

--- a/bin/clihost_billing_lib.py
+++ b/bin/clihost_billing_lib.py
@@ -1,0 +1,424 @@
+"""Pure stdlib helpers for host-side clihost billing (issue #37).
+
+This module is imported by ``bin/clihost-billing.sh`` (via an inline
+``python3`` block) and by ``tests/unit/test_clihost_billing_agg.py``. It holds
+*only* pure functions — parsers for the human-formatted numbers that
+``docker stats`` / ``docker ps -s`` emit, the container-hours aggregation, the
+report table formatter, and the (stage-2) rates hook. No I/O, no docker calls,
+no filesystem access lives here; the bash dispatcher owns all of that so this
+module stays trivially unit-testable without root or Docker.
+
+Design notes tied to the approved plan (37-quizzical-storm.md):
+
+* Container-hours use **left-Riemann** integration over the *actual* ``dt``
+  between consecutive samples of one container, with **gap detection**
+  (``dt > 2.5 * interval`` means the collector/server was down for that stretch,
+  so the interval is not billed) and rejection of non-positive ``dt``.
+* A stopped container writes ``running: false`` samples: those seconds are not
+  counted as billable *running* hours, but disk (rootfs/image) is still tracked.
+* stdlib only — no third-party deps (matches the repo-wide Python convention).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+
+# Default collector cadence in seconds; the bash dispatcher passes the real
+# interval through, but the aggregation falls back to this so a bare call still
+# has a sane gap threshold.
+DEFAULT_INTERVAL_SECONDS = 300
+
+# A dt larger than this multiple of the sampling interval is treated as a gap
+# (collector down / server asleep) and excluded from billed time.
+GAP_INTERVAL_MULTIPLE = 2.5
+
+
+# --------------------------------------------------------------------------- #
+# Field parsers — turn docker's human-formatted strings into raw numbers.
+# --------------------------------------------------------------------------- #
+
+# Binary (IEC) and decimal (SI) unit multipliers. docker stats emits IEC units
+# (MiB/GiB); docker ps -s emits SI units (MB/GB). Both are handled so a parser
+# never silently mis-scales a value.
+_UNIT_MULTIPLIERS = {
+    "b": 1,
+    "kb": 1000,
+    "mb": 1000 ** 2,
+    "gb": 1000 ** 3,
+    "tb": 1000 ** 4,
+    "pb": 1000 ** 5,
+    "kib": 1024,
+    "mib": 1024 ** 2,
+    "gib": 1024 ** 3,
+    "tib": 1024 ** 4,
+    "pib": 1024 ** 5,
+    # docker occasionally prints a bare "kB"/"B" already covered above; the
+    # plain-byte "B" maps to 1.
+}
+
+
+def parse_cpu_perc(value):
+    """Parse a ``docker stats`` CPUPerc field like ``"9.28%"`` into a float.
+
+    Returns the percentage as a number (``9.28``), not a fraction. The caller
+    divides by 100 when it wants CPU-core units. ``"--"`` / empty / unparseable
+    input returns ``0.0`` (a stopped container reports ``--``).
+    """
+    if value is None:
+        return 0.0
+    text = str(value).strip()
+    if not text or text in ("--", "-"):
+        return 0.0
+    text = text.rstrip("%").strip()
+    try:
+        return float(text)
+    except ValueError:
+        return 0.0
+
+
+def _parse_one_size(token):
+    """Parse a single ``<number><unit>`` token (e.g. ``512.4MiB``) into bytes."""
+    token = token.strip()
+    if not token:
+        return 0
+    # Split the numeric prefix from the unit suffix.
+    idx = 0
+    while idx < len(token) and (token[idx].isdigit() or token[idx] in ".+-eE"):
+        idx += 1
+    number_part = token[:idx].strip()
+    unit_part = token[idx:].strip().lower()
+    if not number_part:
+        return 0
+    try:
+        number = float(number_part)
+    except ValueError:
+        return 0
+    if not unit_part:
+        # A bare number with no unit is already bytes.
+        return int(round(number))
+    multiplier = _UNIT_MULTIPLIERS.get(unit_part)
+    if multiplier is None:
+        # Unknown unit — treat the number as bytes rather than crash.
+        return int(round(number))
+    return int(round(number * multiplier))
+
+
+def parse_mem_usage(value):
+    """Parse a ``docker stats`` MemUsage field into (used_bytes, limit_bytes).
+
+    Input looks like ``"512.4MiB / 2GiB"``; the left side is the used memory,
+    the right side the limit. ``"--"`` or a missing side yields ``0`` for that
+    component. Only the used side matters for billing, but the limit is returned
+    too so a caller can compute headroom if it wants.
+    """
+    if value is None:
+        return (0, 0)
+    text = str(value).strip()
+    if not text or text in ("--", "-"):
+        return (0, 0)
+    parts = text.split("/")
+    used = _parse_one_size(parts[0]) if len(parts) >= 1 else 0
+    limit = _parse_one_size(parts[1]) if len(parts) >= 2 else 0
+    return (used, limit)
+
+
+def parse_size_field(value):
+    """Parse a ``docker ps -s`` Size field into (rootfs_bytes, virtual_bytes).
+
+    Input looks like ``"2.54GB (virtual 5.73GB)"`` where the first number is the
+    container's writable layer and ``virtual`` is the total (image + writable
+    layer). A field with no ``(virtual …)`` part returns ``0`` for the virtual
+    component. This is how disk usage is measured without ``sudo du`` (the
+    ``dokku`` user can't read the root storage mount).
+    """
+    if value is None:
+        return (0, 0)
+    text = str(value).strip()
+    if not text or text in ("--", "-"):
+        return (0, 0)
+    virtual = 0
+    rootfs_part = text
+    # Extract the parenthetical "(virtual X)" if present.
+    open_idx = text.find("(")
+    if open_idx != -1:
+        rootfs_part = text[:open_idx]
+        close_idx = text.find(")", open_idx)
+        inner = text[open_idx + 1:close_idx if close_idx != -1 else len(text)]
+        inner = inner.strip()
+        # inner looks like "virtual 5.73GB"
+        lowered = inner.lower()
+        if lowered.startswith("virtual"):
+            inner = inner[len("virtual"):].strip()
+        virtual = _parse_one_size(inner)
+    rootfs = _parse_one_size(rootfs_part)
+    return (rootfs, virtual)
+
+
+# --------------------------------------------------------------------------- #
+# Timestamp helpers.
+# --------------------------------------------------------------------------- #
+
+def parse_ts(value):
+    """Parse an ISO-8601 UTC timestamp (``...Z`` or ``+00:00``) to epoch seconds."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.timestamp()
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation — the billing core.
+# --------------------------------------------------------------------------- #
+
+def iter_samples(lines):
+    """Yield parsed sample dicts from an iterable of JSONL lines/strings.
+
+    Blank lines and lines that fail to parse (truncated append, partial write)
+    are skipped silently — the store is append-only and a crashed collector can
+    leave a torn final line, which must not poison a whole report.
+    """
+    for line in lines:
+        if line is None:
+            continue
+        text = line.strip() if isinstance(line, str) else line
+        if not text:
+            continue
+        if isinstance(text, (bytes, bytearray)):
+            try:
+                text = text.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            text = text.strip()
+            if not text:
+                continue
+        try:
+            obj = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def aggregate(samples, interval_seconds=DEFAULT_INTERVAL_SECONDS):
+    """Aggregate per-container samples into billable rows keyed by app.
+
+    ``samples`` is an iterable of dicts as written by ``collect`` (see
+    ``clihost-billing.sh``). Returns a list of row dicts, one per app, sorted by
+    app name. Each row carries:
+
+    * ``app``
+    * ``running_hours``      — billed running container-hours (left-Riemann,
+                               gaps excluded, only intervals whose left sample
+                               had ``running: true``)
+    * ``billed_hours``       — total billed span (running + stopped, gaps
+                               excluded); the denominator for uptime%
+    * ``uptime_pct``         — 100 * running_hours / billed_hours (or 0)
+    * ``cpu_core_hours``     — integral of (cpu_perc/100) dt over running span
+    * ``avg_cpu_cores``      — cpu_core_hours / running_hours (avg busy cores)
+    * ``mem_byte_hours``     — integral of mem_bytes dt over running span
+    * ``avg_mem_bytes``      — mem_byte_hours / running_hours
+    * ``last_rootfs_bytes``  — most recent writable-layer size seen
+    * ``last_image_bytes``   — most recent image (virtual - rootfs, floored at 0)
+                               size seen
+    * ``last_ts``            — most recent sample timestamp (ISO string)
+    * ``sample_count``       — number of samples for this app
+
+    The gap threshold is ``GAP_INTERVAL_MULTIPLE * interval_seconds``; any
+    ``dt`` above it (server down / collector stopped) is excluded from billed
+    time, as is any non-positive ``dt`` (clock skew / duplicate sample).
+    """
+    if not interval_seconds or interval_seconds <= 0:
+        interval_seconds = DEFAULT_INTERVAL_SECONDS
+    gap_threshold = GAP_INTERVAL_MULTIPLE * interval_seconds
+
+    # Group samples first by app, then by container within the app. Integration
+    # is per-container (so consecutive samples of the SAME container bound a real
+    # interval); an app with several web.N instances sums each container's
+    # contribution. Grouping only by app would fabricate bogus intervals between
+    # interleaved samples of different containers.
+    by_app = {}
+    for sample in samples:
+        app = sample.get("app")
+        if not app:
+            continue
+        epoch = parse_ts(sample.get("ts"))
+        if epoch is None:
+            continue
+        container = sample.get("container") or app
+        by_app.setdefault(app, {}).setdefault(container, []).append((epoch, sample))
+
+    rows = []
+    for app in sorted(by_app):
+        running_seconds = 0.0
+        billed_seconds = 0.0
+        cpu_core_seconds = 0.0
+        mem_byte_seconds = 0.0
+        # Disk is a point-in-time size, not an integral: track the newest sample
+        # per container and sum the latest per-container sizes for the app.
+        last_rootfs_by_container = {}
+        last_image_by_container = {}
+        last_ts = None
+        last_ts_epoch = None
+        sample_count = 0
+
+        for container in sorted(by_app[app]):
+            entries = sorted(by_app[app][container], key=lambda item: item[0])
+            sample_count += len(entries)
+
+            for idx, (epoch, sample) in enumerate(entries):
+                if last_ts_epoch is None or epoch >= last_ts_epoch:
+                    last_ts_epoch = epoch
+                    last_ts = sample.get("ts")
+                rootfs = int(sample.get("rootfs_bytes") or 0)
+                image = int(sample.get("image_bytes") or 0)
+                last_rootfs_by_container[container] = rootfs
+                last_image_by_container[container] = image
+
+                if idx == 0:
+                    continue
+                prev_epoch, prev_sample = entries[idx - 1]
+                dt = epoch - prev_epoch
+                if dt <= 0:
+                    continue
+                if dt > gap_threshold:
+                    # Collector/server was down across this interval; don't bill it.
+                    continue
+                # Left-Riemann: attribute the interval to the previous sample's state.
+                billed_seconds += dt
+                if prev_sample.get("running"):
+                    running_seconds += dt
+                    cpu = parse_cpu_perc(prev_sample.get("cpu_perc"))
+                    cpu_core_seconds += (cpu / 100.0) * dt
+                    mem_byte_seconds += int(prev_sample.get("mem_bytes") or 0) * dt
+
+        last_rootfs = sum(last_rootfs_by_container.values())
+        last_image = sum(last_image_by_container.values())
+        running_hours = running_seconds / 3600.0
+        billed_hours = billed_seconds / 3600.0
+        cpu_core_hours = cpu_core_seconds / 3600.0
+        mem_byte_hours = mem_byte_seconds / 3600.0
+        uptime_pct = (100.0 * running_seconds / billed_seconds) if billed_seconds > 0 else 0.0
+        avg_cpu_cores = (cpu_core_seconds / running_seconds) if running_seconds > 0 else 0.0
+        avg_mem_bytes = (mem_byte_seconds / running_seconds) if running_seconds > 0 else 0.0
+
+        rows.append({
+            "app": app,
+            "running_hours": running_hours,
+            "billed_hours": billed_hours,
+            "uptime_pct": uptime_pct,
+            "cpu_core_hours": cpu_core_hours,
+            "avg_cpu_cores": avg_cpu_cores,
+            "mem_byte_hours": mem_byte_hours,
+            "avg_mem_bytes": avg_mem_bytes,
+            "last_rootfs_bytes": last_rootfs,
+            "last_image_bytes": last_image,
+            "last_ts": last_ts,
+            "sample_count": sample_count,
+        })
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Rates hook (stage 2) — not wired to any rates.json yet.
+# --------------------------------------------------------------------------- #
+
+def apply_rates(rows, rates=None):
+    """Attach a ``cost`` field to each row from a rates table (stage-2 hook).
+
+    ``rates`` is either ``None`` (no ``rates.json`` yet → every ``cost`` is
+    ``None``, rendered as an em dash) or a dict with per-unit prices:
+    ``{"cpu_core_hour": <float>, "mem_gib_hour": <float>, "image_gib": <float>,
+    "rootfs_gib": <float>}``. Missing keys are treated as ``0``. This lets
+    stage 2 turn on billing without touching ``aggregate`` or ``report``.
+
+    Returns the same list (rows mutated in place) for convenience.
+    """
+    for row in rows:
+        if not rates:
+            row["cost"] = None
+            continue
+        gib = float(1024 ** 3)
+        cpu_price = float(rates.get("cpu_core_hour", 0) or 0)
+        mem_price = float(rates.get("mem_gib_hour", 0) or 0)
+        image_price = float(rates.get("image_gib", 0) or 0)
+        rootfs_price = float(rates.get("rootfs_gib", 0) or 0)
+        cost = (
+            cpu_price * row.get("cpu_core_hours", 0.0)
+            + mem_price * (row.get("mem_byte_hours", 0.0) / gib)
+            + image_price * (row.get("last_image_bytes", 0) / gib)
+            + rootfs_price * (row.get("last_rootfs_bytes", 0) / gib)
+        )
+        row["cost"] = cost
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Report formatting.
+# --------------------------------------------------------------------------- #
+
+def _human_bytes(num):
+    """Format a byte count as a short human string (IEC units)."""
+    try:
+        num = float(num)
+    except (TypeError, ValueError):
+        return "0B"
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(num) < 1024.0 or unit == "TiB":
+            if unit == "B":
+                return "%dB" % int(num)
+            return "%.1f%s" % (num, unit)
+        num /= 1024.0
+    return "%.1fTiB" % num
+
+
+def _format_cost(cost):
+    if cost is None:
+        return "—"
+    return "%.2f" % cost
+
+
+def format_report_table(rows):
+    """Render aggregated (+ rated) rows as a fixed-width text table.
+
+    Columns: app / avg CPU (cores) / avg mem / disk (image+rootfs) / container-
+    hours / uptime% / COST. COST is an em dash until a rates.json exists.
+    """
+    headers = ["APP", "AVG CPU", "AVG MEM", "DISK", "CONT-HRS", "UPTIME%", "COST"]
+    table = []
+    for row in rows:
+        disk = row.get("last_image_bytes", 0) + row.get("last_rootfs_bytes", 0)
+        table.append([
+            str(row.get("app", "")),
+            "%.3f" % row.get("avg_cpu_cores", 0.0),
+            _human_bytes(row.get("avg_mem_bytes", 0.0)),
+            _human_bytes(disk),
+            "%.2f" % row.get("running_hours", 0.0),
+            "%.1f" % row.get("uptime_pct", 0.0),
+            _format_cost(row.get("cost")),
+        ])
+
+    widths = [len(h) for h in headers]
+    for line in table:
+        for i, cell in enumerate(line):
+            widths[i] = max(widths[i], len(cell))
+
+    def render(cells):
+        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells)).rstrip()
+
+    out = [render(headers)]
+    out.append("  ".join("-" * widths[i] for i in range(len(headers))).rstrip())
+    for line in table:
+        out.append(render(line))
+    return "\n".join(out)

--- a/tests/unit/test_clihost_billing_agg.py
+++ b/tests/unit/test_clihost_billing_agg.py
@@ -1,0 +1,267 @@
+"""Unit tests for the pure billing helpers (bin/clihost_billing_lib.py, #37).
+
+These exercise the parsers on the exact strings the Dokku server emits, the
+container-hours aggregation (left-Riemann + gap detection + running:false
+exclusion + multi-instance summing), the torn-JSONL-line tolerance, and the
+stage-2 rates hook / table formatting.
+"""
+import datetime
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BIN_DIR = REPO_ROOT / "bin"
+# The billing library lives in bin/, not app/ (conftest only wires app/).
+sys.path.insert(0, str(BIN_DIR))
+
+import clihost_billing_lib as lib  # noqa: E402
+
+
+def ts(minutes):
+    """Return an ISO-8601 Z timestamp `minutes` after a fixed base."""
+    base = datetime.datetime(2026, 7, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    return (base + datetime.timedelta(minutes=minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sample(app, minutes, running=True, cpu="10.00%", mem_bytes=1024 ** 3,
+           rootfs=1000, image=4661408563, container=None):
+    return {
+        "ts": ts(minutes),
+        "app": app,
+        "container": container or (app + ".web.1"),
+        "running": running,
+        "cpu_perc": cpu,
+        "mem_bytes": mem_bytes,
+        "rootfs_bytes": rootfs,
+        "image_bytes": image,
+    }
+
+
+class TestParsers(unittest.TestCase):
+    def test_parse_cpu_perc_real_string(self):
+        self.assertAlmostEqual(lib.parse_cpu_perc("9.28%"), 9.28)
+        self.assertAlmostEqual(lib.parse_cpu_perc("0.00%"), 0.0)
+        self.assertAlmostEqual(lib.parse_cpu_perc("125.4%"), 125.4)
+
+    def test_parse_cpu_perc_dashes_and_junk(self):
+        self.assertEqual(lib.parse_cpu_perc("--"), 0.0)
+        self.assertEqual(lib.parse_cpu_perc(""), 0.0)
+        self.assertEqual(lib.parse_cpu_perc(None), 0.0)
+        self.assertEqual(lib.parse_cpu_perc("garbage"), 0.0)
+
+    def test_parse_mem_usage_real_string(self):
+        used, limit = lib.parse_mem_usage("512.4MiB / 2GiB")
+        self.assertEqual(used, int(round(512.4 * 1024 ** 2)))
+        self.assertEqual(limit, 2 * 1024 ** 3)
+
+    def test_parse_mem_usage_edge(self):
+        self.assertEqual(lib.parse_mem_usage("--"), (0, 0))
+        self.assertEqual(lib.parse_mem_usage(None), (0, 0))
+        used, limit = lib.parse_mem_usage("1.5GiB / 7.6GiB")
+        self.assertEqual(used, int(round(1.5 * 1024 ** 3)))
+
+    def test_parse_size_field_real_string(self):
+        rootfs, virtual = lib.parse_size_field("2.54GB (virtual 5.73GB)")
+        self.assertEqual(rootfs, int(round(2.54 * 1000 ** 3)))
+        self.assertEqual(virtual, int(round(5.73 * 1000 ** 3)))
+
+    def test_parse_size_field_no_virtual(self):
+        rootfs, virtual = lib.parse_size_field("0B (virtual 4.34GB)")
+        self.assertEqual(rootfs, 0)
+        self.assertEqual(virtual, int(round(4.34 * 1000 ** 3)))
+
+    def test_parse_size_field_edge(self):
+        self.assertEqual(lib.parse_size_field("--"), (0, 0))
+        self.assertEqual(lib.parse_size_field(None), (0, 0))
+
+    def test_parse_ts_roundtrip(self):
+        epoch = lib.parse_ts("2026-07-09T12:00:00Z")
+        self.assertIsNotNone(epoch)
+        epoch2 = lib.parse_ts("2026-07-09T12:05:00Z")
+        self.assertAlmostEqual(epoch2 - epoch, 300)
+
+    def test_parse_ts_junk(self):
+        self.assertIsNone(lib.parse_ts("not-a-date"))
+        self.assertIsNone(lib.parse_ts(""))
+        self.assertIsNone(lib.parse_ts(None))
+
+
+class TestAggregate(unittest.TestCase):
+    def test_basic_running_hours_left_riemann(self):
+        # Three samples 5 min apart at 100% CPU (1 core), 1 GiB mem.
+        samples = [
+            sample("clihost-a", 0, cpu="100.00%", mem_bytes=1024 ** 3),
+            sample("clihost-a", 5, cpu="100.00%", mem_bytes=1024 ** 3),
+            sample("clihost-a", 10, cpu="100.00%", mem_bytes=1024 ** 3),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        # Two 5-min intervals = 10 min = 1/6 hour billed running.
+        self.assertAlmostEqual(row["running_hours"], 10 / 60.0, places=6)
+        self.assertAlmostEqual(row["billed_hours"], 10 / 60.0, places=6)
+        self.assertAlmostEqual(row["uptime_pct"], 100.0, places=6)
+        # 100% CPU = 1 core on average.
+        self.assertAlmostEqual(row["avg_cpu_cores"], 1.0, places=6)
+        self.assertAlmostEqual(row["avg_mem_bytes"], float(1024 ** 3), places=1)
+
+    def test_gap_interval_is_excluded(self):
+        # A dt of 20 min with interval 300s (5 min) exceeds 2.5x -> excluded.
+        samples = [
+            sample("clihost-a", 0, cpu="100.00%"),
+            sample("clihost-a", 5, cpu="100.00%"),   # +5 min: billed
+            sample("clihost-a", 25, cpu="100.00%"),  # +20 min gap: excluded
+            sample("clihost-a", 30, cpu="100.00%"),  # +5 min: billed
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        row = rows[0]
+        # Only two 5-min intervals count; the 20-min gap is dropped.
+        self.assertAlmostEqual(row["running_hours"], 10 / 60.0, places=6)
+
+    def test_running_false_excluded_from_running_hours_but_billed(self):
+        # Left sample stopped -> interval is billed (denominator) but not running.
+        samples = [
+            sample("clihost-a", 0, running=False, cpu="0.00%"),
+            sample("clihost-a", 5, running=True, cpu="100.00%"),
+            sample("clihost-a", 10, running=True, cpu="100.00%"),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        row = rows[0]
+        # First interval (left=stopped): billed, not running.
+        # Second interval (left=running): billed and running.
+        self.assertAlmostEqual(row["billed_hours"], 10 / 60.0, places=6)
+        self.assertAlmostEqual(row["running_hours"], 5 / 60.0, places=6)
+        self.assertAlmostEqual(row["uptime_pct"], 50.0, places=6)
+
+    def test_non_positive_dt_skipped(self):
+        # Duplicate timestamps / clock skew must not create negative or zero dt.
+        samples = [
+            sample("clihost-a", 0, cpu="100.00%"),
+            sample("clihost-a", 0, cpu="100.00%"),  # dt == 0 -> skipped
+            sample("clihost-a", 5, cpu="100.00%"),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        row = rows[0]
+        self.assertAlmostEqual(row["running_hours"], 5 / 60.0, places=6)
+
+    def test_multi_instance_summing(self):
+        # Two containers of the same app run in parallel: their running-hours sum,
+        # and their per-container intervals are NOT interleaved into fake ones.
+        samples = [
+            sample("clihost-a", 0, cpu="100.00%", container="clihost-a.web.1"),
+            sample("clihost-a", 5, cpu="100.00%", container="clihost-a.web.1"),
+            sample("clihost-a", 0, cpu="100.00%", container="clihost-a.web.2"),
+            sample("clihost-a", 5, cpu="100.00%", container="clihost-a.web.2"),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        # Each container contributes one 5-min interval -> 10 min total.
+        self.assertAlmostEqual(row["running_hours"], 10 / 60.0, places=6)
+        # 2 cores busy across both -> 2 core-hours' worth per elapsed hour;
+        # avg_cpu_cores = cpu_core_seconds / running_seconds = 1.0 per container.
+        self.assertAlmostEqual(row["avg_cpu_cores"], 1.0, places=6)
+
+    def test_multi_instance_disk_sums_latest_per_container(self):
+        samples = [
+            sample("clihost-a", 0, container="clihost-a.web.1", rootfs=100, image=1000),
+            sample("clihost-a", 5, container="clihost-a.web.1", rootfs=150, image=1000),
+            sample("clihost-a", 5, container="clihost-a.web.2", rootfs=200, image=2000),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        row = rows[0]
+        # Latest per container: web.1 rootfs=150 image=1000, web.2 rootfs=200 image=2000.
+        self.assertEqual(row["last_rootfs_bytes"], 350)
+        self.assertEqual(row["last_image_bytes"], 3000)
+
+    def test_multiple_apps_sorted(self):
+        samples = [
+            sample("clihost-b", 0), sample("clihost-b", 5),
+            sample("clihost-a", 0), sample("clihost-a", 5),
+        ]
+        rows = lib.aggregate(samples, interval_seconds=300)
+        self.assertEqual([r["app"] for r in rows], ["clihost-a", "clihost-b"])
+
+    def test_single_sample_has_no_billed_time(self):
+        rows = lib.aggregate([sample("clihost-a", 0)], interval_seconds=300)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["running_hours"], 0.0)
+        self.assertEqual(rows[0]["billed_hours"], 0.0)
+        self.assertEqual(rows[0]["uptime_pct"], 0.0)
+
+    def test_empty_input(self):
+        self.assertEqual(lib.aggregate([]), [])
+
+
+class TestIterSamples(unittest.TestCase):
+    def test_torn_jsonl_line_is_skipped(self):
+        lines = [
+            '{"ts":"2026-07-09T12:00:00Z","app":"clihost-a","running":true}',
+            '{"ts":"2026-07-09T12:05:00Z","app":"clihost-a"',  # torn/truncated
+            '',
+            '   ',
+            'not json at all',
+            '{"ts":"2026-07-09T12:10:00Z","app":"clihost-a","running":true}',
+        ]
+        parsed = list(lib.iter_samples(lines))
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["ts"], "2026-07-09T12:00:00Z")
+        self.assertEqual(parsed[1]["ts"], "2026-07-09T12:10:00Z")
+
+    def test_non_dict_json_skipped(self):
+        parsed = list(lib.iter_samples(["[1,2,3]", '"a string"', "42"]))
+        self.assertEqual(parsed, [])
+
+
+class TestApplyRates(unittest.TestCase):
+    def test_no_rates_yields_none_cost(self):
+        rows = lib.aggregate(
+            [sample("clihost-a", 0), sample("clihost-a", 5)],
+            interval_seconds=300,
+        )
+        lib.apply_rates(rows, rates=None)
+        self.assertIsNone(rows[0]["cost"])
+
+    def test_rates_compute_cost(self):
+        rows = [{
+            "cpu_core_hours": 2.0,
+            "mem_byte_hours": float(1024 ** 3),  # 1 GiB-hour
+            "last_image_bytes": 2 * 1024 ** 3,   # 2 GiB
+            "last_rootfs_bytes": 1024 ** 3,      # 1 GiB
+        }]
+        lib.apply_rates(rows, rates={
+            "cpu_core_hour": 1.0,
+            "mem_gib_hour": 0.5,
+            "image_gib": 0.1,
+            "rootfs_gib": 0.2,
+        })
+        # 2*1 + 1*0.5 + 2*0.1 + 1*0.2 = 2 + 0.5 + 0.2 + 0.2 = 2.9
+        self.assertAlmostEqual(rows[0]["cost"], 2.9, places=6)
+
+
+class TestFormatReportTable(unittest.TestCase):
+    def test_table_has_headers_and_em_dash_cost_without_rates(self):
+        rows = lib.aggregate(
+            [sample("clihost-a", 0, cpu="100.00%"), sample("clihost-a", 5, cpu="100.00%")],
+            interval_seconds=300,
+        )
+        lib.apply_rates(rows, rates=None)
+        table = lib.format_report_table(rows)
+        self.assertIn("APP", table)
+        self.assertIn("AVG CPU", table)
+        self.assertIn("UPTIME%", table)
+        self.assertIn("COST", table)
+        self.assertIn("clihost-a", table)
+        # COST column is an em dash when there is no rates.json.
+        self.assertIn("—", table)
+
+    def test_table_empty_rows_is_just_headers(self):
+        table = lib.format_report_table([])
+        # Header line + separator line, no data rows.
+        self.assertEqual(len(table.splitlines()), 2)
+        self.assertIn("APP", table)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -19,6 +19,8 @@ GLM = REPO_ROOT / "bin/glm"
 CLAUDE_AUTH_SNAPSHOT = REPO_ROOT / "bin/claude-auth-snapshot.sh"
 CLAUDE_AUTH_SNAPSHOT_HOST = REPO_ROOT / "bin/claude-auth-snapshot-host.sh"
 CLIHOST_SYNC = REPO_ROOT / "bin/clihost-sync.sh"
+CLIHOST_BILLING = REPO_ROOT / "bin/clihost-billing.sh"
+CLIHOST_BILLING_LIB = REPO_ROOT / "bin/clihost_billing_lib.py"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 CLAUDE_SETTINGS_TEMPLATE = REPO_ROOT / "config/claude-settings.json"
@@ -50,6 +52,7 @@ class TestShellSyntax(unittest.TestCase):
             CLAUDE_AUTH_SNAPSHOT,
             CLAUDE_AUTH_SNAPSHOT_HOST,
             CLIHOST_SYNC,
+            CLIHOST_BILLING,
         ):
             with self.subTest(script=script.name):
                 result = subprocess.run(
@@ -2463,6 +2466,265 @@ class TestEnvExampleDocumentsRuntimeVars(unittest.TestCase):
                 re.compile(rf"^#?\s*{re.escape(var)}=", re.MULTILINE),
                 f"{var} is read by the code but not documented in .env.example",
             )
+
+
+class TestClihostBillingScript(unittest.TestCase):
+    """Host-side billing dispatcher contract (issue #37, PR1 + PR2).
+
+    Static invariants + an end-to-end `report`/`raw`/`collect` run against a
+    synthetic JSONL store and fake docker/flock binaries, so the tool is proven
+    without a Dokku host, root, or Docker.
+    """
+
+    def setUp(self):
+        self.text = CLIHOST_BILLING.read_text()
+
+    # --- static invariants ------------------------------------------------- #
+
+    def test_uses_strict_bash_mode(self):
+        self.assertTrue(self.text.startswith("#!/bin/bash\nset -euo pipefail\n"))
+
+    def test_is_host_only_not_copied_into_image(self):
+        # Like claude-auth-snapshot-host.sh: the billing tool must NOT be COPY'd
+        # into the image (inside the container it has no docker.sock and is unsafe).
+        dockerfile = DOCKERFILE.read_text()
+        self.assertNotIn("clihost-billing.sh", dockerfile)
+        self.assertNotIn("clihost_billing_lib.py", dockerfile)
+
+    def test_storage_under_configurable_billing_dir(self):
+        self.assertIn(': "${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}"', self.text)
+        self.assertIn('SAMPLES_DIR="${CLIHOST_BILLING_DIR}/samples"', self.text)
+        self.assertIn('STATE_DIR="${CLIHOST_BILLING_DIR}/state"', self.text)
+
+    def _code_lines(self):
+        # Non-comment, non-blank lines only (a mention of `sudo`/`crontab` in a
+        # comment or printed heredoc instruction is fine; an executable call is
+        # not). This is a coarse filter — heredoc bodies also survive it — so the
+        # callers additionally scope what they assert.
+        return [
+            line for line in self.text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+
+    def test_collect_uses_docker_not_du(self):
+        # HDD is measured via docker ps -s / images, never sudo du (dokku can't
+        # read the root storage mount, and sudo needs a password).
+        self.assertIn("docker stats --no-stream", self.text)
+        self.assertIn("docker ps -a -s", self.text)
+        self.assertNotIn("du -s", self.text)
+        # `sudo` must never be executed (it may appear in a comment explaining
+        # why it is avoided; those lines are filtered out).
+        for line in self._code_lines():
+            self.assertNotRegex(line, re.compile(r'(^|[|;&(`$]\s*)sudo\b'))
+
+    def test_collect_serialized_with_flock(self):
+        self.assertIn("flock -n 9", self.text)
+        self.assertIn('LOCK_FILE="${STATE_DIR}/collect.lock"', self.text)
+
+    def test_cron_line_does_not_auto_install(self):
+        # cron-line only PRINTS a crontab line; it must never EXECUTE `crontab`
+        # (the string "crontab -e" appears only inside the printed heredoc as an
+        # instruction to the operator). Assert no code line invokes crontab as a
+        # command.
+        for line in self._code_lines():
+            self.assertNotRegex(line, re.compile(r'(^|[|;&(`$]\s*)crontab\b'))
+        self.assertIn("crontab -e", self.text)  # printed instruction only
+
+    def test_python_is_stdlib_only(self):
+        # The library must not import any third-party package.
+        lib_text = CLIHOST_BILLING_LIB.read_text()
+        self.assertNotRegex(lib_text, re.compile(r'^\s*import\s+(requests|jq|yaml|numpy)', re.MULTILINE))
+        # Only stdlib imports are expected.
+        self.assertIn("import json", lib_text)
+        self.assertIn("import datetime", lib_text)
+
+    # --- end-to-end runs --------------------------------------------------- #
+
+    def _run(self, args, billing_dir, extra_path=None, env_extra=None):
+        env = dict(os.environ)
+        env["CLIHOST_BILLING_DIR"] = str(billing_dir)
+        if extra_path:
+            env["PATH"] = f"{extra_path}{os.pathsep}{env['PATH']}"
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            ["bash", str(CLIHOST_BILLING), *args],
+            capture_output=True, text=True, env=env,
+        )
+
+    def _write_samples(self, billing_dir, lines):
+        samples_dir = billing_dir / "samples"
+        samples_dir.mkdir(parents=True, exist_ok=True)
+        (samples_dir / "2026-07.jsonl").write_text("\n".join(lines) + "\n")
+
+    def test_help_exits_nonzero_only_when_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self._run(["help"], pathlib.Path(tmp))
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("Usage", out.stderr)
+            # No subcommand => usage + exit 2.
+            out2 = self._run([], pathlib.Path(tmp))
+            self.assertEqual(out2.returncode, 2)
+
+    def test_unknown_subcommand_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self._run(["bogus"], pathlib.Path(tmp))
+            self.assertNotEqual(out.returncode, 0)
+            self.assertIn("unknown subcommand", out.stderr)
+
+    def test_cron_line_prints_collector_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self._run(["cron-line"], pathlib.Path(tmp))
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("collect", out.stdout)
+            self.assertRegex(out.stdout, r"\*/\d+ \* \* \* \*")
+            self.assertIn("crontab -e", out.stdout)
+
+    def test_report_on_synthetic_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            billing_dir = pathlib.Path(tmp)
+            self._write_samples(billing_dir, [
+                '{"ts":"2026-07-09T12:00:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"100.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+                '{"ts":"2026-07-09T12:05:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"100.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+                '{"ts":"2026-07-09T12:00:00Z","app":"clihost-work1nw","container":"clihost-work1nw.web.1","running":true,"cpu_perc":"50.00%","mem_bytes":536870912,"rootfs_bytes":500,"image_bytes":4661408563}',
+                '{"ts":"2026-07-09T12:05:00Z","app":"clihost-work1nw","container":"clihost-work1nw.web.1","running":true,"cpu_perc":"50.00%","mem_bytes":536870912,"rootfs_bytes":500,"image_bytes":4661408563}',
+                'this is a torn line that must be skipped {',
+            ])
+            out = self._run(["report"], billing_dir)
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("clihost-axisrow", out.stdout)
+            self.assertIn("clihost-work1nw", out.stdout)
+            self.assertIn("APP", out.stdout)
+            self.assertIn("COST", out.stdout)
+            # No rates.json => COST is an em dash.
+            self.assertIn("—", out.stdout)
+
+    def test_report_json_and_raw_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            billing_dir = pathlib.Path(tmp)
+            self._write_samples(billing_dir, [
+                '{"ts":"2026-07-09T12:00:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"100.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+                '{"ts":"2026-07-09T12:05:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"100.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+            ])
+            out = self._run(["report", "--json"], billing_dir)
+            self.assertEqual(out.returncode, 0, out.stderr)
+            payload = json.loads(out.stdout)
+            self.assertIn("rows", payload)
+            self.assertEqual(payload["rows"][0]["app"], "clihost-axisrow")
+            self.assertIsNone(payload["rows"][0]["cost"])
+            # `raw` is `report --json`.
+            out_raw = self._run(["raw"], billing_dir)
+            self.assertEqual(out_raw.returncode, 0, out_raw.stderr)
+            self.assertEqual(json.loads(out_raw.stdout), payload)
+
+    def test_report_warns_when_collector_stale(self):
+        # Samples with an old timestamp (> 2x interval old) must trigger the
+        # "collector likely not running" warning on stderr.
+        with tempfile.TemporaryDirectory() as tmp:
+            billing_dir = pathlib.Path(tmp)
+            self._write_samples(billing_dir, [
+                '{"ts":"2020-01-01T00:00:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"10.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+                '{"ts":"2020-01-01T00:05:00Z","app":"clihost-axisrow","container":"clihost-axisrow.web.1","running":true,"cpu_perc":"10.00%","mem_bytes":1073741824,"rootfs_bytes":1000,"image_bytes":4661408563}',
+            ])
+            out = self._run(["report"], billing_dir)
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("collector likely not running", out.stderr)
+
+    def test_report_no_samples_is_graceful(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self._run(["report"], pathlib.Path(tmp))
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("no samples yet", out.stderr)
+
+    def _make_fake_docker(self, tmp_path):
+        # A fake `docker` that answers stats/ps/inspect for two clihost apps.
+        fake_docker = tmp_path / "docker"
+        fake_docker.write_text(r'''#!/bin/bash
+sub="$1"; shift
+case "$sub" in
+  stats)
+    echo '{"Name":"clihost-axisrow.web.1","CPUPerc":"9.28%","MemUsage":"512.4MiB / 2GiB"}'
+    ;;
+  ps)
+    # Two shapes: `ps -a -s --format ...` (the size query) and
+    # `ps -a --filter name=... --format {{.Names}}` (the inspect name list).
+    if [[ "$*" == *"{{.Names}}"* ]]; then
+      echo "clihost-axisrow.web.1"
+      echo "clihost-work1nw.web.1"
+    else
+      echo '{"Names":"clihost-axisrow.web.1","Image":"clihost","Size":"2.54GB (virtual 5.73GB)","State":"running"}'
+      echo '{"Names":"clihost-work1nw.web.1","Image":"clihost","Size":"0B (virtual 4.34GB)","State":"exited"}'
+    fi
+    ;;
+  inspect)
+    name="${!#}"
+    if [[ "$name" == *axisrow* ]]; then
+      echo '{"name":"/clihost-axisrow.web.1","restart_count":0,"status":"running","exit_code":0,"oom_killed":false}'
+    else
+      echo '{"name":"/clihost-work1nw.web.1","restart_count":2,"status":"exited","exit_code":137,"oom_killed":true}'
+    fi
+    ;;
+esac
+''')
+        fake_docker.chmod(0o755)
+        # A fake `flock` (absent on macOS) that just succeeds.
+        fake_flock = tmp_path / "flock"
+        fake_flock.write_text("#!/bin/bash\nexit 0\n")
+        fake_flock.chmod(0o755)
+        return fake_docker
+
+    def test_collect_builds_samples_from_docker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            billing_dir = tmp_path / "billing"
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            self._make_fake_docker(bin_dir)
+
+            out = self._run(["collect"], billing_dir, extra_path=str(bin_dir))
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("collected 2 sample(s)", out.stdout)
+
+            samples = list((billing_dir / "samples").glob("*.jsonl"))
+            self.assertEqual(len(samples), 1)
+            lines = [
+                json.loads(line)
+                for line in samples[0].read_text().splitlines() if line.strip()
+            ]
+            self.assertEqual(len(lines), 2)
+            by_app = {s["app"]: s for s in lines}
+            self.assertIn("clihost-axisrow", by_app)
+            self.assertIn("clihost-work1nw", by_app)
+            # Running app: cpu/mem parsed; disk = image (virtual - rootfs).
+            axi = by_app["clihost-axisrow"]
+            self.assertTrue(axi["running"])
+            self.assertGreater(axi["mem_bytes"], 0)
+            self.assertEqual(axi["rootfs_bytes"], int(round(2.54 * 1000 ** 3)))
+            self.assertEqual(
+                axi["image_bytes"],
+                int(round(5.73 * 1000 ** 3)) - int(round(2.54 * 1000 ** 3)),
+            )
+            # Stopped app: running false, no cpu billed, oom flag carried.
+            work = by_app["clihost-work1nw"]
+            self.assertFalse(work["running"])
+            self.assertEqual(work["cpu_perc"], 0.0)
+            self.assertTrue(work["oom_killed"])
+            self.assertEqual(work["restart_count"], 2)
+
+    def test_collect_then_report_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            billing_dir = tmp_path / "billing"
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            self._make_fake_docker(bin_dir)
+            # Two collects (the timestamps are the same wall-clock second in a
+            # fast test, so this mainly proves the pipeline runs; report still
+            # renders a table without error).
+            self._run(["collect"], billing_dir, extra_path=str(bin_dir))
+            out = self._run(["report"], billing_dir)
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("clihost-axisrow", out.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Foundation for host-side usage billing of clihost apps on a Dokku host (issue #37) — **PR1 + PR2 only** (accounting + report). A **host-only** tool pair (like `claude-auth-snapshot-host.sh`), never copied into the image; runs as the `dokku` user, which is in the `docker` group and can call `docker stats/ps -s/inspect` **without sudo**.

- **`bin/clihost-billing.sh`** — bash dispatcher (`set -euo pipefail`, `die`/`usage`/`main`+`case`). Subcommands:
  - `collect` — sample every `clihost-*` container once (cron-driven, `flock`-serialized, appends JSONL).
  - `cron-line` — print a ready-to-paste `crontab` line (operator installs it manually; never auto-installed).
  - `report [--json]` / `raw` — aggregated per-app table (avg CPU cores / avg mem / disk / container-hours / uptime% / COST).
  - `help`.
- **`bin/clihost_billing_lib.py`** — stdlib-only parsers + aggregation + formatting (extracted so it's unit-tested without root/Docker). Container-hours are **left-Riemann** integrated over the actual `dt` per container, with gap detection (`dt > 2.5 × interval` → excluded) and `dt ≤ 0` skip; `running:false` samples count toward uptime% denominator but not billable running hours; disk is a point-in-time size. `apply_rates` is a stage-2 hook — no `rates.json` yet → COST renders as `—`.
- **Data sources**: `docker stats` (CPU/Mem), `docker ps -a -s` writable-layer `Size` (`rootfs` + `virtual`→`image`), `docker inspect` (RestartCount/Status/ExitCode/OOMKilled). No `sudo`, no `du`, no `jq`/`sqlite3`.
- **Storage**: append-only JSONL under `${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}` (`samples/YYYY-MM.jsonl`, `state/collect.lock`, `state/last-collect.json`).

## Environment variables (new)

- `CLIHOST_BILLING_DIR` — storage root (default `/home/dokku/.clihost-billing`).
- `CLIHOST_BILLING_INTERVAL` — collector cadence in seconds (default `300`; also the gap-detection base).
- `CLIHOST_APP_PREFIX` — container/app prefix to account (default `clihost-`).

These are host-only runtime knobs for the billing tool (not container env), so `.env.example` is intentionally untouched; documented in the new CLAUDE.md section.

## Ports / volumes

None. `Dockerfile` is not touched — the tool is host-only and never enters the image.

## Tests

- `tests/unit/test_clihost_billing_agg.py` (new, 24 tests): parsers on real server strings, left-Riemann, gap exclusion, `running:false` exclusion, non-positive `dt`, multi-instance summing, torn JSONL line, rates hook, table formatting.
- `TestClihostBillingScript` added to `tests/unit/test_shell_scripts.py`: static invariants (host-only, no-sudo/no-du, flock, cron-line-never-auto-installs, stdlib-only) + end-to-end `report`/`raw`/`collect`→`report` with fake `docker`/`flock`.
- `python -m pytest tests/unit/test_clihost_billing_agg.py tests/unit/test_shell_scripts.py` → **187 passed**; `bash -n bin/clihost-billing.sh` → OK.

## Follow-ups (not in this PR)

`diagnose`/`restart` (#37.2), `gc-mounts` (#37.3), `idle-sleep` (#37.4), and stage 2 (tariffs/invoices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)