### PR TITLE
feat: add orphan storage cleanup (#37.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,9 +306,8 @@ over-engineering until the manual contract proves insufficient.
 unsafe (no `docker.sock`). They live on the Dokku host (e.g. `/home/dokku/bin/`)
 and run as the `dokku` user, who is in the `docker` group and can therefore call
 `docker stats/ps -s/inspect` **without sudo** (`sudo` needs a password and is
-unavailable). This is the accounting foundation for issue #37 (PR1 + PR2:
-collect + report); the operational subcommands (`diagnose`/`restart`,
-`gc-mounts`, `idle-sleep`) and stage 2 (tariffs/invoices) are follow-up PRs.
+unavailable). This is the accounting and operational foundation for issue #37;
+`idle-sleep` and stage 2 (tariffs/invoices) remain follow-up work.
 
 The bash file is a thin dispatcher (`set -euo pipefail`, `die`/`usage`/`main`
 +`case`, one docker/I-O owner); all pure logic (parsers + aggregation +
@@ -322,9 +321,12 @@ static+end-to-end checks in `tests/unit/test_shell_scripts.py`). No `jq`/`sqlite
 | Subcommand | Purpose |
 |---|---|
 | `collect` | Sample every `clihost-*` container once (cron-driven). Idempotent, `flock`-serialized, appends JSONL. |
-| `cron-line` | Print a ready-to-paste `crontab` line — the operator installs it manually (`crontab -e` as `dokku`; we never auto-install into a crontab, no sudo). |
+| `cron-line` | Print ready-to-paste collector and daily orphan-GC lines — the operator installs them manually (`crontab -e` as `dokku`; we never auto-install into a crontab, no sudo). |
 | `report [--json]` | Aggregated usage table per app (avg CPU cores / avg mem / disk / container-hours / uptime% / COST). |
 | `raw` | Alias for `report --json` (machine-readable). |
+| `diagnose [--app] APP` | Read-only container health evidence and a compact verdict. |
+| `restart APP [--apply] [--yes]` | Safe app restart; dry-run by default and non-TTY apply requires `--yes`. |
+| `gc-mounts [--apply] [--yes]` | Track legacy `clihost-*` storage directories and delete only after 30 days continuously orphaned; dry-run by default. |
 | `help` | Usage. |
 
 **Storage** — append-only JSONL under `${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}`
@@ -334,6 +336,8 @@ static+end-to-end checks in `tests/unit/test_shell_scripts.py`). No `jq`/`sqlite
 - `state/last-collect.json` — last-collect metadata (feeds the "collector likely
   not running" warning `report` prints when the newest sample is older than
   `2 × interval`).
+- `state/orphan-mounts.json` — first-seen times for directories continuously
+  absent from both the Dokku app inventory and every Docker container mount.
 - `rates.json` (stage 2) — not present yet; `report` calls `apply_rates(rows, None)`
   so COST renders as an em dash (`—`) until rates exist.
 
@@ -358,7 +362,21 @@ tracked. Disk is a point-in-time size (latest per container summed), not integra
 
 **Environment:** `CLIHOST_BILLING_DIR` (storage root), `CLIHOST_BILLING_INTERVAL`
 (collector cadence in seconds, default 300 — also the gap-detection base),
-`CLIHOST_APP_PREFIX` (container/app prefix to account, default `clihost-`).
+`CLIHOST_APP_PREFIX` (container/app prefix to account, default `clihost-`),
+`CLIHOST_STORAGE_ROOT` (legacy app-named Dokku storage directory root, default
+`/var/lib/dokku/data/storage`), and `CLIHOST_GC_RETENTION_DAYS` (continuous
+orphan retention, default 30).
+
+`gc-mounts` is deliberately fail-closed. It considers only direct directories
+whose names match `clihost-[a-z0-9_-]+`; existing Dokku apps and paths mounted
+by running or stopped Docker containers are always preserved. A new orphan is
+tracked, not deleted. It becomes eligible only after it remains absent from both
+inventories for the full retention window. Inventory/state errors abort, the
+storage root must be an absolute non-symlink directory, and deletion requires
+both `--apply` and (outside a TTY) `--yes`. The default invocation records the
+observation and prints what would be deleted without deleting it.
+`cron-line` includes a daily `gc-mounts --apply --yes` entry; installing that
+line is the explicit operator opt-in to automatic cleanup.
 
 **Verification:** `python -m pytest tests/unit/test_clihost_billing_agg.py
 tests/unit/test_shell_scripts.py`; on the server, copy both files to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,14 @@ observation and prints what would be deleted without deleting it.
 `cron-line` includes a daily `gc-mounts --apply --yes` entry; installing that
 line is the explicit operator opt-in to automatic cleanup.
 
