### PR TITLE
Fix ttyd port reuse race

### DIFF
--- a/app/ttydproxy/app.py
+++ b/app/ttydproxy/app.py
@@ -478,29 +478,22 @@ class TTYDProxyHandler(BaseHandler):
         username = self._check_auth()
         if not username:
             return
-        terminal = ttyd_manager.get_terminal(terminal_id)
-        if not terminal:
-            self.send_json(404, {"error": f"Terminal ttyd{terminal_id} not found"})
-            return
-        # NOTE (#101/#8, deferred): the lock is released inside get_terminal(),
-        # so this `port` is not revalidated at connect time. If terminal_id is
-        # deleted and its port reused (lowest-free, see _allocate_port) before
-        # the connect below, an in-flight request could reach a different
-        # terminal's ttyd. The window is narrow (usually ECONNREFUSED->502) and
-        # not a security boundary; a proper fix (a per-terminal lease/refcount
-        # holding the port until the request completes) is tracked separately.
-        port = terminal["port"]
-        parsed = urlparse(self.path)
-        prefix = f"/ttyd{terminal_id}"
-        if parsed.path.startswith(prefix + "/"):
-            upstream_path = parsed.path[len(prefix):] + ("?" + parsed.query if parsed.query else "")
-        else:
-            upstream_path = "/"
+        with ttyd_manager.lease_terminal(terminal_id) as terminal:
+            if not terminal:
+                self.send_json(404, {"error": f"Terminal ttyd{terminal_id} not found"})
+                return
+            port = terminal["port"]
+            parsed = urlparse(self.path)
+            prefix = f"/ttyd{terminal_id}"
+            if parsed.path.startswith(prefix + "/"):
+                upstream_path = parsed.path[len(prefix):] + ("?" + parsed.query if parsed.query else "")
+            else:
+                upstream_path = "/"
 
-        if is_websocket_request(self):
-            proxy_ttyd_websocket(self, upstream_path, port)
-        else:
-            proxy_ttyd_http(self, upstream_path, port)
+            if is_websocket_request(self):
+                proxy_ttyd_websocket(self, upstream_path, port)
+            else:
+                proxy_ttyd_http(self, upstream_path, port)
 
 
 def _warn_on_user_mismatch():

--- a/app/ttydproxy/manager.py
+++ b/app/ttydproxy/manager.py
@@ -1,4 +1,5 @@
 """Lifecycle management for ttyd child processes."""
+from contextlib import contextmanager
 import os
 import socket
 import subprocess
@@ -19,6 +20,7 @@ class TTYDManager:
         tmux_wrapper="/bin/tmux-wrapper.sh",
     ):
         self.terminals = {}
+        self._port_leases = {}
         self.next_id = 1
         self.lock = threading.Lock()
         self.base_port = base_port
@@ -34,17 +36,10 @@ class TTYDManager:
         self._reaper_stop = threading.Event()
 
     def _allocate_port(self):
-        """Find the next available port, reusing freed ports.
-
-        NOTE (#101/#8, deferred): lowest-free reuse means a just-freed port can
-        be handed to a new terminal immediately. Combined with the connect-time
-        gap in handle_ttyd_proxy (the lock is dropped before connect), an
-        in-flight request to a deleted terminal could reach the new terminal's
-        ttyd. The window is narrow and not a security boundary; the proper fix
-        (a per-terminal lease that holds the port for the request's lifetime) is
-        tracked separately.
-        """
-        used_ports = {terminal["port"] for terminal in self.terminals.values()}
+        """Find the next port not owned by a terminal or in-flight proxy."""
+        used_ports = {
+            terminal["port"] for terminal in self.terminals.values()
+        } | self._port_leases.keys()
         max_port = self.base_port + self.max_terminals
         port = self.base_port
         while port in used_ports:
@@ -235,6 +230,41 @@ class TTYDManager:
             self._cleanup_terminal(terminal_id, dead_info, f"Terminal ttyd{terminal_id} died, cleaned up")
         return None
 
