### PR TITLE
feat: add automatic idle sleep (#37.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,7 @@ unsafe (no `docker.sock`). They live on the Dokku host (e.g. `/home/dokku/bin/`)
 and run as the `dokku` user, who is in the `docker` group and can therefore call
 `docker stats/ps -s/inspect` **without sudo** (`sudo` needs a password and is
 unavailable). This is the accounting and operational foundation for issue #37;
-`idle-sleep` and stage 2 (tariffs/invoices) remain follow-up work.
+stage 2 (tariffs/invoices) remains follow-up work.
 
 The bash file is a thin dispatcher (`set -euo pipefail`, `die`/`usage`/`main`
 +`case`, one docker/I-O owner); all pure logic (parsers + aggregation +
@@ -327,6 +327,7 @@ static+end-to-end checks in `tests/unit/test_shell_scripts.py`). No `jq`/`sqlite
 | `diagnose [--app] APP` | Read-only container health evidence and a compact verdict. |
 | `restart APP [--apply] [--yes]` | Safe app restart; dry-run by default and non-TTY apply requires `--yes`. |
 | `gc-mounts [--apply] [--yes]` | Track legacy `clihost-*` storage directories and delete only after 30 days continuously orphaned; dry-run by default. |
+| `idle-sleep [--apply] [--yes]` | Stop explicitly allowlisted apps after continuous CPU and network inactivity; dry-run by default. |
 | `help` | Usage. |
 
 **Storage** — append-only JSONL under `${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}`
@@ -338,6 +339,8 @@ static+end-to-end checks in `tests/unit/test_shell_scripts.py`). No `jq`/`sqlite
   `2 × interval`).
 - `state/orphan-mounts.json` — first-seen times for directories continuously
   absent from both the Dokku app inventory and every Docker container mount.
+- `state/idle-sleep.json` — per-app network counter, last observation, and start
+  of the current continuous idle window.
 - `rates.json` (stage 2) — not present yet; `report` calls `apply_rates(rows, None)`
   so COST renders as an em dash (`—`) until rates exist.
 
@@ -364,8 +367,12 @@ tracked. Disk is a point-in-time size (latest per container summed), not integra
 (collector cadence in seconds, default 300 — also the gap-detection base),
 `CLIHOST_APP_PREFIX` (container/app prefix to account, default `clihost-`),
 `CLIHOST_STORAGE_ROOT` (legacy app-named Dokku storage directory root, default
-`/var/lib/dokku/data/storage`), and `CLIHOST_GC_RETENTION_DAYS` (continuous
-orphan retention, default 30).
+`/var/lib/dokku/data/storage`), `CLIHOST_GC_RETENTION_DAYS` (continuous
+orphan retention, default 30), `CLIHOST_IDLE_APPS` (comma-separated idle-sleep
+allowlist, default empty/disabled), `CLIHOST_IDLE_MINUTES` (continuous idle
+window, default 60), `CLIHOST_IDLE_CPU_PCT` (max aggregate CPU percentage
+considered idle, default 1), and `CLIHOST_IDLE_NET_BYTES` (max network bytes
+per observation considered idle, default 65536).
 
 `gc-mounts` is deliberately fail-closed. It considers only direct directories
 whose names match `clihost-[a-z0-9_-]+`; existing Dokku apps and paths mounted
@@ -385,6 +392,28 @@ one scan interval is invisible. Worst case, a deletion's true continuous-orphan
 age can be short of `CLIHOST_GC_RETENTION_DAYS` by up to one scan interval
 (~24h with the shipped daily cron) — closing that gap fully would need
 event-based hooks into Dokku app create/destroy rather than periodic sampling.
