### PR TITLE
fix: unify runtime env parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,14 @@
 # INSTALL_CLOUDFLARED=true   # cloudflared — провайдер SSH-туннеля по умолчанию (issue #79)
 # INSTALL_CHISEL=true        # chisel — альтернативный провайдер SSH-туннеля (issue #79)
 
+# Runtime parsing contract: boolean values accept 1/true/yes/on and
+# 0/false/no/off (case-insensitive). Missing or empty values use the documented
+# default; any other explicit boolean or malformed integer aborts startup.
+# Runtime ports must be in 1..65535 (PORT: 1024..65535); security TTL values
+# below their documented minimum clamp to that minimum (fail-closed).
+
 # Hapi Runner Configuration (optional)
-HAPI_RUNNER_ENABLED=false   # Set to 'true' to enable hapi runner
+HAPI_RUNNER_ENABLED=false   # Set to a true value to enable hapi runner
 # HAPI_HOST=0.0.0.0         # Bind address (default: 0.0.0.0)
 # HAPI_PORT=80              # Port for hapi client connections (default: 80)
 # HAPI_USER=hapi            # Пользователь, под которым работают hapi server/runner и демоны (default: hapi)

--- a/Dockerfile
+++ b/Dockerfile
@@ -284,6 +284,7 @@ RUN chmod +x /bin/tmux-wrapper.sh /bin/glm /bin/claude-auth-snapshot.sh /bin/cli
     chown hapi:hapi /home/hapi/.tmux.conf
 
 COPY entrypoint.sh /entrypoint.sh
+COPY bin/env-contract.sh /usr/local/lib/clihost/env-contract.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080

--- a/app/ttydproxy/config.py
+++ b/app/ttydproxy/config.py
@@ -5,26 +5,42 @@ import re
 from ttydproxy.security import env_bool, env_int, env_secret
 
 
-PORT = env_int(os.environ.get("PORT"), 8080, name="PORT")
+PORT = env_int(
+    os.environ.get("PORT"),
+    8080,
+    name="PORT",
+    minimum=1024,
+    maximum=65535,
+    clamp_minimum=False,
+)
 TTYD_USER = os.environ.get("TTYD_USER", "hapi")
 TTYD_PASSWORD = os.environ.get("TTYD_PASSWORD", "")
 PASSWORD_SECRET = env_secret("PASSWORD_SECRET", "default-secret-change-me")
 TTYD_BASE_PORT = 7681
 CLEANUP_ROOT = os.environ.get("CLEANUP_ROOT", "/home/hapi")
 HAPI_HOME = os.environ.get("HAPI_HOME", f"{CLEANUP_ROOT}/.hapi")
-MAX_TERMINALS = env_int(os.environ.get("MAX_TERMINALS"), 100, name="MAX_TERMINALS")
-# minimum=1: a non-positive TTL would issue already-expired tokens and lock out
-# every login / reject every CSRF check. A bad value clamps to 1s (fail-closed),
-# never expands to the week-long default (B1).
+MAX_TERMINALS = env_int(
+    os.environ.get("MAX_TERMINALS"),
+    100,
+    name="MAX_TERMINALS",
+    minimum=1,
+    clamp_minimum=False,
+)
 SESSION_TIMEOUT = env_int(os.environ.get("SESSION_TIMEOUT"), 604800, name="SESSION_TIMEOUT", minimum=1)
-VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True)
+VIRTUAL_KEYBOARD = env_bool(os.environ.get("VIRTUAL_KEYBOARD"), default=True, name="VIRTUAL_KEYBOARD")
 CSRF_TOKEN_TTL = env_int(os.environ.get("CSRF_TOKEN_TTL"), 604800, name="CSRF_TOKEN_TTL", minimum=1)
-SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False)
+SECURE_COOKIES = env_bool(os.environ.get("SECURE_COOKIES"), default=False, name="SECURE_COOKIES")
 HAPI_URL_FILE = os.environ.get("HAPI_URL_FILE", "/home/hapi/url")
 # SSH connection string written by the tunnel (#79/#82); default matches the
 # path entrypoint.sh writes. Rendered on the dashboard only when present (#80).
 SSH_URL_FILE = os.environ.get("SSH_URL_FILE", "/home/hapi/ssh-url")
-MAX_UPLOAD_SIZE = env_int(os.environ.get("MAX_UPLOAD_SIZE"), 10485760, name="MAX_UPLOAD_SIZE")
+MAX_UPLOAD_SIZE = env_int(
+    os.environ.get("MAX_UPLOAD_SIZE"),
+    10485760,
+    name="MAX_UPLOAD_SIZE",
+    minimum=1,
+    clamp_minimum=False,
+)
 UPLOAD_DIR = os.environ.get("UPLOAD_DIR", f"{CLEANUP_ROOT}/.uploads")
 
 # Per-connection socket read timeout (seconds). Without it a slow client

--- a/app/ttydproxy/security.py
+++ b/app/ttydproxy/security.py
@@ -14,52 +14,60 @@ import pwd
 USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9_.-]{1,32}$")
 
 
-def env_bool(value, default=False):
-    """Parse common boolean env var values."""
-    if value is None:
+def env_bool(value, default=False, name=None):
+    """Parse a boolean, rejecting invalid named environment variables.
+
+    Unnamed callers also use this helper for optional query parameters, where
+    retaining the caller-provided default is the established contract.
+    """
+    if value is None or str(value).strip() == "":
         return default
     value = str(value).strip().lower()
     if value in ("1", "true", "yes", "on"):
         return True
     if value in ("0", "false", "no", "off"):
         return False
-    return default
-
-
-def env_int(value, default, name=None, minimum=None):
-    """Parse an integer env var value, falling back to default on garbage.
-
-    When `minimum` is given, the result is never returned below it: a parsed
-    value below the minimum (or a fallback `default` below it) is clamped UP to
-    the minimum (warning + minimum). This guards time-to-live settings against a
-    non-positive value that would otherwise issue already-expired tokens and
-    lock out logins (B1) — clamping fails CLOSED (the access window shrinks to
-    the minimum) rather than expanding to a possibly-large default.
-    """
-    def _floor(n):
-        # The minimum binds every return path, so even a sub-minimum default
-        # (no real caller passes one today) can't silently undercut the floor.
-        return n if minimum is None or n >= minimum else minimum
-
-    if value is None or str(value).strip() == "":
-        return _floor(default)
+    if name is None:
+        return default
     label = name or "env var"
