### PR TITLE
feat: clihost-billing diagnose + restart (#37.2)

### DIFF
--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 #   cron-line   print a ready-to-paste crontab line (operator installs it).
 #   report      render an aggregated usage table (per app).
 #   raw         emit aggregated rows as JSON (machine-readable).
+#   diagnose    inspect the current container state and print a verdict.
+#   restart     safely restart one clihost app (dry-run by default).
 #   help        usage.
 #
 # Storage is append-only JSONL under ${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}:
@@ -48,6 +50,10 @@ Usage:
   clihost-billing.sh cron-line          print a crontab line to install the collector
   clihost-billing.sh report [--json]    aggregated usage table (per app)
   clihost-billing.sh raw                aggregated rows as JSON (alias for report --json)
+  clihost-billing.sh diagnose [--app] APP
+                                            inspect APP.web.1 (read-only)
+  clihost-billing.sh restart APP [--apply] [--yes]
+                                            restart APP (dry-run by default)
   clihost-billing.sh help               this message
 
 Environment:
@@ -65,6 +71,22 @@ require_python() {
 
 require_docker() {
   command -v docker >/dev/null 2>&1 || die "docker CLI not found"
+}
+
+validate_app_name() {
+  local app="$1"
+  [[ "${app}" =~ ^clihost-[a-z0-9_-]+$ ]] \
+    || die "invalid app name '${app}'; expected ^clihost-[a-z0-9_-]+$"
+}
+
+require_app_container() {
+  local app="$1"
+  local container="${app}.web.1"
+
+  validate_app_name "${app}"
+  require_docker
+  docker ps --format '{{.Names}}' | grep -Fqx -- "${container}" \
+    || die "container is not running or not found in docker ps: ${container}"
 }
 
 ensure_dirs() {
@@ -340,6 +362,100 @@ else:
 PY
 }
 
+# diagnose: read Docker state only; never restart or otherwise mutate it.
+cmd_diagnose() {
+  local app=""
+  case "$#:${1:-}" in
+    1:*) app="$1" ;;
+    2:--app) app="$2" ;;
+    *) die "diagnose requires [--app] APP" ;;
+  esac
+
+  validate_app_name "${app}"
+  require_docker
+  command -v python3 >/dev/null 2>&1 || die "python3 not found"
+
+  local container="${app}.web.1"
+  local restart_count status exit_code oom_killed state_error started_at finished_at
+  restart_count="$(docker inspect --format '{{.RestartCount}}' -- "${container}")"
+  status="$(docker inspect --format '{{.State.Status}}' -- "${container}")"
+  exit_code="$(docker inspect --format '{{.State.ExitCode}}' -- "${container}")"
+  oom_killed="$(docker inspect --format '{{.State.OOMKilled}}' -- "${container}")"
+  state_error="$(docker inspect --format '{{.State.Error}}' -- "${container}")"
+  started_at="$(docker inspect --format '{{.State.StartedAt}}' -- "${container}")"
+  finished_at="$(docker inspect --format '{{.State.FinishedAt}}' -- "${container}")"
+
+  CLIHOST_DIAG_CONTAINER="${container}" \
+  CLIHOST_DIAG_RESTART_COUNT="${restart_count}" \
+  CLIHOST_DIAG_STATUS="${status}" \
+  CLIHOST_DIAG_EXIT_CODE="${exit_code}" \
+  CLIHOST_DIAG_OOM_KILLED="${oom_killed}" \
+  CLIHOST_DIAG_ERROR="${state_error}" \
+  CLIHOST_DIAG_STARTED_AT="${started_at}" \
+  CLIHOST_DIAG_FINISHED_AT="${finished_at}" \
+  python3 <<'PY'
+import os
+
+restart_count = int(os.environ["CLIHOST_DIAG_RESTART_COUNT"])
+status = os.environ["CLIHOST_DIAG_STATUS"]
+oom_killed = os.environ["CLIHOST_DIAG_OOM_KILLED"].lower() == "true"
+
+print("Container: " + os.environ["CLIHOST_DIAG_CONTAINER"])
+print("RestartCount: " + str(restart_count))
+print("State.Status: " + status)
+print("State.ExitCode: " + os.environ["CLIHOST_DIAG_EXIT_CODE"])
+print("State.OOMKilled: " + str(oom_killed).lower())
+print("State.Error: " + os.environ["CLIHOST_DIAG_ERROR"])
+print("State.StartedAt: " + os.environ["CLIHOST_DIAG_STARTED_AT"])
+print("State.FinishedAt: " + os.environ["CLIHOST_DIAG_FINISHED_AT"])
+
+if oom_killed:
+    print("Verdict: OOM: поднять mem limit (dokku resource:limit --memory N)")
+elif restart_count > 0 and status == "exited":
+    print("Verdict: crash-loop: dokku logs APP --tail")
+elif status == "running" and restart_count == 0:
+    print("Verdict: healthy")
+else:
+    print("Verdict: needs investigation")
+PY
+}
+
+cmd_restart() {
+  local app=""
+  local apply="false"
+  local yes="false"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --apply) apply="true" ;;
+      --yes) yes="true" ;;
+      --) shift; break ;;
+      -*) die "unknown option: $1" ;;
+      *)
+        [ -z "${app}" ] || die "restart accepts exactly one APP"
+        app="$1"
+        ;;
+    esac
+    shift
+  done
+  [ "$#" -eq 0 ] || die "restart accepts exactly one APP"
+  [ -n "${app}" ] || die "restart requires APP"
+
+  require_app_container "${app}"
+  if [ "${apply}" != "true" ]; then
+    echo "would run: dokku ps:restart ${app}"
+    return 0
+  fi
+  if [ ! -t 0 ] && [ "${yes}" != "true" ]; then
+    die "restart --apply in non-TTY mode requires --yes"
+  fi
+
+  if command -v dokku >/dev/null 2>&1 && dokku ps:restart "${app}"; then
+    return 0
+  fi
+  docker restart -- "${app}.web.1"
+}
+
 main() {
   local command="${1:-}"
   case "${command}" in
@@ -359,6 +475,14 @@ main() {
       shift
       [ "$#" -eq 0 ] || die "raw accepts no arguments"
       cmd_report --json
+      ;;
+    diagnose)
+      shift
+      cmd_diagnose "$@"
+      ;;
+    restart)
+      shift
+      cmd_restart "$@"
       ;;
     -h|--help|help)
       usage

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -2673,6 +2673,126 @@ esac
         fake_flock.chmod(0o755)
         return fake_docker
 