+
+**Idle sleep is opt-in and fail-closed.** `CLIHOST_IDLE_APPS` is an empty
+comma-separated allowlist by default, so the command does nothing until an
+operator names apps explicitly. `CLIHOST_IDLE_MINUTES` defaults to 60 and
+`CLIHOST_IDLE_CPU_PCT` defaults to 1 aggregate CPU percent.
+`CLIHOST_IDLE_NET_BYTES` defaults to 65536 bytes per observation, allowing
+small tunnel/runner keepalives without keeping an otherwise idle app awake.
+Every invocation reads live `docker stats`: CPU above the threshold, cumulative
+`NetIO` growth above that byte threshold, a container counter reset, or an observation gap greater than `2.5 ×
+CLIHOST_BILLING_INTERVAL` resets the idle window. Missing/malformed stats or
+state abort instead of being interpreted as idle. The first observation only
+starts tracking. An eligible app is printed in dry-run mode; stopping requires
+`--apply` and, outside a TTY, `--yes`, and uses `dokku ps:stop APP`.
+
+This implements **automatic sleeping**, not automatic request-triggered waking.
+Dokku's default nginx proxy has no built-in scale-from-zero request hook, and
+once the web container is stopped it cannot receive the request that would wake
+it. Wake manually with `dokku ps:start APP`. True wake-on-HTTP requires a
+separate always-on, wake-aware proxy/control-plane integration and is outside
+this repository's container/host-helper scope. `cron-line` prints a commented
+opt-in template; replace the example allowlist and uncomment it to schedule the
+sleep evaluator.
 
 **Verification:** `python -m pytest tests/unit/test_clihost_billing_agg.py
 tests/unit/test_shell_scripts.py`; on the server, copy both files to

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 #   diagnose    inspect the current container state and print a verdict.
 #   restart     safely restart one clihost app (dry-run by default).
 #   gc-mounts   remove app storage after 30 days continuously orphaned.
+#   idle-sleep  stop explicitly opted-in apps after continuous inactivity.
 #   help        usage.
 #
 # Storage is append-only JSONL under ${CLIHOST_BILLING_DIR:=/home/dokku/.clihost-billing}:
@@ -35,12 +36,17 @@ BILLING_LIB="${SCRIPT_DIR}/clihost_billing_lib.py"
 : "${CLIHOST_APP_PREFIX:=clihost-}"
 : "${CLIHOST_STORAGE_ROOT:=/var/lib/dokku/data/storage}"
 : "${CLIHOST_GC_RETENTION_DAYS:=30}"
+: "${CLIHOST_IDLE_APPS:=}"
+: "${CLIHOST_IDLE_MINUTES:=60}"
+: "${CLIHOST_IDLE_CPU_PCT:=1}"
+: "${CLIHOST_IDLE_NET_BYTES:=65536}"
 
 SAMPLES_DIR="${CLIHOST_BILLING_DIR}/samples"
 STATE_DIR="${CLIHOST_BILLING_DIR}/state"
 LOCK_FILE="${STATE_DIR}/collect.lock"
 LAST_COLLECT_FILE="${STATE_DIR}/last-collect.json"
 ORPHAN_MOUNTS_FILE="${STATE_DIR}/orphan-mounts.json"
+IDLE_SLEEP_FILE="${STATE_DIR}/idle-sleep.json"
 
 die() {
   echo "ERROR: $*" >&2
@@ -61,6 +67,9 @@ Usage:
   clihost-billing.sh gc-mounts [--apply] [--yes]
                                             delete storage continuously orphaned
                                             for the retention window (dry-run)
+  clihost-billing.sh idle-sleep [--apply] [--yes]
+                                            stop opted-in apps after continuous
+                                            CPU and network inactivity (dry-run)
   clihost-billing.sh help               this message
 
 Environment:
@@ -72,6 +81,12 @@ Environment:
                             (default: /var/lib/dokku/data/storage)
   CLIHOST_GC_RETENTION_DAYS days continuously orphaned before eligibility
                             (default: 30)
+  CLIHOST_IDLE_APPS         comma-separated app allowlist (default: empty/disabled)
+  CLIHOST_IDLE_MINUTES      continuous idle window (default: 60)
+  CLIHOST_IDLE_CPU_PCT      max aggregate CPU percentage considered idle
+                            (default: 1)
+  CLIHOST_IDLE_NET_BYTES    max network bytes per observation considered idle;
+                            permits small keepalives (default: 65536)
 EOF
 }
 
@@ -287,6 +302,8 @@ cmd_cron_line() {
 */${minutes} * * * * ${self} collect >> ${CLIHOST_BILLING_DIR}/state/collect.log 2>&1
 # clihost orphan storage GC (tracks for 30 days before deleting; dry-run is not useful in cron)
 17 3 * * * ${self} gc-mounts --apply --yes >> ${CLIHOST_BILLING_DIR}/state/gc-mounts.log 2>&1
+# idle sleep is opt-in: replace the example allowlist, then uncomment this line
+# */${minutes} * * * * CLIHOST_IDLE_APPS=clihost-example ${self} idle-sleep --apply --yes >> ${CLIHOST_BILLING_DIR}/state/idle-sleep.log 2>&1
 EOF
 }
 