-    try:
-        result = int(str(value).strip())
-    except ValueError:
-        print(
-            f"Invalid integer for {label}: {value!r}, using default {default}",
-            file=sys.stderr,
-            flush=True,
-        )
-        return _floor(default)
+    raise ValueError(
+        f"Invalid boolean for {label}: {value!r}; "
+        "expected 1/true/yes/on or 0/false/no/off"
+    )
+
+
+def env_int(
+    value,
+    default,
+    name=None,
+    minimum=None,
+    maximum=None,
+    clamp_minimum=True,
+):
+    """Parse an integer env value, rejecting explicit invalid/out-of-range values."""
+    if value is None or str(value).strip() == "":
+        result = default
+    else:
+        label = name or "env var"
+        text = str(value).strip()
+        if not re.fullmatch(r"[+-]?[0-9]+", text):
+            raise ValueError(f"Invalid integer for {label}: {value!r}")
+        try:
+            result = int(text)
+        except ValueError as exc:
+            raise ValueError(f"Invalid integer for {label}: {value!r}") from exc
+    label = name or "env var"
     if minimum is not None and result < minimum:
-        print(
-            f"{label}: {result} below minimum {minimum}, clamping to {minimum}",
-            file=sys.stderr,
-            flush=True,
-        )
-        return minimum
+        if clamp_minimum:
+            print(
+                f"{label}: {result} below minimum {minimum}, clamping to {minimum}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return minimum
+        raise ValueError(f"{label}: {result} below minimum {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{label}: {result} above maximum {maximum}")
     return result
 
 
@@ -255,4 +263,3 @@ def verify_pam_password(username, password):
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
-

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -429,7 +429,16 @@ cmd_restart() {
     case "$1" in
       --apply) apply="true" ;;
       --yes) yes="true" ;;
-      --) shift; break ;;
+      --)
+        shift
+        [ -z "${app}" ] || die "restart accepts exactly one APP"
+        [ "$#" -le 1 ] || die "restart accepts exactly one APP"
+        if [ "$#" -eq 1 ]; then
+          app="$1"
+          shift
+        fi
+        break
+        ;;
       -*) die "unknown option: $1" ;;
       *)
         [ -z "${app}" ] || die "restart accepts exactly one APP"

--- a/bin/clihost-billing.sh
+++ b/bin/clihost-billing.sh
@@ -459,8 +459,13 @@ cmd_restart() {
     die "restart --apply in non-TTY mode requires --yes"
   fi
 
-  if command -v dokku >/dev/null 2>&1 && dokku ps:restart "${app}"; then
-    return 0
+  if command -v dokku >/dev/null 2>&1; then
+    if dokku ps:restart "${app}"; then
+      return 0
+    fi
+    echo "dokku ps:restart ${app} failed; falling back to docker restart ${app}.web.1" >&2
+  else
+    echo "dokku not found; falling back to docker restart ${app}.web.1" >&2
   fi
   docker restart -- "${app}.web.1"
 }