+    def _make_billing_control_fakes(self, tmp_path):
+        log = tmp_path / "commands.log"
+        log.write_text("")
+        fake_docker = tmp_path / "docker"
+        fake_docker.write_text(r'''#!/bin/bash
+printf 'docker' >> "${CLIHOST_TEST_LOG}"
+printf ' %q' "$@" >> "${CLIHOST_TEST_LOG}"
+printf '\n' >> "${CLIHOST_TEST_LOG}"
+
+case "${1:-}" in
+  ps)
+    echo "clihost-good.web.1"
+    ;;
+  inspect)
+    case "$3" in
+      '{{.RestartCount}}') echo "0" ;;
+      '{{.State.Status}}') echo "running" ;;
+      '{{.State.ExitCode}}') echo "0" ;;
+      '{{.State.OOMKilled}}') echo "false" ;;
+      '{{.State.Error}}') echo "" ;;
+      '{{.State.StartedAt}}') echo "2026-07-23T10:00:00Z" ;;
+      '{{.State.FinishedAt}}') echo "0001-01-01T00:00:00Z" ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  restart)
+    echo "clihost-good.web.1"
+    ;;
+esac
+''')
+        fake_docker.chmod(0o755)
+        fake_dokku = tmp_path / "dokku"
+        fake_dokku.write_text(r'''#!/bin/bash
+printf 'dokku' >> "${CLIHOST_TEST_LOG}"
+printf ' %q' "$@" >> "${CLIHOST_TEST_LOG}"
+printf '\n' >> "${CLIHOST_TEST_LOG}"
+''')
+        fake_dokku.chmod(0o755)
+        return log
+
+    def test_diagnose_is_read_only_and_prints_healthy_verdict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            out = self._run(
+                ["diagnose", "--app", "clihost-good"],
+                tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_TEST_LOG": str(log)},
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("RestartCount: 0", out.stdout)
+            self.assertIn("State.Status: running", out.stdout)
+            self.assertIn("Verdict: healthy", out.stdout)
+            commands = log.read_text()
+            self.assertIn("docker inspect", commands)
+            self.assertNotIn("restart", commands)
+            self.assertNotIn("dokku", commands)
+
+    def test_restart_defaults_to_dry_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            out = self._run(
+                ["restart", "clihost-good"], tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_TEST_LOG": str(log)},
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertEqual(
+                out.stdout.strip(), "would run: dokku ps:restart clihost-good"
+            )
+            self.assertNotIn("restart", log.read_text())
+
+    def test_restart_fails_closed_for_foreign_or_invalid_app(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            env = {"CLIHOST_TEST_LOG": str(log)}
+            for app in ("clihost-missing", "foreign-app"):
+                with self.subTest(app=app):
+                    out = self._run(
+                        ["restart", app], tmp_path / "billing",
+                        extra_path=str(tmp_path), env_extra=env,
+                    )
+                    self.assertNotEqual(out.returncode, 0)
+            self.assertNotIn("restart", log.read_text())
+
+    def test_restart_rejects_option_injection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            out = self._run(
+                ["restart", "--", "--help"], tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_TEST_LOG": str(log)},
+            )
+            self.assertNotEqual(out.returncode, 0)
+            self.assertNotIn("restart", log.read_text())
+
+    def test_restart_apply_requires_yes_in_non_tty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            env = {"CLIHOST_TEST_LOG": str(log)}
+            refused = self._run(
+                ["restart", "clihost-good", "--apply"], tmp_path / "billing",
+                extra_path=str(tmp_path), env_extra=env,
+            )
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("non-TTY mode requires --yes", refused.stderr)
+            self.assertNotIn("dokku", log.read_text())
+
+            applied = self._run(
+                ["restart", "clihost-good", "--apply", "--yes"],
+                tmp_path / "billing", extra_path=str(tmp_path), env_extra=env,
+            )
+            self.assertEqual(applied.returncode, 0, applied.stderr)
+            self.assertIn("dokku ps:restart clihost-good", log.read_text())
+
     def test_collect_builds_samples_from_docker(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)


### PR DESCRIPTION
## Summary

- `diagnose` performs read-only Docker inspection and reports OOM, crash-loop, or healthy verdicts.
- `restart` is dry-run by default, supports `--apply`/`--yes`, and fails closed with a strict app-name guard against option injection.
- Extended shell regression coverage; 168 tests pass.

Closes part of #37

Generated with Claude Code.