@@ -640,6 +657,211 @@ if not found:
 PY
 }
 
+# Stop only explicitly allowlisted apps after a continuous low-CPU window with
+# no change in Docker's cumulative NetIO counters. This is host-side sleeping,
+# not request-triggered waking: an operator starts a sleeping app with
+# `dokku ps:start APP` (or provides a separate wake-aware proxy integration).
+cmd_idle_sleep() {
+  local apply="false"
+  local yes="false"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --apply) apply="true" ;;
+      --yes) yes="true" ;;
+      --) shift; break ;;
+      -*) die "unknown option: $1" ;;
+      *) die "idle-sleep takes no operands" ;;
+    esac
+    shift
+  done
+  [ "$#" -eq 0 ] || die "idle-sleep takes no operands"
+
+  if [ -z "${CLIHOST_IDLE_APPS//[[:space:],]/}" ]; then
+    echo "idle-sleep disabled: CLIHOST_IDLE_APPS is empty"
+    return 0
+  fi
+  if [ "${apply}" = "true" ] && [ ! -t 0 ] && [ "${yes}" != "true" ]; then
+    die "idle-sleep --apply in non-TTY mode requires --yes"
+  fi
+  [[ "${CLIHOST_IDLE_MINUTES}" =~ ^[1-9][0-9]*$ ]] \
+    || die "CLIHOST_IDLE_MINUTES must be a positive integer"
+  [[ "${CLIHOST_BILLING_INTERVAL}" =~ ^[1-9][0-9]*$ ]] \
+    || die "CLIHOST_BILLING_INTERVAL must be a positive integer"
+  [[ "${CLIHOST_IDLE_CPU_PCT}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] \
+    || die "CLIHOST_IDLE_CPU_PCT must be a non-negative number"
+  [[ "${CLIHOST_IDLE_NET_BYTES}" =~ ^[0-9]+$ ]] \
+    || die "CLIHOST_IDLE_NET_BYTES must be a non-negative integer"
+
+  require_python
+  require_docker
+  command -v dokku >/dev/null 2>&1 || die "dokku CLI not found"
+  ensure_dirs
+
+  # Failure to read live stats is indeterminate, never evidence of idleness.
+  local stats_json result actions line app
+  stats_json="$(docker stats --no-stream --format '{{json .}}')"
+  result="$(
+    CLIHOST_IDLE_ALLOWLIST="${CLIHOST_IDLE_APPS}" \
+    CLIHOST_IDLE_MINUTES_VALUE="${CLIHOST_IDLE_MINUTES}" \
+    CLIHOST_IDLE_CPU_VALUE="${CLIHOST_IDLE_CPU_PCT}" \
+    CLIHOST_IDLE_NET_VALUE="${CLIHOST_IDLE_NET_BYTES}" \
+    CLIHOST_IDLE_INTERVAL="${CLIHOST_BILLING_INTERVAL}" \
+    CLIHOST_IDLE_STATE="${IDLE_SLEEP_FILE}" \
+    CLIHOST_IDLE_STATS="${stats_json}" \
+    CLIHOST_BILLING_LIB="${BILLING_LIB}" \
+    python3 <<'PY'
+import json
+import os
+import re
+import tempfile
+import time
+import sys
+
+sys.path.insert(0, os.path.dirname(os.environ["CLIHOST_BILLING_LIB"]))
+import clihost_billing_lib as lib  # noqa: E402
+
+name_re = re.compile(r"^clihost-[a-z0-9_-]+$")
+allowlist = []
+for raw in os.environ["CLIHOST_IDLE_ALLOWLIST"].split(","):
+    app = raw.strip()
+    if not app:
+        continue
+    if not name_re.fullmatch(app):
+        raise SystemExit("ERROR: invalid app in CLIHOST_IDLE_APPS: " + app)
+    if app not in allowlist:
+        allowlist.append(app)
+
+idle_seconds = int(os.environ["CLIHOST_IDLE_MINUTES_VALUE"]) * 60
+cpu_limit = float(os.environ["CLIHOST_IDLE_CPU_VALUE"])
+net_limit = int(os.environ["CLIHOST_IDLE_NET_VALUE"])
+interval = int(os.environ["CLIHOST_IDLE_INTERVAL"])
+state_path = os.environ["CLIHOST_IDLE_STATE"]
+now = int(time.time())
+
+try:
+    with open(state_path, "r", encoding="utf-8") as handle:
+        saved = json.load(handle)
+except FileNotFoundError:
+    saved = {"version": 1, "apps": {}}
+except (OSError, ValueError) as exc:
+    raise SystemExit("ERROR: cannot read valid idle state %s: %s" % (state_path, exc))
+if saved.get("version") != 1 or not isinstance(saved.get("apps"), dict):
+    raise SystemExit("ERROR: unsupported idle state format: " + state_path)
+
+live = {}
+for text in os.environ.get("CLIHOST_IDLE_STATS", "").splitlines():
+    text = text.strip()
+    if not text:
+        continue
+    try:
+        row = json.loads(text)
+    except ValueError as exc:
+        raise SystemExit("ERROR: invalid docker stats JSON: %s" % exc)
+    name = row.get("Name") or row.get("Container") or ""
+    app = name.split(".", 1)[0]
+    if app not in allowlist or not name.startswith(app + ".web."):
+        continue
+    cpu = lib.parse_cpu_perc(row.get("CPUPerc"))
+    net_bytes = lib.parse_net_io(row.get("NetIO"))
+    if net_bytes is None:
+        raise SystemExit("ERROR: missing NetIO counters for " + name)
+    aggregate = live.setdefault(app, {"cpu_pct": 0.0, "net_bytes": 0})
+    aggregate["cpu_pct"] += cpu
+    aggregate["net_bytes"] += net_bytes
+
+current = {}
+actions = []
+previous_apps = saved["apps"]
+for app in allowlist:
+    metrics = live.get(app)
+    if metrics is None:
+        print("not running: " + app)
+        continue
+    previous = previous_apps.get(app)
+    net_bytes = metrics["net_bytes"]
+    cpu_pct = metrics["cpu_pct"]
+    activity_reason = None
+    if previous is None:
+        activity_reason = "first observation"
+    else:
+        try:
+            last_seen = int(previous["last_seen"])
+            old_net = int(previous["net_bytes"])
+            idle_since = int(previous["idle_since"])
+        except (KeyError, TypeError, ValueError):
+            raise SystemExit("ERROR: invalid idle state for " + app)
+        if last_seen < 0 or idle_since < 0 or last_seen > now or idle_since > now:
+            raise SystemExit("ERROR: invalid idle timestamps for " + app)
+        if now - last_seen > 2.5 * interval:
+            activity_reason = "observation gap"
+        elif net_bytes < old_net:
+            activity_reason = "network counter reset"
+        elif net_bytes - old_net > net_limit:
+            activity_reason = "network"
+        elif cpu_pct > cpu_limit:
+            activity_reason = "cpu"
+
+    if activity_reason is not None:
+        idle_since = now
+        if activity_reason == "first observation":
+            print("tracking %s (first observation)" % app)
+        else:
+            print("activity on %s (%s); idle window reset" % (app, activity_reason))
+    age = now - idle_since
+    current[app] = {
+        "idle_since": idle_since,
+        "last_seen": now,
+        "net_bytes": net_bytes,
+    }
+    if age >= idle_seconds:
+        actions.append(app)
+        print("eligible %s (idle %d/%d minutes)" %
+              (app, age // 60, idle_seconds // 60))
+    elif activity_reason is None:
+        print("tracking %s (idle %d/%d minutes)" %
+              (app, age // 60, idle_seconds // 60))
+
+state_dir = os.path.dirname(state_path)
+fd, tmp_path = tempfile.mkstemp(prefix=".idle-sleep.", dir=state_dir, text=True)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump({"version": 1, "apps": current}, handle, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, state_path)
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except FileNotFoundError:
+        pass
+    raise
+
+for app in actions:
+    print("ACTION\t" + app)
+PY
+  )"
+
+  actions=""
+  while IFS= read -r line; do
+    case "${line}" in
+      $'ACTION\t'*) actions+="${line#*$'\t'}"$'\n' ;;
+      *) printf '%s\n' "${line}" ;;
+    esac
+  done <<< "${result}"
+
+  while IFS= read -r app; do
+    [ -n "${app}" ] || continue
+    validate_app_name "${app}"
+    if [ "${apply}" != "true" ]; then
+      echo "would run: dokku ps:stop ${app}"
+    else
+      dokku ps:stop "${app}"
+      echo "slept ${app}; wake with: dokku ps:start ${app}"
+    fi
+  done <<< "${actions}"
+}
+
 main() {
   local command="${1:-}"
   case "${command}" in
@@ -671,6 +893,10 @@ main() {
     gc-mounts)
       shift
       cmd_gc_mounts "$@"
+      ;;
+    idle-sleep)
+      shift
+      cmd_idle_sleep "$@"
       ;;
     -h|--help|help)
       usage

--- a/bin/clihost_billing_lib.py
+++ b/bin/clihost_billing_lib.py
@@ -124,6 +124,20 @@ def parse_mem_usage(value):
     return (used, limit)
 
 
+def parse_net_io(value):
+    """Parse Docker's cumulative ``NetIO`` field into total transferred bytes.
+
+    Return ``None`` unless both received and transmitted counters are present,
+    allowing safety-sensitive callers to treat missing data as indeterminate.
+    """
+    if value is None:
+        return None
+    parts = str(value).split("/")
+    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+        return None
+    return _parse_one_size(parts[0]) + _parse_one_size(parts[1])
+
+
 def parse_size_field(value):
     """Parse a ``docker ps -s`` Size field into (rootfs_bytes, virtual_bytes).
 

--- a/tests/unit/test_clihost_billing_agg.py
+++ b/tests/unit/test_clihost_billing_agg.py
@@ -58,6 +58,11 @@ class TestParsers(unittest.TestCase):
     def test_parse_mem_usage_edge(self):
         self.assertEqual(lib.parse_mem_usage("--"), (0, 0))
         self.assertEqual(lib.parse_mem_usage(None), (0, 0))
+
+    def test_parse_net_io(self):
+        self.assertEqual(lib.parse_net_io("1.2MB / 34kB"), 1_234_000)
+        self.assertEqual(lib.parse_net_io("50B / 50B"), 100)
+        self.assertIsNone(lib.parse_net_io("--"))
         used, limit = lib.parse_mem_usage("1.5GiB / 7.6GiB")
         self.assertEqual(used, int(round(1.5 * 1024 ** 3)))
 

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -122,25 +122,27 @@ class TestEntrypointRegressions(unittest.TestCase):
         # ValueError at import time for a malformed Python-owned var (e.g.
         # MAX_TERMINALS, SECURE_COOKIES) that the shell-side contract does not
         # validate. Backgrounding the proxy with a bare `&` and never checking
-        # it before `exec sshd` would leave the container "healthy" (sshd up)
-        # with its only HTTP service dead. The entrypoint must capture the
-        # proxy's PID and fail closed if it does not survive a short grace
-        # window.
+        # it before the final `exec` would leave the container "healthy"
+        # (sshd/CMD up) with its only HTTP service dead. The entrypoint must
+        # capture the proxy's PID and fail closed if it does not survive a
+        # short grace window. Since #117 the final line is `exec "$@"` (honors
+        # an operator-supplied Docker CMD override) instead of a hardcoded
+        # `exec /usr/sbin/sshd -D -e`.
         proxy_launch_pos = self.text.find(
             'runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &'
         )
         pid_capture_pos = self.text.find("PROXY_PID=$!")
-        sshd_pos = self.text.find("exec /usr/sbin/sshd -D -e")
+        exec_pos = self.text.rfind('exec "$@"')
         self.assertGreater(proxy_launch_pos, -1, "proxy launch line not found")
         self.assertGreater(
             pid_capture_pos, -1,
             "entrypoint.sh must capture the proxy PID ($!) to verify startup",
         )
         self.assertGreater(pid_capture_pos, proxy_launch_pos)
-        self.assertGreater(sshd_pos, -1)
+        self.assertGreater(exec_pos, -1, "final exec \"$@\" line not found")
         self.assertLess(
-            pid_capture_pos, sshd_pos,
-            "PID capture must happen before exec sshd",
+            pid_capture_pos, exec_pos,
+            "PID capture must happen before the final exec",
         )
         # A liveness check (kill -0) must run between the PID capture and the
         # final exec, and abort (die/exit) on failure rather than continue
@@ -151,7 +153,7 @@ class TestEntrypointRegressions(unittest.TestCase):
             "entrypoint.sh must verify the proxy process is still alive",
         )
         self.assertGreater(liveness_pos, pid_capture_pos)
-        self.assertLess(liveness_pos, sshd_pos)
+        self.assertLess(liveness_pos, exec_pos)
         self.assertIn("TTYD HTTP proxy exited immediately after startup", self.text)
 
     def test_python_config_validated_before_destructive_actions(self):

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -7,6 +7,7 @@ import shlex
 import stat
 import subprocess
 import tempfile
+import time
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -2815,6 +2816,8 @@ class TestClihostBillingScript(unittest.TestCase):
             self.assertRegex(out.stdout, r"\*/\d+ \* \* \* \*")
             self.assertIn("crontab -e", out.stdout)
             self.assertIn("gc-mounts --apply --yes", out.stdout)
+            self.assertIn("CLIHOST_IDLE_APPS=clihost-example", out.stdout)
+            self.assertIn("idle-sleep --apply --yes", out.stdout)
 
     def test_report_on_synthetic_jsonl(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -3193,6 +3196,137 @@ printf '\n' >> "${CLIHOST_TEST_LOG}"
             )
             self.assertNotEqual(out.returncode, 0)
             self.assertTrue(orphan.is_dir())
+
+    def _make_idle_sleep_fakes(self, tmp_path, stats_lines):
+        log = tmp_path / "idle-commands.log"
+        log.write_text("")
+        fake_docker = tmp_path / "docker"
+        fake_docker.write_text(
+            "#!/bin/bash\n"
+            "printf 'docker' >> \"${CLIHOST_TEST_LOG}\"\n"
+            "printf ' %q' \"$@\" >> \"${CLIHOST_TEST_LOG}\"\n"
+            "printf '\\n' >> \"${CLIHOST_TEST_LOG}\"\n"
+            "if [ \"${1:-}\" = stats ]; then\n"
+            f"cat <<'EOF'\n{stats_lines}EOF\n"
+            "else\n"
+            "  exit 2\n"
+            "fi\n"
+        )
+        fake_docker.chmod(0o755)
+        fake_dokku = tmp_path / "dokku"
+        fake_dokku.write_text(
+            "#!/bin/bash\n"
+            "printf 'dokku' >> \"${CLIHOST_TEST_LOG}\"\n"
+            "printf ' %q' \"$@\" >> \"${CLIHOST_TEST_LOG}\"\n"
+            "printf '\\n' >> \"${CLIHOST_TEST_LOG}\"\n"
+        )
+        fake_dokku.chmod(0o755)
+        return log
+
+    def test_idle_sleep_is_disabled_without_explicit_app_allowlist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            out = self._run(["idle-sleep"], tmp_path / "billing")
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("CLIHOST_IDLE_APPS is empty", out.stdout)
+
+    def test_idle_sleep_first_observation_only_starts_tracking(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_idle_sleep_fakes(
+                tmp_path,
+                '{"Name":"clihost-good.web.1","CPUPerc":"0.10%","NetIO":"100B / 100B"}\n',
+            )
+            out = self._run(
+                ["idle-sleep", "--apply", "--yes"], tmp_path / "billing",
+                extra_path=str(tmp_path), env_extra={
+                    "CLIHOST_TEST_LOG": str(log),
+                    "CLIHOST_IDLE_APPS": "clihost-good",
+                    "CLIHOST_IDLE_MINUTES": "1",
+                },
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("tracking clihost-good", out.stdout)
+            self.assertNotIn("dokku", log.read_text())
+
+    def test_idle_sleep_stops_only_after_continuous_cpu_and_network_idle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            billing = tmp_path / "billing"
+            state_dir = billing / "state"
+            state_dir.mkdir(parents=True)
+            now = int(time.time())
+            (state_dir / "idle-sleep.json").write_text(json.dumps({
+                "version": 1,
+                "apps": {"clihost-good": {
+                    "idle_since": now - 3600,
+                    "last_seen": now - 300,
+                    "net_bytes": 100,
+                }},
+            }))
+            log = self._make_idle_sleep_fakes(
+                tmp_path,
+                # 100 bytes since the last observation is below the default
+                # keepalive allowance and must not reset the idle window.
+                '{"Name":"clihost-good.web.1","CPUPerc":"0.10%","NetIO":"100B / 100B"}\n',
+            )
+            env = {
+                "CLIHOST_TEST_LOG": str(log),
+                "CLIHOST_IDLE_APPS": "clihost-good",
+                "CLIHOST_IDLE_MINUTES": "30",
+            }
+
+            dry_run = self._run(
+                ["idle-sleep"], billing, extra_path=str(tmp_path), env_extra=env,
+            )
+            self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+            self.assertIn("would run: dokku ps:stop clihost-good", dry_run.stdout)
+            self.assertNotIn("dokku", log.read_text())
+
+            refused = self._run(
+                ["idle-sleep", "--apply"], billing,
+                extra_path=str(tmp_path), env_extra=env,
+            )
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("non-TTY mode requires --yes", refused.stderr)
+
+            applied = self._run(
+                ["idle-sleep", "--apply", "--yes"], billing,
+                extra_path=str(tmp_path), env_extra=env,
+            )
+            self.assertEqual(applied.returncode, 0, applied.stderr)
+            self.assertIn("dokku ps:stop clihost-good", log.read_text())
+
+    def test_idle_sleep_network_activity_resets_idle_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            billing = tmp_path / "billing"
+            state_dir = billing / "state"
+            state_dir.mkdir(parents=True)
+            now = int(time.time())
+            (state_dir / "idle-sleep.json").write_text(json.dumps({
+                "version": 1,
+                "apps": {"clihost-good": {
+                    "idle_since": now - 3600,
+                    "last_seen": now - 300,
+                    "net_bytes": 100,
+                }},
+            }))
+            log = self._make_idle_sleep_fakes(
+                tmp_path,
+                '{"Name":"clihost-good.web.1","CPUPerc":"0.10%","NetIO":"100kB / 50B"}\n',
+            )
+            out = self._run(
+                ["idle-sleep", "--apply", "--yes"], billing,
+                extra_path=str(tmp_path), env_extra={
+                    "CLIHOST_TEST_LOG": str(log),
+                    "CLIHOST_IDLE_APPS": "clihost-good",
+                    "CLIHOST_IDLE_MINUTES": "30",
+                },
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("activity on clihost-good", out.stdout)
+            self.assertNotIn("dokku", log.read_text())
 
     def test_collect_builds_samples_from_docker(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add opt-in `clihost-billing.sh idle-sleep` for automatic sleeping of selected Dokku apps
- require a continuous idle window using aggregate CPU plus cumulative Docker NetIO deltas; tolerate small configurable keepalives
- reset the window on load, counter resets, or collector gaps, and fail closed on missing/malformed observations or state
- keep the action dry-run by default; actual `dokku ps:stop APP` requires `--apply` and non-TTY `--yes`
- print a commented cron template so enabling automatic sleep remains an explicit operator choice

## Environment variables

- `CLIHOST_IDLE_APPS` — comma-separated app allowlist (default empty, so disabled)
- `CLIHOST_IDLE_MINUTES` — continuous idle window (default `60`)
- `CLIHOST_IDLE_CPU_PCT` — maximum aggregate CPU percentage considered idle (default `1`)
- `CLIHOST_IDLE_NET_BYTES` — maximum network bytes per observation considered idle, allowing small tunnel keepalives (default `65536`)

These are host-only settings, so `.env.example` is unchanged.

## Wake contract / scope

This PR implements automatic **sleeping** via Dokku's supported `ps:stop`. It does not claim automatic wake-on-request: Dokku's default nginx proxy has no built-in scale-from-zero request hook, and a stopped app cannot receive the request that would wake it. Sleeping apps are restarted with `dokku ps:start APP`. True wake-on-HTTP needs a separate always-on wake-aware proxy/control-plane integration, outside this repository's current host-helper scope.

## Ports / volumes

None.

## Tests

- `python -m pytest tests/unit/test_clihost_billing_agg.py tests/unit/test_shell_scripts.py -q` — 197 passed
- `bash -n bin/clihost-billing.sh`

Closes part of #37