--- a/bin/env-contract.sh
+++ b/bin/env-contract.sh
@@ -43,15 +43,25 @@ env_positive_int() {
 
   digits="${value#"${value%%[!0]*}"}"
   [ -n "${digits}" ] || digits=0
-  if [ "${#digits}" -lt "${#minimum}" ] \
-     || { [ "${#digits}" -eq "${#minimum}" ] && [[ "${digits}" < "${minimum}" ]]; }; then
+
+  # Strip leading zeros from the bounds too so the length+lexicographic
+  # comparison below reflects numeric magnitude, not raw digit-string form
+  # (a zero-padded bound like "05" must compare as 5, not sort above "9").
+  local min_digits="${minimum#"${minimum%%[!0]*}"}"
+  [ -n "${min_digits}" ] || min_digits=0
+  if [ "${#digits}" -lt "${#min_digits}" ] \
+     || { [ "${#digits}" -eq "${#min_digits}" ] && [[ "${digits}" < "${min_digits}" ]]; }; then
     echo "ERROR: ${name}=${value} is below minimum ${minimum}" >&2
     return 1
   fi
-  if [ -n "${maximum}" ] && { [ "${#digits}" -gt "${#maximum}" ] \
-     || { [ "${#digits}" -eq "${#maximum}" ] && [[ "${digits}" > "${maximum}" ]]; }; }; then
-    echo "ERROR: ${name}=${value} is above maximum ${maximum}" >&2
-    return 1
+  if [ -n "${maximum}" ]; then
+    local max_digits="${maximum#"${maximum%%[!0]*}"}"
+    [ -n "${max_digits}" ] || max_digits=0
+    if [ "${#digits}" -gt "${#max_digits}" ] \
+       || { [ "${#digits}" -eq "${#max_digits}" ] && [[ "${digits}" > "${max_digits}" ]]; }; then
+      echo "ERROR: ${name}=${value} is above maximum ${maximum}" >&2
+      return 1
+    fi
   fi
 
   printf -v "${name}" '%s' "${digits}"

--- a/bin/env-contract.sh
+++ b/bin/env-contract.sh
@@ -86,5 +86,16 @@ env_secret() {
     # Keep the resolved secret in this shell only. Service children must receive
     # secrets through their dedicated file/env channels, not by broad inheritance.
     export -n "${name}" "${file_name}" 2>/dev/null || true
+  elif [ -n "${!name-}" ]; then
+    # No *_FILE override: a directly-supplied value still goes through the same
+    # trim + empty-after-trim check as the file path, so a whitespace-only
+    # PASSWORD_SECRET fails closed instead of silently becoming the effective
+    # secret.
+    value="$(_env_trim "${!name}")"
+    if [ -z "${value}" ]; then
+      echo "ERROR: ${name} is set but empty (whitespace only)" >&2
+      return 1
+    fi
+    printf -v "${name}" '%s' "${value}"
   fi
 }

--- a/bin/env-contract.sh
+++ b/bin/env-contract.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Runtime environment parsing shared by entrypoint.sh.  A missing or empty
+# value uses its documented default; an explicitly supplied malformed value is
+# a configuration error.
+
+_env_trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+env_bool() {
+  local name="$1" default="$2" value
+  value="$(_env_trim "${!name-}")"
+  [ -n "${value}" ] || value="${default}"
+
+  case "${value}" in
+    1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]) printf -v "${name}" '%s' true ;;
+    0|[Ff][Aa][Ll][Ss][Ee]|[Nn][Oo]|[Oo][Ff][Ff]) printf -v "${name}" '%s' false ;;
+    *)
+      echo "ERROR: ${name}='${value}' is invalid; expected 1/true/yes/on or 0/false/no/off" >&2
+      return 1
+      ;;
+  esac
+  export "${name}"
+}
+
+env_positive_int() {
+  local name="$1" default="$2" minimum="$3" maximum="${4-}" value digits
+  value="$(_env_trim "${!name-}")"
+  [ -n "${value}" ] || value="${default}"
+  case "${value}" in
+    +*) value="${value#+}" ;;
+  esac
+  case "${value}" in
+    ''|*[!0-9]*)
+      echo "ERROR: ${name}='${value}' is invalid; expected a decimal integer" >&2
+      return 1
+      ;;
+  esac
+
+  digits="${value#"${value%%[!0]*}"}"
+  [ -n "${digits}" ] || digits=0
+  if [ "${#digits}" -lt "${#minimum}" ] \
+     || { [ "${#digits}" -eq "${#minimum}" ] && [[ "${digits}" < "${minimum}" ]]; }; then
+    echo "ERROR: ${name}=${value} is below minimum ${minimum}" >&2
+    return 1
+  fi
+  if [ -n "${maximum}" ] && { [ "${#digits}" -gt "${#maximum}" ] \
+     || { [ "${#digits}" -eq "${#maximum}" ] && [[ "${digits}" > "${maximum}" ]]; }; }; then
+    echo "ERROR: ${name}=${value} is above maximum ${maximum}" >&2
+    return 1
+  fi
+
+  printf -v "${name}" '%s' "${digits}"
+  export "${name}"
+}
+
+env_secret() {
+  local name="$1" file_name path value
+  file_name="${name}_FILE"
+  path="${!file_name-}"
+  if [ -n "${path}" ]; then
+    if [ ! -f "${path}" ] || [ ! -r "${path}" ]; then
+      echo "ERROR: Cannot read ${file_name}=${path}" >&2
+      return 1
+    fi
+    value="$(_env_trim "$(cat -- "${path}")")"
+    if [ -z "${value}" ]; then
+      echo "ERROR: ${file_name}=${path} is empty" >&2
+      return 1
+    fi
+    printf -v "${name}" '%s' "${value}"
+    # Keep the resolved secret in this shell only. Service children must receive
+    # secrets through their dedicated file/env channels, not by broad inheritance.
+    export -n "${name}" "${file_name}" 2>/dev/null || true
+  fi
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,22 @@ env_positive_int CHISEL_REMOTE_PORT 2222 1 65535
 # proxy's Docker-secret contract. An unreadable or empty file fails startup.
 env_secret PASSWORD_SECRET
 
+# Fail closed on a malformed Python-owned env var (e.g. MAX_TERMINALS,
+# SECURE_COOKIES) BEFORE any destructive/idempotent-breaking startup step runs
+# (cleanup_runner_state deletes persisted hapi state; Hermes/Droid/AO daemons
+# get registered and started). Importing ttydproxy.config here runs the same
+# strict parsing the backgrounded proxy process would hit later, but as a
+# side-effect-free preflight check in this shell — not after state has already
+# been torn down and daemons started, which would otherwise repeat those
+# destructive actions on every crash-loop restart before failing closed.
+if ! PYTHONPATH=/app python3 -c 'import ttydproxy.config' 2>/tmp/clihost-config-preflight.err; then
+  echo "ERROR: invalid TTYD proxy configuration (see below); aborting before any runner state is touched" >&2
+  cat /tmp/clihost-config-preflight.err >&2
+  rm -f /tmp/clihost-config-preflight.err
+  exit 1
+fi
+rm -f /tmp/clihost-config-preflight.err
+
 # Generate a random secret only when neither PASSWORD_SECRET nor its
 # authoritative *_FILE source supplied one.
 if [ -z "${PASSWORD_SECRET:-}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -483,6 +483,19 @@ CLEANUP_ROOT="${CLEANUP_ROOT}" \
 HAPI_HOME="${HAPI_HOME}" \
 TTYD_SANDBOX="${TTYD_SANDBOX}" \
 runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &
+PROXY_PID=$!
+
+# Fail closed if the proxy dies immediately after launch. The strict env
+# contract (#113) makes ttydproxy.config raise on a malformed value for a
+# Python-owned var (e.g. MAX_TERMINALS, SECURE_COOKIES) that the shell-side
+# env-contract.sh does not itself validate. Without this check the container
+# would keep running (sshd stays up via the unconditional `exec` below) with
+# its only HTTP service dead and no supervision to catch it.
+sleep 1
+if ! kill -0 "${PROXY_PID}" 2>/dev/null; then
+  echo "ERROR: TTYD HTTP proxy exited immediately after startup; check the error above (e.g. an invalid env value)" >&2
+  exit 1
+fi
 
 # Drop any stale dashboard URL up front. On a persistent /home/hapi volume a URL
 # from a previous hapi-enabled image would otherwise make the dashboard render an

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source /usr/local/lib/clihost/env-contract.sh
+
 # TTYD Configuration
 : "${PORT:=8080}"
 : "${TTYD_USER:=hapi}"
 : "${TTYD_PASSWORD:=}"
-
-# Generate secure random secret if not provided
-if [ -z "${PASSWORD_SECRET:-}" ]; then
-  PASSWORD_SECRET=$(openssl rand -hex 32)
-  echo "Generated random PASSWORD_SECRET (set PASSWORD_SECRET environment variable to persist across restarts)"
-fi
 
 : "${HAPI_HOST:=0.0.0.0}"
 : "${HAPI_PORT:=80}"
@@ -34,6 +30,32 @@ fi
 : "${CHISEL_SERVER:=}"
 : "${CHISEL_AUTH:=}"
 : "${CHISEL_REMOTE_PORT:=2222}"
+
+# Normalize every runtime boolean before any service starts. Unknown explicit
+# values fail startup instead of silently toggling a service in the opposite
+# direction. Runtime ports likewise accept decimal integers only and fail on
+# invalid/out-of-range input.
+env_bool HAPI_RUNNER_ENABLED false
+env_bool DROID_DAEMON_ENABLED false
+env_bool AO_DAEMON_ENABLED false
+env_bool TTYD_SANDBOX false
+env_bool SSH_TUNNEL_ENABLED false
+env_bool HERMES_AUTO_UPDATE true
+env_positive_int PORT 8080 1024 65535
+env_positive_int HAPI_PORT 80 1 65535
+env_positive_int AO_PORT 3001 1 65535
+env_positive_int CHISEL_REMOTE_PORT 2222 1 65535
+
+# PASSWORD_SECRET_FILE is authoritative when supplied, matching the Python
+# proxy's Docker-secret contract. An unreadable or empty file fails startup.
+env_secret PASSWORD_SECRET
+
+# Generate a random secret only when neither PASSWORD_SECRET nor its
+# authoritative *_FILE source supplied one.
+if [ -z "${PASSWORD_SECRET:-}" ]; then
+  PASSWORD_SECRET=$(openssl rand -hex 32)
+  echo "Generated random PASSWORD_SECRET (set PASSWORD_SECRET environment variable to persist across restarts)"
+fi
 
 HAPI_USER="${HAPI_USER:-hapi}"
 HAPI_USER_HOME="/home/${HAPI_USER}"
@@ -326,14 +348,6 @@ fi
 # default, this no-auth/no-TLS daemon could be exposed on a published port — re-check
 # that the hardcoded-loopback invariant still holds before bumping the pinned ao ref.
 if [ "${AO_DAEMON_ENABLED}" = "true" ]; then
-  # Validate AO_PORT numeric: it is interpolated into the `ao daemon` launch
-  # string, so a non-numeric value must fail loudly (mirrors PORT / CHISEL_REMOTE_PORT).
-  case "${AO_PORT}" in
-    ''|*[!0-9]*)
-      echo "ERROR: AO_PORT='${AO_PORT}' must be a positive integer" >&2
-      exit 1
-      ;;
-  esac
   if PATH="${HAPI_RUN_PATH}" command -v ao >/dev/null 2>&1; then
     AO_DAEMON_LOG="${HAPI_HOME}/ao-daemon.log"
     # `: >` (truncate-or-create), not `touch`: the launch appends via `>>`, so
@@ -363,15 +377,6 @@ SSH_URL_FILE="${HAPI_USER_HOME}/ssh-url"
 # from a previous run / provider); recreated below only when a tunnel starts.
 rm -f "${SSH_URL_FILE}" 2>/dev/null || true
 if [ "${SSH_TUNNEL_ENABLED}" = "true" ]; then
-  # Validate CHISEL_REMOTE_PORT is numeric up front: it is interpolated into the
-  # chisel R:<port>:localhost:22 spec, so a non-numeric value must fail loudly
-  # rather than silently produce a broken forward (mirrors the PORT check below).
-  case "${CHISEL_REMOTE_PORT}" in
-    ''|*[!0-9]*)
-      echo "ERROR: CHISEL_REMOTE_PORT='${CHISEL_REMOTE_PORT}' must be a positive integer" >&2
-      exit 1
-      ;;
-  esac
   SSH_TUNNEL_LOG="${HAPI_HOME}/ssh-tunnel.log"
   touch "${SSH_TUNNEL_LOG}"
   chown "${HAPI_USER}:${HAPI_USER}" "${SSH_TUNNEL_LOG}"