+Eligibility is sampled once per scan (daily, per the generated cron-line), not
+observed continuously: only a scan that catches a directory active resets its
+tracked first-seen time, so a reuse-and-reorphan cycle squeezed entirely inside
+one scan interval is invisible. Worst case, a deletion's true continuous-orphan
+age can be short of `CLIHOST_GC_RETENTION_DAYS` by up to one scan interval
+(~24h with the shipped daily cron) — closing that gap fully would need
+event-based hooks into Dokku app create/destroy rather than periodic sampling.
+
 **Verification:** `python -m pytest tests/unit/test_clihost_billing_agg.py
 tests/unit/test_shell_scripts.py`; on the server, copy both files to
 `/home/dokku/bin/`, run `clihost-billing.sh collect` a few times with a pause,

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -473,6 +473,16 @@ cmd_restart() {
 # that have been continuously orphaned for the full retention window. An app is
 # not orphaned if it still exists in Dokku OR any Docker container references
 # its directory. Discovery failures abort before deletion; apply is opt-in.
+#
+# Eligibility is sampled once per invocation (daily, per the generated
+# cron-line), not observed continuously: a directory that is reused and
+# re-orphaned entirely within the gap between two consecutive scans is
+# invisible to this check, since only a scan that observes the directory
+# active resets its tracked first-seen time. Worst case this shifts a
+# deletion's *true* continuous-orphan age by up to one scan interval
+# (~24h with the shipped daily cron) short of CLIHOST_GC_RETENTION_DAYS —
+# closing that gap fully would require event-based hooks into Dokku
+# app create/destroy rather than periodic sampling, which is out of scope.
 cmd_gc_mounts() {
   local apply="false"
   local yes="false"

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -11,11 +11,12 @@ set -euo pipefail
 #
 # Subcommands (PR1 + PR2 — accounting + report):
 #   collect     take one sample of every clihost-* container (cron-driven).
-#   cron-line   print a ready-to-paste crontab line (operator installs it).
+#   cron-line   print ready-to-paste collector and orphan-GC crontab lines.
 #   report      render an aggregated usage table (per app).
 #   raw         emit aggregated rows as JSON (machine-readable).
 #   diagnose    inspect the current container state and print a verdict.
 #   restart     safely restart one clihost app (dry-run by default).
+#   gc-mounts   remove app storage after 30 days continuously orphaned.
 #   help        usage.
 #
 # Storage is append-only JSONL under ${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}:
@@ -32,11 +33,14 @@ BILLING_LIB="${SCRIPT_DIR}/clihost_billing_lib.py"
 : "${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}"
 : "${CLIHOST_BILLING_INTERVAL:=300}"
 : "${CLIHOST_APP_PREFIX:=clihost-}"
+: "${CLIHOST_STORAGE_ROOT:=/var/lib/dokku/data/storage}"
+: "${CLIHOST_GC_RETENTION_DAYS:=30}"
 
 SAMPLES_DIR="${CLIHOST_BILLING_DIR}/samples"
 STATE_DIR="${CLIHOST_BILLING_DIR}/state"
 LOCK_FILE="${STATE_DIR}/collect.lock"
 LAST_COLLECT_FILE="${STATE_DIR}/last-collect.json"
+ORPHAN_MOUNTS_FILE="${STATE_DIR}/orphan-mounts.json"
 
 die() {
   echo "ERROR: $*" >&2
@@ -47,13 +51,16 @@ usage() {
   cat >&2 <<'EOF'
 Usage:
   clihost-billing.sh collect            take one sample of all clihost-* containers
-  clihost-billing.sh cron-line          print a crontab line to install the collector
+  clihost-billing.sh cron-line          print collector and orphan-GC crontab lines
   clihost-billing.sh report [--json]    aggregated usage table (per app)
   clihost-billing.sh raw                aggregated rows as JSON (alias for report --json)
   clihost-billing.sh diagnose [--app] APP
                                             inspect APP.web.1 (read-only)
   clihost-billing.sh restart APP [--apply] [--yes]
                                             restart APP (dry-run by default)
+  clihost-billing.sh gc-mounts [--apply] [--yes]
+                                            delete storage continuously orphaned
+                                            for the retention window (dry-run)
   clihost-billing.sh help               this message
 
 Environment:
@@ -61,6 +68,10 @@ Environment:
   CLIHOST_BILLING_INTERVAL  collector cadence in seconds (default: 300); used as
                             the gap-detection base (dt > 2.5x interval = server down)
   CLIHOST_APP_PREFIX        container/app name prefix to account (default: clihost-)
+  CLIHOST_STORAGE_ROOT      legacy Dokku storage root
+                            (default: /var/lib/dokku/data/storage)
+  CLIHOST_GC_RETENTION_DAYS days continuously orphaned before eligibility
+                            (default: 30)
 EOF
 }
 
@@ -262,8 +273,8 @@ PY
   echo "collected ${n} sample(s) at ${ts} -> ${sample_file}"
 }
 
-# cron-line: print a crontab line the operator installs manually (no sudo, we do
-# NOT auto-install into anyone's crontab).
+# cron-line: print collector + daily orphan-GC lines the operator installs
+# manually (no sudo; we do NOT auto-install into anyone's crontab).
 cmd_cron_line() {
   [ "$#" -eq 0 ] || die "cron-line accepts no arguments"
   local self minutes
@@ -274,6 +285,8 @@ cmd_cron_line() {
   cat <<EOF
 # clihost billing collector (issue #37) — paste into: crontab -e  (as the dokku user)
 */${minutes} * * * * ${self} collect >> ${CLIHOST_BILLING_DIR}/state/collect.log 2>&1
+# clihost orphan storage GC (tracks for 30 days before deleting; dry-run is not useful in cron)
+17 3 * * * ${self} gc-mounts --apply --yes >> ${CLIHOST_BILLING_DIR}/state/gc-mounts.log 2>&1
 EOF
 }
 
@@ -456,6 +469,153 @@ cmd_restart() {
   docker restart -- "${app}.web.1"
 }
 
+# Track legacy app-named Dokku storage directories and remove only directories
+# that have been continuously orphaned for the full retention window. An app is
+# not orphaned if it still exists in Dokku OR any Docker container references
+# its directory. Discovery failures abort before deletion; apply is opt-in.
+cmd_gc_mounts() {
+  local apply="false"
+  local yes="false"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --apply) apply="true" ;;
+      --yes) yes="true" ;;
+      --) shift; break ;;
+      -*) die "unknown option: $1" ;;
+      *) die "gc-mounts takes no operands" ;;
+    esac
+    shift
+  done
+  [ "$#" -eq 0 ] || die "gc-mounts takes no operands"
+  if [ "${apply}" = "true" ] && [ ! -t 0 ] && [ "${yes}" != "true" ]; then
+    die "gc-mounts --apply in non-TTY mode requires --yes"
+  fi
+  [[ "${CLIHOST_GC_RETENTION_DAYS}" =~ ^[1-9][0-9]*$ ]] \
+    || die "CLIHOST_GC_RETENTION_DAYS must be a positive integer"
+  [[ "${CLIHOST_STORAGE_ROOT}" = /* ]] \
+    || die "CLIHOST_STORAGE_ROOT must be absolute"
+  [ -d "${CLIHOST_STORAGE_ROOT}" ] \
+    || die "storage root is not a directory: ${CLIHOST_STORAGE_ROOT}"
+  [ ! -L "${CLIHOST_STORAGE_ROOT}" ] \
+    || die "storage root must not be a symlink: ${CLIHOST_STORAGE_ROOT}"
+
+  require_python
+  require_docker
+  command -v dokku >/dev/null 2>&1 || die "dokku CLI not found"
+  ensure_dirs
+
+  # Both inventories are authoritative safety guards. Under `set -e`, a failed
+  # command substitution aborts rather than turning an unknown inventory into
+  # an apparently empty one.
+  local apps container_ids mount_sources
+  apps="$(dokku --quiet apps:list)"
+  container_ids="$(docker ps -aq)"
+  mount_sources=""
+  if [ -n "${container_ids}" ]; then
+    # shellcheck disable=SC2086 # IDs are Docker-generated whitespace tokens.
+    mount_sources="$(docker inspect --format '{{range .Mounts}}{{println .Source}}{{end}}' -- ${container_ids})"
+  fi
+
+  CLIHOST_GC_APPLY="${apply}" \
+  CLIHOST_GC_ROOT="${CLIHOST_STORAGE_ROOT}" \
+  CLIHOST_GC_DAYS="${CLIHOST_GC_RETENTION_DAYS}" \
+  CLIHOST_GC_STATE="${ORPHAN_MOUNTS_FILE}" \
+  CLIHOST_GC_APPS="${apps}" \
+  CLIHOST_GC_MOUNTS="${mount_sources}" \
+  python3 <<'PY'
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import time
+
+root = os.path.normpath(os.environ["CLIHOST_GC_ROOT"])
+state_path = os.environ["CLIHOST_GC_STATE"]
+retention_seconds = int(os.environ["CLIHOST_GC_DAYS"]) * 86400
+apply = os.environ["CLIHOST_GC_APPLY"] == "true"
+apps = {line.strip() for line in os.environ.get("CLIHOST_GC_APPS", "").splitlines()
+        if line.strip()}
+mounted = {os.path.realpath(line.strip())
+           for line in os.environ.get("CLIHOST_GC_MOUNTS", "").splitlines()
+           if line.strip()}
+name_re = re.compile(r"^clihost-[a-z0-9_-]+$")
+
+try:
+    with open(state_path, "r", encoding="utf-8") as handle:
+        saved = json.load(handle)
+except FileNotFoundError:
+    saved = {"version": 1, "orphans": {}}
+except (OSError, ValueError) as exc:
+    raise SystemExit("ERROR: cannot read valid gc state %s: %s" % (state_path, exc))
+if saved.get("version") != 1 or not isinstance(saved.get("orphans"), dict):
+    raise SystemExit("ERROR: unsupported gc state format: " + state_path)
+
+now = int(time.time())
+previous = saved["orphans"]
+current = {}
+found = 0
+for entry in sorted(os.scandir(root), key=lambda item: item.name):
+    if not name_re.fullmatch(entry.name):
+        continue
+    if not entry.is_dir(follow_symlinks=False):
+        continue
+    found += 1
+    path = os.path.join(root, entry.name)
+    real_path = os.path.realpath(path)
+    if entry.name in apps or real_path in mounted:
+        print("preserved %s (active)" % entry.name)
+        continue
+
+    first_seen = previous.get(path, now)
+    if not isinstance(first_seen, (int, float)) or first_seen < 0 or first_seen > now:
+        raise SystemExit("ERROR: invalid first-seen time for " + path)
+    age = now - int(first_seen)
+    if age < retention_seconds:
+        current[path] = int(first_seen)
+        print("tracking %s (orphaned %d/%d days)" %
+              (entry.name, age // 86400, retention_seconds // 86400))
+        continue
+
+    if not apply:
+        current[path] = int(first_seen)
+        print("would delete %s (orphaned %d days)" % (entry.name, age // 86400))
+        continue
+
+    # Re-check the directory identity immediately before deletion. Refuse a
+    # symlink swap and never operate outside a direct, strictly named child.
+    before = entry.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(before.st_mode):
+        raise SystemExit("ERROR: candidate changed type before deletion: " + path)
+    current_entry = os.stat(path, follow_symlinks=False)
+    if (current_entry.st_dev, current_entry.st_ino) != (before.st_dev, before.st_ino):
+        raise SystemExit("ERROR: candidate changed before deletion: " + path)
+    shutil.rmtree(path)
+    print("deleted %s (orphaned %d days)" % (entry.name, age // 86400))
+
+# Atomic state replacement: an interrupted scan never partially resets ages.
+state_dir = os.path.dirname(state_path)
+fd, tmp_path = tempfile.mkstemp(prefix=".orphan-mounts.", dir=state_dir, text=True)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump({"version": 1, "orphans": current}, handle, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, state_path)
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except FileNotFoundError:
+        pass
+    raise
+
+if not found:
+    print("no clihost storage directories under " + root)
+PY
+}
+
 main() {
   local command="${1:-}"
   case "${command}" in
@@ -483,6 +643,10 @@ main() {
     restart)
       shift
       cmd_restart "$@"
+      ;;
+    gc-mounts)
+      shift
+      cmd_gc_mounts "$@"
       ;;
     -h|--help|help)
       usage

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import stat
 import subprocess
 import tempfile
@@ -2579,6 +2580,7 @@ class TestClihostBillingScript(unittest.TestCase):
             self.assertIn("collect", out.stdout)
             self.assertRegex(out.stdout, r"\*/\d+ \* \* \* \*")
             self.assertIn("crontab -e", out.stdout)
+            self.assertIn("gc-mounts --apply --yes", out.stdout)
 
     def test_report_on_synthetic_jsonl(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2792,6 +2794,139 @@ printf '\n' >> "${CLIHOST_TEST_LOG}"
             )
             self.assertEqual(applied.returncode, 0, applied.stderr)
             self.assertIn("dokku ps:restart clihost-good", log.read_text())
+
+    def _make_gc_fakes(self, tmp_path, *, apps="", mounts=""):
+        fake_dokku = tmp_path / "dokku"
+        fake_dokku.write_text(
+            "#!/bin/bash\n"
+            "if [ \"$1 $2\" = \"--quiet apps:list\" ]; then\n"
+            f"  printf '%s' {shlex.quote(apps)}\n"
+            "else\n"
+            "  exit 2\n"
+            "fi\n"
+        )
+        fake_dokku.chmod(0o755)
+        fake_docker = tmp_path / "docker"
+        fake_docker.write_text(
+            "#!/bin/bash\n"
+            "if [ \"$1\" = \"ps\" ]; then\n"
+            "  echo container-id\n"
+            "elif [ \"$1\" = \"inspect\" ]; then\n"
+            f"  printf '%s' {shlex.quote(mounts)}\n"
+            "else\n"
+            "  exit 2\n"
+            "fi\n"
+        )
+        fake_docker.chmod(0o755)
+
+    def test_gc_mounts_tracks_new_orphans_before_the_retention_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            storage = tmp_path / "storage"
+            orphan = storage / "clihost-orphan"
+            orphan.mkdir(parents=True)
+            (orphan / "credentials").write_text("keep")
+            self._make_gc_fakes(tmp_path)
+
+            out = self._run(
+                ["gc-mounts", "--apply", "--yes"], tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_STORAGE_ROOT": str(storage)},
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("tracking clihost-orphan", out.stdout)
+            self.assertTrue(orphan.is_dir())
+
+    def test_gc_mounts_deletes_only_eligible_unreferenced_orphans(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            storage = tmp_path / "storage"
+            billing = tmp_path / "billing"
+            orphan = storage / "clihost-orphan"
+            live = storage / "clihost-live"
+            mounted = storage / "clihost-mounted"
+            for path in (orphan, live, mounted):
+                path.mkdir(parents=True)
+                (path / "credentials").write_text("keep")
+            self._make_gc_fakes(
+                tmp_path,
+                apps="clihost-live\n",
+                mounts=str(mounted) + "\n",
+            )
+            state_dir = billing / "state"
+            state_dir.mkdir(parents=True)
+            (state_dir / "orphan-mounts.json").write_text(json.dumps({
+                "version": 1,
+                "orphans": {
+                    str(orphan): 0,
+                    str(live): 0,
+                    str(mounted): 0,
+                },
+            }))
+
+            out = self._run(
+                ["gc-mounts", "--apply", "--yes"], billing,
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_STORAGE_ROOT": str(storage)},
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("deleted clihost-orphan", out.stdout)
+            self.assertFalse(orphan.exists())
+            self.assertTrue(live.is_dir())
+            self.assertTrue(mounted.is_dir())
+
+    def test_gc_mounts_is_dry_run_and_requires_yes_for_non_tty_apply(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            storage = tmp_path / "storage"
+            billing = tmp_path / "billing"
+            orphan = storage / "clihost-orphan"
+            orphan.mkdir(parents=True)
+            self._make_gc_fakes(tmp_path)
+            state_dir = billing / "state"
+            state_dir.mkdir(parents=True)
+            state = {"version": 1, "orphans": {str(orphan): 0}}
+            (state_dir / "orphan-mounts.json").write_text(json.dumps(state))
+
+            dry_run = self._run(
+                ["gc-mounts"], billing, extra_path=str(tmp_path),
+                env_extra={"CLIHOST_STORAGE_ROOT": str(storage)},
+            )
+            self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+            self.assertIn("would delete clihost-orphan", dry_run.stdout)
+            self.assertTrue(orphan.is_dir())
+
+            refused = self._run(
+                ["gc-mounts", "--apply"], billing, extra_path=str(tmp_path),
+                env_extra={"CLIHOST_STORAGE_ROOT": str(storage)},
+            )
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("non-TTY mode requires --yes", refused.stderr)
+            self.assertTrue(orphan.is_dir())
+
+    def test_gc_mounts_fails_closed_when_dokku_inventory_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            storage = tmp_path / "storage"
+            billing = tmp_path / "billing"
+            orphan = storage / "clihost-orphan"
+            orphan.mkdir(parents=True)
+            self._make_gc_fakes(tmp_path)
+            (tmp_path / "dokku").write_text("#!/bin/bash\nexit 3\n")
+            (tmp_path / "dokku").chmod(0o755)
+            state_dir = billing / "state"
+            state_dir.mkdir(parents=True)
+            (state_dir / "orphan-mounts.json").write_text(json.dumps({
+                "version": 1, "orphans": {str(orphan): 0},
+            }))
+
+            out = self._run(
+                ["gc-mounts", "--apply", "--yes"], billing,
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_STORAGE_ROOT": str(storage)},
+            )
+            self.assertNotEqual(out.returncode, 0)
+            self.assertTrue(orphan.is_dir())
 
     def test_collect_builds_samples_from_docker(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add `clihost-billing.sh gc-mounts` for legacy app-named Dokku storage directories
- track first-seen orphan time and require 30 continuous days absent from both Dokku apps and all Docker container mounts
- keep deletion dry-run by default; require `--apply` and non-TTY `--yes`, with fail-closed inventory/state/path checks
- include an explicit daily GC opt-in in `cron-line` and document the operator contract

## Environment variables

- `CLIHOST_STORAGE_ROOT` — legacy Dokku storage root (default `/var/lib/dokku/data/storage`)
- `CLIHOST_GC_RETENTION_DAYS` — continuous orphan retention window (default `30`)

These are host-only settings, so `.env.example` is unchanged.

## Ports / volumes

No container port or volume mapping changes. The command operates on host-side legacy Dokku storage only.

## Tests

- `python -m pytest tests/unit/test_clihost_billing_agg.py tests/unit/test_shell_scripts.py -q` — 196 passed, 93 subtests passed
- `bash -n bin/clihost-billing.sh`

## Risk

Deletion is intentionally limited to direct `clihost-*` directories that remain continuously absent from both authoritative inventories for the configured retention window. Operators must install the generated cron entry to enable automatic cleanup.

Closes part of #37