+    @contextmanager
+    def lease_terminal(self, terminal_id):
+        """Hold a terminal's port against reuse for an in-flight proxy request."""
+        dead_info = None
+        port = None
+        terminal = None
+        with self.lock:
+            info = self.terminals.get(terminal_id)
+            if info:
+                process = info.get("process")
+                if process and process.poll() is not None:
+                    dead_info = self.terminals.pop(terminal_id)
+                else:
+                    port = info["port"]
+                    self._port_leases[port] = self._port_leases.get(port, 0) + 1
+                    terminal = {"id": info["id"], "port": port}
+
+        if dead_info:
+            self._cleanup_terminal(
+                terminal_id,
+                dead_info,
+                f"Terminal ttyd{terminal_id} died, cleaned up",
+            )
+
+        try:
+            yield terminal
+        finally:
+            if port is not None:
+                with self.lock:
+                    remaining = self._port_leases[port] - 1
+                    if remaining:
+                        self._port_leases[port] = remaining
+                    else:
+                        del self._port_leases[port]
+
     def _wait_for_ready(self, port, timeout=15):
         """Wait until ttyd is responding on the given port."""
         for _ in range(timeout):
@@ -246,4 +276,3 @@ class TTYDManager:
                 time.sleep(1)
         print(f"TTYD on port {port} failed to start within {timeout}s", file=sys.stderr, flush=True)
         return False
-

--- a/tests/integration/test_ttyd_handler.py
+++ b/tests/integration/test_ttyd_handler.py
@@ -1,6 +1,10 @@
 """Integration-style tests for virtual keyboard query handling."""
+import threading
 import unittest
+from unittest.mock import MagicMock, patch
 
+from ttydproxy import app
+from ttydproxy.manager import TTYDManager
 from ttydproxy.views import resolve_vkbd_enabled
 
 
@@ -24,6 +28,57 @@ class TestTTYDHandlerVKBD(unittest.TestCase):
         self.assertTrue(resolve_vkbd_enabled("/ttyd?vkbd=true&vkbd=false", False))
 
 
+class TestTTYDProxyPortLease(unittest.TestCase):
+    @patch("ttydproxy.manager.subprocess.run")
+    @patch("ttydproxy.manager.subprocess.Popen")
+    def test_inflight_proxy_prevents_port_reuse(self, mock_popen, _mock_run):
+        processes = []
+
+        def make_process(*_args, **_kwargs):
+            process = MagicMock()
+            process.pid = 100 + len(processes)
+            process.poll.return_value = None
+            processes.append(process)
+            return process
+
+        mock_popen.side_effect = make_process
+        manager = TTYDManager(base_port=9000, max_terminals=2)
+        first = manager.create_terminal()
+        proxy_started = threading.Event()
+        allow_proxy_to_finish = threading.Event()
+        proxied_ports = []
+
+        def blocked_proxy(_handler, _path, port):
+            proxied_ports.append(port)
+            proxy_started.set()
+            self.assertTrue(allow_proxy_to_finish.wait(timeout=5))
+
+        handler = MagicMock()
+        handler._check_auth.return_value = "alice"
+        handler.path = "/ttyd1/"
+
+        with patch.object(app, "ttyd_manager", manager), patch.object(
+            app, "is_websocket_request", return_value=False
+        ), patch.object(app, "proxy_ttyd_http", side_effect=blocked_proxy):
+            request = threading.Thread(
+                target=app.TTYDProxyHandler.handle_ttyd_proxy,
+                args=(handler, first["id"]),
+            )
+            request.start()
+            self.assertTrue(proxy_started.wait(timeout=5))
+            try:
+                self.assertTrue(manager.delete_terminal(first["id"]))
+                replacement = manager.create_terminal()
+                self.assertEqual(replacement["port"], 9001)
+            finally:
+                allow_proxy_to_finish.set()
+                request.join(timeout=5)
+
+        self.assertFalse(request.is_alive())
+        self.assertEqual(proxied_ports, [9000])
+        self.assertTrue(manager.delete_terminal(replacement["id"]))
+        self.assertEqual(manager.create_terminal()["port"], 9000)
+
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- add ref-counted terminal port leases for the lifetime of HTTP and WebSocket proxy requests
- exclude leased ports from allocation after a terminal is deleted
- add a deterministic barrier-based regression test covering deletion and recreation during an in-flight proxy request

## Tests
- `python -m pytest tests/unit/test_ttyd_manager.py tests/integration/test_ttyd_handler.py -q` (28 passed)
- `git diff --check`

Closes #110
Related to #107