@@ -454,18 +459,6 @@ fi
 # Start TTYD HTTP proxy (manages TTYD processes dynamically; drops root and
 # runs as TTYD_USER). The secret goes through a TTYD_USER-only file (Docker
 # *_FILE convention) so it never appears in the proxy's /proc/<pid>/environ.
-# Validate PORT is numeric first: `[ "$PORT" -lt 1024 ]` on a non-numeric value
-# exits 2 (error, not false), which would let the range guard silently pass.
-case "${PORT}" in
-  ''|*[!0-9]*)
-    echo "ERROR: PORT=${PORT} must be a positive integer" >&2
-    exit 1
-    ;;
-esac
-if [ "${PORT}" -lt 1024 ]; then
-  echo "ERROR: PORT=${PORT} is a privileged port; the proxy runs as ${TTYD_USER} and needs PORT >= 1024" >&2
-  exit 1
-fi
 # The proxy runs as TTYD_USER and creates upload files itself; pre-create and
 # chown UPLOAD_DIR so a bind-mounted /home/hapi (often not writable by the hapi
 # UID) doesn't make pasted-image uploads fail with 500.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,13 +58,27 @@ env_secret PASSWORD_SECRET
 # side-effect-free preflight check in this shell — not after state has already
 # been torn down and daemons started, which would otherwise repeat those
 # destructive actions on every crash-loop restart before failing closed.
-if ! PYTHONPATH=/app python3 -c 'import ttydproxy.config' 2>/tmp/clihost-config-preflight.err; then
-  echo "ERROR: invalid TTYD proxy configuration (see below); aborting before any runner state is touched" >&2
-  cat /tmp/clihost-config-preflight.err >&2
-  rm -f /tmp/clihost-config-preflight.err
-  exit 1
-fi
-rm -f /tmp/clihost-config-preflight.err
+# mktemp -u only *names* a unique path; opening it with the shell's O_CREAT|
+# O_EXCL redirection guard (noclobber) is what actually matters here — a fixed,
+# predictable /tmp path let an unprivileged user pre-plant a symlink before this
+# root-run redirection ever opens it, and a plain `2>path` follows an existing
+# symlink and truncates its target before python3 even runs. `mktemp` gives an
+# unpredictable name so nothing can be pre-planted, and `set -C` (noclobber)
+# makes the shell refuse to open the target at all if anything (symlink or
+# regular file) already exists there — belt and suspenders.
+clihost_preflight_err="$(mktemp -u /tmp/clihost-config-preflight.XXXXXXXX.err)"
+(
+  set -C
+  if ! PYTHONPATH=/app python3 -c 'import ttydproxy.config' 2>"${clihost_preflight_err}"; then
+    echo "ERROR: invalid TTYD proxy configuration (see below); aborting before any runner state is touched" >&2
+    cat -- "${clihost_preflight_err}" >&2
+    rm -f -- "${clihost_preflight_err}"
+    exit 1
+  fi
+)
+clihost_preflight_status=$?
+rm -f -- "${clihost_preflight_err}"
+[ "${clihost_preflight_status}" -eq 0 ] || exit "${clihost_preflight_status}"
 
 # Generate a random secret only when neither PASSWORD_SECRET nor its
 # authoritative *_FILE source supplied one.

--- a/tests/unit/test_env_bool.py
+++ b/tests/unit/test_env_bool.py
@@ -24,8 +24,12 @@ class TestEnvBoolDefault(unittest.TestCase):
         self.assertTrue(env_bool(None, default=True))
         self.assertFalse(env_bool(""))
         self.assertTrue(env_bool("", default=True))
-        self.assertFalse(env_bool("invalid"))
-        self.assertTrue(env_bool("maybe", default=True))
+
+    def test_invalid_explicit_value_raises(self):
+        for value in ("invalid", "maybe", "2"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "expected 1/true/yes/on"):
+                    env_bool(value, default=True, name="FEATURE_ENABLED")
 
 
 class TestEnvBoolWhitespace(unittest.TestCase):
@@ -38,4 +42,3 @@ class TestEnvBoolWhitespace(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/unit/test_env_contract.py
+++ b/tests/unit/test_env_contract.py
@@ -1,0 +1,126 @@
+"""Table-driven parity tests for the Bash and Python env contracts (#113)."""
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+from ttydproxy.security import env_bool, env_int
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SHELL_CONTRACT = REPO_ROOT / "bin/env-contract.sh"
+
+
+def bash_parse(function, name, value, *args):
+    env = os.environ.copy()
+    env.pop(name, None)
+    if value is not None:
+        env[name] = value
+    command = (
+        'source "$1"; shift; '
+        f'{function} {name} "$@" && printf "%s" "${{{name}}}"'
+    )
+    return subprocess.run(
+        ["bash", "-c", command, "bash", str(SHELL_CONTRACT), *map(str, args)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestBooleanContractParity(unittest.TestCase):
+    def test_same_boolean_inputs(self):
+        cases = (
+            (None, False, "false"),
+            ("", True, "true"),
+            ("  TRUE  ", False, "true"),
+            ("1", False, "true"),
+            ("yes", False, "true"),
+            ("ON", False, "true"),
+            ("0", True, "false"),
+            ("No", True, "false"),
+            ("off", True, "false"),
+        )
+        for value, default, expected in cases:
+            with self.subTest(value=value, default=default):
+                shell = bash_parse("env_bool", "FEATURE_ENABLED", value, str(default).lower())
+                self.assertEqual(shell.returncode, 0, shell.stderr)
+                self.assertEqual(shell.stdout, expected)
+                self.assertEqual(str(env_bool(value, default=default)).lower(), expected)
+
+    def test_same_invalid_boolean_inputs(self):
+        for value in ("maybe", "2", "truthy"):
+            with self.subTest(value=value):
+                shell = bash_parse("env_bool", "FEATURE_ENABLED", value, "false")
+                self.assertNotEqual(shell.returncode, 0)
+                with self.assertRaises(ValueError):
+                    env_bool(value, name="FEATURE_ENABLED")
+
+
+class TestIntegerContractParity(unittest.TestCase):
+    def test_same_positive_integer_inputs(self):
+        for value, expected in ((None, 8080), ("", 8080), (" 8081 ", 8081), ("+42", 42), ("0007", 7)):
+            with self.subTest(value=value):
+                shell = bash_parse("env_positive_int", "PORT", value, 8080, 1, 65535)
+                self.assertEqual(shell.returncode, 0, shell.stderr)
+                self.assertEqual(int(shell.stdout), expected)
+                self.assertEqual(
+                    env_int(value, 8080, minimum=1, maximum=65535, clamp_minimum=False),
+                    expected,
+                )
+
+    def test_same_invalid_integer_inputs(self):
+        for value in ("abc", "12.5", "1_000", "١٢", "-1", "0", "65536"):
+            with self.subTest(value=value):
+                shell = bash_parse("env_positive_int", "PORT", value, 8080, 1, 65535)
+                self.assertNotEqual(shell.returncode, 0)
+                with self.assertRaises(ValueError):
+                    env_int(
+                        value,
+                        8080,
+                        name="PORT",
+                        minimum=1,
+                        maximum=65535,
+                        clamp_minimum=False,
+                    )
+
+
+class TestSecretContract(unittest.TestCase):
+    def test_file_is_authoritative(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as secret_file:
+            secret_file.write("  from-file\n")
+            secret_file.flush()
+            env = os.environ.copy()
+            env.update(PASSWORD_SECRET="from-env", PASSWORD_SECRET_FILE=secret_file.name)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; env_secret PASSWORD_SECRET && printf %s "$PASSWORD_SECRET"',
+                    "bash",
+                    str(SHELL_CONTRACT),
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "from-file")
+
+    def test_empty_file_fails(self):
+        with tempfile.NamedTemporaryFile() as secret_file:
+            env = os.environ.copy()
+            env["PASSWORD_SECRET_FILE"] = secret_file.name
+            result = subprocess.run(
+                ["bash", "-c", 'source "$1"; env_secret PASSWORD_SECRET', "bash", str(SHELL_CONTRACT)],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is empty", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_env_contract.py
+++ b/tests/unit/test_env_contract.py
@@ -85,6 +85,18 @@ class TestIntegerContractParity(unittest.TestCase):
                         clamp_minimum=False,
                     )
 
+    def test_zero_padded_bounds_compare_numerically(self):
+        # A zero-padded minimum/maximum must not be compared lexicographically
+        # against the (leading-zero-stripped) value: "9" is >= "05" numerically
+        # even though "9" > "05" as bare strings would already pass, but "9"
+        # vs a padded maximum like "007" must correctly be rejected as above it.
+        shell = bash_parse("env_positive_int", "PORT", "9", 8080, "05", 65535)
+        self.assertEqual(shell.returncode, 0, shell.stderr)
+        self.assertEqual(int(shell.stdout), 9)
+
+        shell = bash_parse("env_positive_int", "PORT", "9", 8080, 1, "007")
+        self.assertNotEqual(shell.returncode, 0)
+
 
 class TestSecretContract(unittest.TestCase):
     def test_file_is_authoritative(self):

--- a/tests/unit/test_env_int.py
+++ b/tests/unit/test_env_int.py
@@ -1,7 +1,5 @@
 """Tests for env_int() from production code."""
-import io
 import unittest
-from contextlib import redirect_stderr
 
 from ttydproxy.security import env_int
 
@@ -24,38 +22,19 @@ class TestEnvIntDefault(unittest.TestCase):
     def test_empty_returns_default(self):
         self.assertEqual(env_int("", 8080), 8080)
 
-    def test_invalid_returns_default(self):
+    def test_invalid_explicit_value_raises(self):
         for value in ("abc", "12.5", "1e3", "0x10", "--1"):
             with self.subTest(value=value):
-                self.assertEqual(env_int(value, 7), 7)
-
-    def test_invalid_warns_to_stderr(self):
-        buf = io.StringIO()
-        with redirect_stderr(buf):
-            env_int("abc", 7, name="MAX_TERMINALS")
-        message = buf.getvalue()
-        self.assertIn("MAX_TERMINALS", message)
-        self.assertIn("abc", message)
-        self.assertIn("7", message)
-
-    def test_none_does_not_warn(self):
-        buf = io.StringIO()
-        with redirect_stderr(buf):
-            env_int(None, 7, name="PORT")
-        self.assertEqual(buf.getvalue(), "")
+                with self.assertRaisesRegex(ValueError, "Invalid integer"):
+                    env_int(value, 7, name="MAX_TERMINALS")
 
 
-class TestEnvIntMinimum(unittest.TestCase):
-    """A lower bound for time-to-live settings: a non-positive value must not be
-    accepted verbatim (it would issue already-expired tokens / lock out logins).
-    Below-minimum values clamp UP to the minimum (fail-closed) rather than
-    expanding to a possibly-large default.
-    """
+class TestEnvIntRange(unittest.TestCase):
 
-    def test_below_minimum_clamps_to_minimum(self):
+    def test_below_minimum_clamps(self):
         self.assertEqual(env_int("-1", 604800, minimum=1), 1)
 
-    def test_zero_below_minimum_clamps_to_minimum(self):
+    def test_zero_below_minimum_clamps(self):
         self.assertEqual(env_int("0", 100, minimum=1), 1)
 
     def test_at_minimum_is_kept(self):
@@ -64,26 +43,21 @@ class TestEnvIntMinimum(unittest.TestCase):
     def test_above_minimum_is_kept(self):
         self.assertEqual(env_int("5000", 100, minimum=1), 5000)
 
-    def test_below_minimum_warns_to_stderr(self):
-        buf = io.StringIO()
-        with redirect_stderr(buf):
-            env_int("-1", 604800, name="SESSION_TIMEOUT", minimum=1)
-        message = buf.getvalue()
-        self.assertIn("SESSION_TIMEOUT", message)
-        # The warning must surface the clamp target (the minimum), not silence.
-        self.assertIn("1", message)
-
     def test_no_minimum_keeps_negative(self):
         # Backwards compatible: without a minimum, a negative value is returned
         # verbatim (e.g. settings where negative is meaningful).
         self.assertEqual(env_int("-5", 1), -5)
 
-    def test_sub_minimum_default_is_also_floored(self):
-        # The minimum binds the fallback paths too: a default below the minimum
-        # is clamped up, so the floor can never be silently undercut.
+    def test_invalid_default_is_range_checked(self):
         self.assertEqual(env_int(None, 0, minimum=1), 1)
-        self.assertEqual(env_int("", 0, minimum=1), 1)
-        self.assertEqual(env_int("abc", 0, minimum=1), 1)
+
+    def test_strict_minimum_raises(self):
+        with self.assertRaisesRegex(ValueError, "below minimum 1"):
+            env_int("0", 100, minimum=1, clamp_minimum=False)
+
+    def test_above_maximum_raises(self):
+        with self.assertRaisesRegex(ValueError, "above maximum 65535"):
+            env_int("65536", 8080, name="PORT", maximum=65535)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -115,6 +115,71 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertGreater(validation_pos, -1, "PORT is not validated")
         self.assertLess(validation_pos, proxy_pos)
 
+    def test_proxy_startup_is_verified_before_continuing(self):
+        # The strict env-parsing contract (#113) makes ttydproxy.config raise
+        # ValueError at import time for a malformed Python-owned var (e.g.
+        # MAX_TERMINALS, SECURE_COOKIES) that the shell-side contract does not
+        # validate. Backgrounding the proxy with a bare `&` and never checking
+        # it before `exec sshd` would leave the container "healthy" (sshd up)
+        # with its only HTTP service dead. The entrypoint must capture the
+        # proxy's PID and fail closed if it does not survive a short grace
+        # window.
+        proxy_launch_pos = self.text.find(
+            'runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &'
+        )
+        pid_capture_pos = self.text.find("PROXY_PID=$!")
+        sshd_pos = self.text.find("exec /usr/sbin/sshd -D -e")
+        self.assertGreater(proxy_launch_pos, -1, "proxy launch line not found")
+        self.assertGreater(
+            pid_capture_pos, -1,
+            "entrypoint.sh must capture the proxy PID ($!) to verify startup",
+        )
+        self.assertGreater(pid_capture_pos, proxy_launch_pos)
+        self.assertGreater(sshd_pos, -1)
+        self.assertLess(
+            pid_capture_pos, sshd_pos,
+            "PID capture must happen before exec sshd",
+        )
+        # A liveness check (kill -0) must run between the PID capture and the
+        # final exec, and abort (die/exit) on failure rather than continue
+        # with a dead proxy.
+        liveness_pos = self.text.find('kill -0 "${PROXY_PID}"')
+        self.assertGreater(
+            liveness_pos, -1,
+            "entrypoint.sh must verify the proxy process is still alive",
+        )
+        self.assertGreater(liveness_pos, pid_capture_pos)
+        self.assertLess(liveness_pos, sshd_pos)
+        self.assertIn("TTYD HTTP proxy exited immediately after startup", self.text)
+
+    def test_proxy_liveness_check_is_actually_fail_closed(self):
+        # Execute the real PID-capture + kill -0 supervision block extracted
+        # from entrypoint.sh against a process that exits immediately (like
+        # ttyd_proxy.py would on a strict env ValueError) and one that stays
+        # alive, to prove the mechanism itself works, not just its presence.
+        match = re.search(
+            r'^sleep 1\nif ! kill -0 "\$\{PROXY_PID\}".*?\nfi\n',
+            self.text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "proxy liveness check block not found")
+        liveness_block = match.group(0).replace("sleep 1", "sleep 0.1")
+
+        dying = subprocess.run(
+            ["bash", "-c", f'(exit 1) & PROXY_PID=$!\n{liveness_block}\necho SURVIVED'],
+            capture_output=True, text=True,
+        )
+        self.assertNotEqual(dying.returncode, 0)
+        self.assertIn("exited immediately after startup", dying.stderr)
+        self.assertNotIn("SURVIVED", dying.stdout)
+
+        surviving = subprocess.run(
+            ["bash", "-c", f'sleep 5 & PROXY_PID=$!\n{liveness_block}\necho SURVIVED\nkill "$PROXY_PID"'],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(surviving.returncode, 0, surviving.stderr)
+        self.assertIn("SURVIVED", surviving.stdout)
+
     def test_upload_dir_prepared_before_proxy(self):
         # The unprivileged proxy creates upload files itself; a bind-mounted
         # /home/hapi may not be writable by the hapi UID, so the entrypoint
@@ -2769,6 +2834,38 @@ printf '\n' >> "${CLIHOST_TEST_LOG}"
                 env_extra={"CLIHOST_TEST_LOG": str(log)},
             )
             self.assertNotEqual(out.returncode, 0)
+            self.assertNotIn("restart", log.read_text())
+
+    def test_restart_accepts_app_after_option_terminator(self):
+        # `--` must stop option parsing without discarding the APP argument
+        # that follows it (a legitimate app name is not an option).
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            out = self._run(
+                ["restart", "--", "clihost-good"], tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_TEST_LOG": str(log)},
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn(
+                "would run: dokku ps:restart clihost-good", out.stdout
+            )
+
+    def test_restart_rejects_multiple_apps_after_option_terminator(self):
+        # A single `--` must still enforce "exactly one APP"; it is not a
+        # license to accept every remaining positional argument.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            log = self._make_billing_control_fakes(tmp_path)
+            out = self._run(
+                ["restart", "--", "clihost-good", "clihost-other"],
+                tmp_path / "billing",
+                extra_path=str(tmp_path),
+                env_extra={"CLIHOST_TEST_LOG": str(log)},
+            )
+            self.assertNotEqual(out.returncode, 0)
+            self.assertIn("exactly one APP", out.stderr)
             self.assertNotIn("restart", log.read_text())
 
     def test_restart_apply_requires_yes_in_non_tty(self):

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -20,6 +20,7 @@ CLAUDE_AUTH_SNAPSHOT = REPO_ROOT / "bin/claude-auth-snapshot.sh"
 CLAUDE_AUTH_SNAPSHOT_HOST = REPO_ROOT / "bin/claude-auth-snapshot-host.sh"
 CLIHOST_SYNC = REPO_ROOT / "bin/clihost-sync.sh"
 CLIHOST_BILLING = REPO_ROOT / "bin/clihost-billing.sh"
+ENV_CONTRACT = REPO_ROOT / "bin/env-contract.sh"
 CLIHOST_BILLING_LIB = REPO_ROOT / "bin/clihost_billing_lib.py"
 README = REPO_ROOT / "README.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
@@ -53,6 +54,7 @@ class TestShellSyntax(unittest.TestCase):
             CLAUDE_AUTH_SNAPSHOT_HOST,
             CLIHOST_SYNC,
             CLIHOST_BILLING,
+            ENV_CONTRACT,
         ):
             with self.subTest(script=script.name):
                 result = subprocess.run(
@@ -108,13 +110,10 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertIn('install -m 400 -o "${TTYD_USER}"', self.text)
 
     def test_port_validated_numeric_before_range_check(self):
-        # A non-numeric PORT must fail loudly: `[ "$PORT" -lt 1024 ]` returns
-        # exit 2 (error, not "false"), so the range guard silently passes and
-        # the proxy starts on the default 8080. A numeric pre-check prevents it.
-        case_pos = self.text.find("*[!0-9]*")
-        range_pos = self.text.find('[ "${PORT}" -lt 1024 ]')
-        self.assertGreater(case_pos, -1, "PORT is not validated as numeric")
-        self.assertLess(case_pos, range_pos)
+        validation_pos = self.text.find("env_positive_int PORT 8080 1024 65535")
+        proxy_pos = self.text.find('runuser -u "${TTYD_USER}" -- python3')
+        self.assertGreater(validation_pos, -1, "PORT is not validated")
+        self.assertLess(validation_pos, proxy_pos)
 
     def test_upload_dir_prepared_before_proxy(self):
         # The unprivileged proxy creates upload files itself; a bind-mounted
@@ -217,14 +216,11 @@ class TestEntrypointRegressions(unittest.TestCase):
     def test_ao_port_validated_numeric_in_daemon_gate(self):
         # AO_PORT is interpolated into the `ao daemon` launch string, so a
         # non-numeric value must fail loudly (mirrors PORT / CHISEL_REMOTE_PORT).
-        # The guard lives inside the AO_DAEMON_ENABLED gate so the default path
-        # (flag off) never validates a value it doesn't use.
         gate_pos = self.text.find('if [ "${AO_DAEMON_ENABLED}" = "true" ]; then')
         self.assertGreater(gate_pos, -1, "AO_DAEMON_ENABLED gate is missing")
-        check_pos = self.text.find(
-            "AO_PORT='${AO_PORT}' must be a positive integer", gate_pos
-        )
-        self.assertGreater(check_pos, gate_pos, "AO_PORT numeric check missing in gate")
+        check_pos = self.text.find("env_positive_int AO_PORT 3001 1 65535")
+        self.assertGreater(check_pos, -1, "AO_PORT numeric check missing")
+        self.assertLess(check_pos, gate_pos)
 
     def test_ssh_tunnel_env_defaults(self):
         # Pluggable SSH tunnel (issue #79): env defaults must be set so the gate
@@ -320,10 +316,12 @@ class TestEntrypointRegressions(unittest.TestCase):
         # CHISEL_REMOTE_PORT is interpolated into the R:<port>:... spec, so a
         # non-numeric value must fail loudly (like the PORT check), not silently
         # produce a broken forward.
-        self.assertIn(
-            "CHISEL_REMOTE_PORT='${CHISEL_REMOTE_PORT}' must be a positive integer",
-            self.text,
+        validation_pos = self.text.find(
+            "env_positive_int CHISEL_REMOTE_PORT 2222 1 65535"
         )
+        tunnel_pos = self.text.find('if [ "${SSH_TUNNEL_ENABLED}" = "true" ]; then')
+        self.assertGreater(validation_pos, -1)
+        self.assertLess(validation_pos, tunnel_pos)
 
     def test_ssh_tunnel_logs_via_redirect_not_tee(self):
         # Logging through a plain redirect (not `| tee`) keeps $! on the tunnel

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -183,7 +183,8 @@ class TestEntrypointRegressions(unittest.TestCase):
         # ttydproxy.config parser would) rather than just checking the text is
         # present.
         match = re.search(
-            r"^if ! PYTHONPATH=/app python3 -c 'import ttydproxy\.config'.*?\nfi\n",
+            r"^clihost_preflight_err=.*?\n"
+            r"\[ \"\$\{clihost_preflight_status\}\" -eq 0 \] \|\| exit \"\$\{clihost_preflight_status\}\"\n",
             self.text,
             re.MULTILINE | re.DOTALL,
         )
@@ -209,6 +210,51 @@ class TestEntrypointRegressions(unittest.TestCase):
         )
         self.assertEqual(good.returncode, 0, good.stderr)
         self.assertIn("SURVIVED", good.stdout)
+
+    def test_python_config_preflight_refuses_preplanted_symlink(self):
+        # Issue found in round-3 review: a fixed, predictable stderr path in
+        # world-writable /tmp let an unprivileged user pre-plant a symlink
+        # before this root-run redirection opened it; a plain `2>path`
+        # follows an existing symlink and truncates its target. The fixed
+        # block must use an unpredictable name and refuse to write through
+        # any pre-existing path (symlink or regular file).
+        match = re.search(
+            r"^clihost_preflight_err=.*?\n"
+            r"\[ \"\$\{clihost_preflight_status\}\" -eq 0 \] \|\| exit \"\$\{clihost_preflight_status\}\"\n",
+            self.text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "python config preflight block not found")
+        preflight_block = match.group(0).replace(
+            "PYTHONPATH=/app", f"PYTHONPATH={REPO_ROOT / 'app'}"
+        )
+        self.assertIn("set -C", preflight_block)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "protected-target")
+            with open(target, "w") as f:
+                f.write("PROTECTED CONTENT")
+
+            # Force the unpredictable filename to a known value so the test can
+            # pre-plant a symlink there deterministically.
+            fixed_name_block = preflight_block.replace(
+                'mktemp -u /tmp/clihost-config-preflight.XXXXXXXX.err',
+                f'echo {tmpdir}/clihost-config-preflight.err',
+            )
+            planted = os.path.join(tmpdir, "clihost-config-preflight.err")
+            os.symlink(target, planted)
+
+            subprocess.run(
+                ["bash", "-c", fixed_name_block],
+                capture_output=True, text=True,
+                env={**os.environ, "MAX_TERMINALS": "garbage"},
+            )
+
+            with open(target) as f:
+                self.assertEqual(
+                    f.read(), "PROTECTED CONTENT",
+                    "preflight redirection truncated a pre-planted symlink's target",
+                )
 
     def test_proxy_liveness_check_is_actually_fail_closed(self):
         # Execute the real PID-capture + kill -0 supervision block extracted

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -152,6 +152,64 @@ class TestEntrypointRegressions(unittest.TestCase):
         self.assertLess(liveness_pos, sshd_pos)
         self.assertIn("TTYD HTTP proxy exited immediately after startup", self.text)
 
+    def test_python_config_validated_before_destructive_actions(self):
+        # A malformed Python-owned var (MAX_TERMINALS, SECURE_COOKIES, etc.)
+        # must fail closed BEFORE cleanup_runner_state deletes persisted hapi
+        # state and before Hermes/Droid/AO daemons are touched — not only when
+        # the backgrounded proxy process itself imports ttydproxy.config later.
+        # Otherwise one config typo repeats destructive side effects on every
+        # crash-loop restart before the container ever fails closed (Codex,
+        # round 2).
+        preflight_pos = self.text.find("import ttydproxy.config")
+        cleanup_call_pos = self.text.find("cleanup_runner_state\n")
+        proxy_launch_pos = self.text.find(
+            'runuser -u "${TTYD_USER}" -- python3 /app/ttyd_proxy.py &'
+        )
+        self.assertGreater(
+            preflight_pos, -1,
+            "entrypoint.sh must import ttydproxy.config as a preflight check",
+        )
+        self.assertGreater(cleanup_call_pos, -1, "cleanup_runner_state call not found")
+        self.assertLess(
+            preflight_pos, cleanup_call_pos,
+            "Python config must be validated before cleanup_runner_state runs",
+        )
+        self.assertLess(preflight_pos, proxy_launch_pos)
+
+    def test_python_config_preflight_is_actually_fail_closed(self):
+        # Execute the real preflight block extracted from entrypoint.sh against
+        # a malformed and a valid Python-owned env var, proving the mechanism
+        # itself rejects bad config (and does so exactly like the strict
+        # ttydproxy.config parser would) rather than just checking the text is
+        # present.
+        match = re.search(
+            r"^if ! PYTHONPATH=/app python3 -c 'import ttydproxy\.config'.*?\nfi\n",
+            self.text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "python config preflight block not found")
+        preflight_block = match.group(0).replace(
+            "PYTHONPATH=/app", f"PYTHONPATH={REPO_ROOT / 'app'}"
+        )
+
+        bad = subprocess.run(
+            ["bash", "-c", f'{preflight_block}\necho SURVIVED'],
+            capture_output=True, text=True,
+            env={**os.environ, "MAX_TERMINALS": "garbage"},
+        )
+        self.assertNotEqual(bad.returncode, 0)
+        self.assertIn("invalid TTYD proxy configuration", bad.stderr)
+        self.assertIn("MAX_TERMINALS", bad.stderr)
+        self.assertNotIn("SURVIVED", bad.stdout)
+
+        good_env = {k: v for k, v in os.environ.items() if k != "MAX_TERMINALS"}
+        good = subprocess.run(
+            ["bash", "-c", f'{preflight_block}\necho SURVIVED'],
+            capture_output=True, text=True, env=good_env,
+        )
+        self.assertEqual(good.returncode, 0, good.stderr)
+        self.assertIn("SURVIVED", good.stdout)
+
     def test_proxy_liveness_check_is_actually_fail_closed(self):
         # Execute the real PID-capture + kill -0 supervision block extracted
         # from entrypoint.sh against a process that exits immediately (like


### PR DESCRIPTION
## Summary
- add one Bash runtime env contract for boolean flags, positive integer ports, and Docker-style secret files
- normalize all entrypoint enable flags before service startup and reject unknown explicit values
- make Python env parsing strict for named env variables while preserving fail-closed TTL clamping and query-parameter fallback behavior
- document the accepted values and add table-driven Bash/Python parity tests

## Environment changes
- Boolean runtime flags now accept `1/true/yes/on` and `0/false/no/off`, case-insensitively; unknown explicit values abort startup.
- Runtime ports are validated before services start (`PORT` 1024..65535; other ports 1..65535).
- `PASSWORD_SECRET_FILE` is authoritative and unreadable/empty files abort startup.
- Malformed Python integer env values now abort instead of silently using defaults. Security TTL values below 1 continue to clamp to 1 (fail-closed).

## Tests
- `python -m pytest tests/ -q` (492 passed, 239 subtests passed)
- `bash -n entrypoint.sh bin/env-contract.sh`
- `git diff --check`

## Risks
- Deployments relying on previously ignored malformed values will now fail fast and must correct those values.

Closes #113
Related to #107 (TD-4)
